### PR TITLE
[FLINK-25770] Delete file is not correct in MergeTreeWriter

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeWriter.java
@@ -115,10 +115,8 @@ public class MergeTreeWriter implements RecordWriter {
             Iterator<KeyValue> iterator = memTable.iterator(keyComparator, accumulator);
             List<SstFileMeta> files =
                     sstFile.write(CloseableIterator.adapterForIterator(iterator), 0);
-            for (SstFileMeta file : files) {
-                newFiles.add(file);
-                levels.addLevel0File(file);
-            }
+            newFiles.addAll(files);
+            files.forEach(levels::addLevel0File);
             memTable.clear();
             submitCompaction();
         }
@@ -139,7 +137,6 @@ public class MergeTreeWriter implements RecordWriter {
     }
 
     private Increment drainIncrement() {
-        // drain files to create Increment
         Increment increment =
                 new Increment(
                         new ArrayList<>(newFiles),
@@ -148,8 +145,6 @@ public class MergeTreeWriter implements RecordWriter {
         newFiles.clear();
         compactBefore.clear();
         compactAfter.clear();
-
-        // return increment
         return increment;
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeWriter.java
@@ -32,10 +32,13 @@ import org.apache.flink.util.CloseableIterator;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 
 /** A {@link RecordWriter} to write records and generate {@link Increment}. */
 public class MergeTreeWriter implements RecordWriter {
@@ -56,7 +59,7 @@ public class MergeTreeWriter implements RecordWriter {
 
     private final LinkedHashSet<SstFileMeta> newFiles;
 
-    private final LinkedHashSet<SstFileMeta> compactBefore;
+    private final LinkedHashMap<String, SstFileMeta> compactBefore;
 
     private final LinkedHashSet<SstFileMeta> compactAfter;
 
@@ -80,7 +83,7 @@ public class MergeTreeWriter implements RecordWriter {
         this.sstFile = sstFile;
         this.commitForceCompact = commitForceCompact;
         this.newFiles = new LinkedHashSet<>();
-        this.compactBefore = new LinkedHashSet<>();
+        this.compactBefore = new LinkedHashMap<>();
         this.compactAfter = new LinkedHashSet<>();
     }
 
@@ -112,8 +115,10 @@ public class MergeTreeWriter implements RecordWriter {
             Iterator<KeyValue> iterator = memTable.iterator(keyComparator, accumulator);
             List<SstFileMeta> files =
                     sstFile.write(CloseableIterator.adapterForIterator(iterator), 0);
-            newFiles.addAll(files);
-            files.forEach(levels::addLevel0File);
+            for (SstFileMeta file : files) {
+                newFiles.add(file);
+                levels.addLevel0File(file);
+            }
             memTable.clear();
             submitCompaction();
         }
@@ -134,26 +139,36 @@ public class MergeTreeWriter implements RecordWriter {
     }
 
     private Increment drainIncrement() {
+        // drain files to create Increment
         Increment increment =
                 new Increment(
                         new ArrayList<>(newFiles),
-                        new ArrayList<>(compactBefore),
+                        new ArrayList<>(compactBefore.values()),
                         new ArrayList<>(compactAfter));
         newFiles.clear();
         compactBefore.clear();
         compactAfter.clear();
+
+        // return increment
         return increment;
     }
 
     private void updateCompactResult(CompactManager.CompactResult result) {
+        Set<String> afterFiles =
+                result.after().stream().map(SstFileMeta::fileName).collect(Collectors.toSet());
         for (SstFileMeta file : result.before()) {
-            boolean removed = compactAfter.remove(file);
-            if (removed) {
+            if (compactAfter.remove(file)) {
                 // This is an intermediate file (not a new data file), which is no longer needed
-                // after compaction and can be deleted directly
-                sstFile.delete(file);
+                // after compaction and can be deleted directly, but upgrade file is required by
+                // previous snapshot and following snapshot, so we should ensure:
+                // 1. This file is not the output of upgraded.
+                // 2. This file is not the input of upgraded.
+                if (!compactBefore.containsKey(file.fileName())
+                        && !afterFiles.contains(file.fileName())) {
+                    sstFile.delete(file);
+                }
             } else {
-                compactBefore.add(file);
+                compactBefore.put(file.fileName(), file);
             }
         }
         compactAfter.addAll(result.after());
@@ -165,16 +180,21 @@ public class MergeTreeWriter implements RecordWriter {
 
     private void finishCompaction() throws ExecutionException, InterruptedException {
         Optional<CompactManager.CompactResult> result = compactManager.finishCompaction(levels);
-        if (result.isPresent()) {
-            updateCompactResult(result.get());
-        }
+        result.ifPresent(this::updateCompactResult);
     }
 
     @Override
-    public List<SstFileMeta> close() {
+    public List<SstFileMeta> close() throws Exception {
+        sync();
         // delete temporary files
         List<SstFileMeta> delete = new ArrayList<>(newFiles);
-        delete.addAll(compactAfter);
+        for (SstFileMeta file : compactAfter) {
+            // upgrade file is required by previous snapshot, so we should ensure that this file is
+            // not the output of upgraded.
+            if (!compactBefore.containsKey(file.fileName())) {
+                delete.add(file);
+            }
+        }
         for (SstFileMeta file : delete) {
             sstFile.delete(file);
         }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
@@ -173,7 +173,11 @@ public class TestCommitThread extends Thread {
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
-            writer.close();
+            try {
+                writer.close();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
@@ -169,11 +169,6 @@ public class TestCommitThread extends Thread {
 
         for (MergeTreeWriter writer : writers.values()) {
             try {
-                writer.sync();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-            try {
                 writer.close();
             } catch (Exception e) {
                 throw new RuntimeException(e);


### PR DESCRIPTION
The deletion in MergeTreeWriter.updateCompactResult dose not consider upgrade case, the upgrade file is required by previous snapshot and following snapshot, we should ensure:
1. This file is not the output of upgraded.
2. This file is not the input of upgraded.

Otherwise, the file will be deleted incorrectly.