### PR TITLE
[FLINK-25687] DropDelete is incorrect in CompactManager when outputLevel is zero

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/CompactManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/CompactManager.java
@@ -75,7 +75,8 @@ public class CompactManager {
                                 return;
                             }
                             boolean dropDelete =
-                                    unit.outputLevel() >= levels.nonEmptyHighestLevel();
+                                    unit.outputLevel() != 0
+                                            && unit.outputLevel() >= levels.nonEmptyHighestLevel();
                             CompactTask task = new CompactTask(unit, dropDelete);
                             taskFuture = executor.submit(task);
                         });

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/CompactManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/CompactManager.java
@@ -74,6 +74,13 @@ public class CompactManager {
                             if (unit.files().size() < 2) {
                                 return;
                             }
+                            /*
+                             * As long as there is no older data, We can drop the deletion.
+                             * If the output level is 0, there may be older data not involved in compaction.
+                             * If the output level is bigger than 0, as long as there is no older data in
+                             * the current levels, the output is the oldest, so we can drop the deletion.
+                             * See CompactStrategy.pick.
+                             */
                             boolean dropDelete =
                                     unit.outputLevel() != 0
                                             && unit.outputLevel() >= levels.nonEmptyHighestLevel();

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/CompactStrategy.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/CompactStrategy.java
@@ -26,5 +26,14 @@ import java.util.Optional;
 /** Compact strategy to decide which files to select for compaction. */
 public interface CompactStrategy {
 
+    /**
+     * Pick compaction unit from runs.
+     *
+     * <ul>
+     *   <li>compaction is runs-based, not file-based.
+     *   <li>level 0 is special, one run per file; all other levels are one run per level.
+     *   <li>compaction is sequential from small level to large level.
+     * </ul>
+     */
     Optional<CompactUnit> pick(int numLevels, List<LevelSortedRun> runs);
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/CompactManagerTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/CompactManagerTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.store.file.mergetree.compact;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.data.writer.BinaryRowWriter;
-import org.apache.flink.table.store.file.mergetree.LevelSortedRun;
 import org.apache.flink.table.store.file.mergetree.Levels;
 import org.apache.flink.table.store.file.mergetree.SortedRun;
 import org.apache.flink.table.store.file.mergetree.sst.SstFileMeta;
@@ -63,6 +62,18 @@ public class CompactManagerTest {
     }
 
     @Test
+    public void testOutputToZeroLevel() throws ExecutionException, InterruptedException {
+        innerTest(
+                Arrays.asList(
+                        new LevelMinMax(0, 1, 3),
+                        new LevelMinMax(0, 1, 5),
+                        new LevelMinMax(0, 1, 8)),
+                Arrays.asList(new LevelMinMax(0, 1, 8), new LevelMinMax(0, 1, 3)),
+                (numLevels, runs) -> Optional.of(CompactUnit.fromLevelRuns(0, runs.subList(0, 2))),
+                false);
+    }
+
+    @Test
     public void testCompactToPenultimateLayer() throws ExecutionException, InterruptedException {
         innerTest(
                 Arrays.asList(
@@ -70,12 +81,7 @@ public class CompactManagerTest {
                         new LevelMinMax(0, 1, 5),
                         new LevelMinMax(2, 1, 7)),
                 Arrays.asList(new LevelMinMax(1, 1, 5), new LevelMinMax(2, 1, 7)),
-                new CompactStrategy() {
-                    @Override
-                    public Optional<CompactUnit> pick(int numLevels, List<LevelSortedRun> runs) {
-                        return Optional.of(CompactUnit.fromLevelRuns(1, runs.subList(0, 2)));
-                    }
-                },
+                (numLevels, runs) -> Optional.of(CompactUnit.fromLevelRuns(1, runs.subList(0, 2))),
                 false);
     }
 


### PR DESCRIPTION
When output level is zero, there may be have other files in level 0, we can not drop delete.

