### PR TITLE
[FLINK-25803] Implement partition and bucket filter in FileStoreScanImpl

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeFactory.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.mergetree;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.store.file.FileFormat;
+import org.apache.flink.table.store.file.mergetree.compact.Accumulator;
+import org.apache.flink.table.store.file.mergetree.sst.SstFile;
+import org.apache.flink.table.store.file.utils.FileStorePathFactory;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.Comparator;
+import java.util.concurrent.ExecutorService;
+
+/** Create a new {@link MergeTree} with specific partition and bucket. */
+public class MergeTreeFactory {
+
+    private final Comparator<RowData> keyComparator;
+    private final Accumulator accumulator;
+    private final MergeTreeOptions mergeTreeOptions;
+    private final SstFile.Factory sstFileFactory;
+
+    public MergeTreeFactory(
+            RowType keyType,
+            RowType rowType,
+            Comparator<RowData> keyComparator,
+            Accumulator accumulator,
+            FileFormat fileFormat,
+            FileStorePathFactory pathFactory,
+            MergeTreeOptions mergeTreeOptions) {
+        this.keyComparator = keyComparator;
+        this.accumulator = accumulator;
+        this.mergeTreeOptions = mergeTreeOptions;
+        this.sstFileFactory =
+                new SstFile.Factory(
+                        keyType, rowType, fileFormat, pathFactory, mergeTreeOptions.targetFileSize);
+    }
+
+    public MergeTree create(BinaryRowData partition, int bucket, ExecutorService compactExecutor) {
+        return new MergeTree(
+                mergeTreeOptions,
+                sstFileFactory.create(partition, bucket),
+                keyComparator,
+                compactExecutor,
+                accumulator);
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/sst/SstPathFactory.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/sst/SstPathFactory.java
@@ -21,25 +21,29 @@ package org.apache.flink.table.store.file.mergetree.sst;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.fs.Path;
 
+import javax.annotation.concurrent.ThreadSafe;
+
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /** Factory which produces new {@link Path}s for sst files. */
+@ThreadSafe
 public class SstPathFactory {
 
     private final Path bucketDir;
     private final String uuid;
 
-    private int pathCount;
+    private final AtomicInteger pathCount;
 
     public SstPathFactory(Path root, String partition, int bucket) {
         this.bucketDir = new Path(root + "/" + partition + "/bucket-" + bucket);
         this.uuid = UUID.randomUUID().toString();
 
-        this.pathCount = 0;
+        this.pathCount = new AtomicInteger(0);
     }
 
     public Path newPath() {
-        return new Path(bucketDir + "/sst-" + uuid + "-" + (pathCount++));
+        return new Path(bucketDir + "/sst-" + uuid + "-" + pathCount.getAndIncrement());
     }
 
     public Path toPath(String fileName) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
@@ -73,12 +73,11 @@ public class FileStoreCommitImpl implements FileStoreCommit {
 
     private final String commitUser;
     private final ManifestCommittableSerializer committableSerializer;
-
     private final FileStorePathFactory pathFactory;
     private final ManifestFile manifestFile;
     private final ManifestList manifestList;
-    private final FileStoreOptions fileStoreOptions;
     private final FileStoreScan scan;
+    private final FileStoreOptions fileStoreOptions;
 
     @Nullable private Lock lock;
 
@@ -86,18 +85,17 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             String commitUser,
             ManifestCommittableSerializer committableSerializer,
             FileStorePathFactory pathFactory,
-            ManifestFile manifestFile,
-            ManifestList manifestList,
-            FileStoreOptions fileStoreOptions,
-            FileStoreScan scan) {
+            ManifestFile.Factory manifestFileFactory,
+            ManifestList.Factory manifestListFactory,
+            FileStoreScan scan,
+            FileStoreOptions fileStoreOptions) {
         this.commitUser = commitUser;
         this.committableSerializer = committableSerializer;
-
         this.pathFactory = pathFactory;
-        this.manifestFile = manifestFile;
-        this.manifestList = manifestList;
-        this.fileStoreOptions = fileStoreOptions;
+        this.manifestFile = manifestFileFactory.create();
+        this.manifestList = manifestListFactory.create();
         this.scan = scan;
+        this.fileStoreOptions = fileStoreOptions;
 
         this.lock = null;
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
@@ -325,9 +325,17 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             return;
         }
 
+        List<BinaryRowData> changedPartitions =
+                changes.stream()
+                        .map(ManifestEntry::partition)
+                        .distinct()
+                        .collect(Collectors.toList());
         try {
-            // TODO use partition filter of scan when implemented
-            for (ManifestEntry entry : scan.withSnapshot(snapshotId).plan().files()) {
+            for (ManifestEntry entry :
+                    scan.withSnapshot(snapshotId)
+                            .withPartitionFilter(changedPartitions)
+                            .plan()
+                            .files()) {
                 removedFiles.remove(entry.identifier());
             }
         } catch (Throwable e) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreScan.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.store.file.operation;
 
+import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.store.file.manifest.ManifestEntry;
 import org.apache.flink.table.store.file.manifest.ManifestFileMeta;
 import org.apache.flink.table.store.file.predicate.Predicate;
@@ -30,6 +31,8 @@ import java.util.List;
 public interface FileStoreScan {
 
     FileStoreScan withPartitionFilter(Predicate predicate);
+
+    FileStoreScan withPartitionFilter(List<BinaryRowData> partitions);
 
     FileStoreScan withKeyFilter(Predicate predicate);
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreScanImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreScanImpl.java
@@ -46,11 +46,11 @@ public class FileStoreScanImpl implements FileStoreScan {
 
     public FileStoreScanImpl(
             FileStorePathFactory pathFactory,
-            ManifestFile manifestFile,
-            ManifestList manifestList) {
+            ManifestFile.Factory manifestFileFactory,
+            ManifestList.Factory manifestListFactory) {
         this.pathFactory = pathFactory;
-        this.manifestFile = manifestFile;
-        this.manifestList = manifestList;
+        this.manifestFile = manifestFileFactory.create();
+        this.manifestList = manifestListFactory.create();
 
         this.snapshotId = null;
         this.manifests = new ArrayList<>();

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreWriteImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreWriteImpl.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.operation;
+
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.store.file.manifest.ManifestEntry;
+import org.apache.flink.table.store.file.mergetree.MergeTree;
+import org.apache.flink.table.store.file.mergetree.MergeTreeFactory;
+import org.apache.flink.table.store.file.utils.FileStorePathFactory;
+import org.apache.flink.table.store.file.utils.RecordWriter;
+
+import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.Collectors;
+
+/** Default implementation of {@link FileStoreWrite}. */
+public class FileStoreWriteImpl implements FileStoreWrite {
+
+    private final FileStorePathFactory pathFactory;
+    private final MergeTreeFactory mergeTreeFactory;
+    private final FileStoreScan scan;
+
+    public FileStoreWriteImpl(
+            FileStorePathFactory pathFactory,
+            MergeTreeFactory mergeTreeFactory,
+            FileStoreScan scan) {
+        this.pathFactory = pathFactory;
+        this.mergeTreeFactory = mergeTreeFactory;
+        this.scan = scan;
+    }
+
+    @Override
+    public RecordWriter createWriter(
+            BinaryRowData partition, int bucket, ExecutorService compactExecutor) {
+        Long latestSnapshotId = pathFactory.latestSnapshotId();
+        if (latestSnapshotId == null) {
+            return createEmptyWriter(partition, bucket, compactExecutor);
+        } else {
+            MergeTree mergeTree = mergeTreeFactory.create(partition, bucket, compactExecutor);
+            return mergeTree.createWriter(
+                    scan.withSnapshot(latestSnapshotId)
+                            .withPartitionFilter(Collections.singletonList(partition))
+                            .withBucket(bucket).plan().files().stream()
+                            .map(ManifestEntry::file)
+                            .collect(Collectors.toList()));
+        }
+    }
+
+    @Override
+    public RecordWriter createEmptyWriter(
+            BinaryRowData partition, int bucket, ExecutorService compactExecutor) {
+        MergeTree mergeTree = mergeTreeFactory.create(partition, bucket, compactExecutor);
+        return mergeTree.createWriter(Collections.emptyList());
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RowDataToObjectArrayConverter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RowDataToObjectArrayConverter.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.utils;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.stream.IntStream;
+
+/** Convert {@link RowData} to object array. */
+public class RowDataToObjectArrayConverter {
+
+    private final RowType rowType;
+    private final RowData.FieldGetter[] fieldGetters;
+
+    public RowDataToObjectArrayConverter(RowType rowType) {
+        this.rowType = rowType;
+        this.fieldGetters =
+                IntStream.range(0, rowType.getFieldCount())
+                        .mapToObj(i -> RowData.createFieldGetter(rowType.getTypeAt(i), i))
+                        .toArray(RowData.FieldGetter[]::new);
+    }
+
+    public RowType rowType() {
+        return rowType;
+    }
+
+    public int getArity() {
+        return fieldGetters.length;
+    }
+
+    public Object[] convert(RowData rowData) {
+        Object[] result = new Object[fieldGetters.length];
+        for (int i = 0; i < fieldGetters.length; i++) {
+            result[i] = fieldGetters[i].getFieldOrNull(rowData);
+        }
+        return result;
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestFileMetaTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestFileMetaTest.java
@@ -135,12 +135,13 @@ public class ManifestFileMetaTest {
     }
 
     private ManifestFile createManifestFile(String path) {
-        return new ManifestFile(
-                PARTITION_TYPE,
-                KEY_TYPE,
-                ROW_TYPE,
-                avro,
-                new FileStorePathFactory(new Path(path), PARTITION_TYPE, "default"));
+        return new ManifestFile.Factory(
+                        PARTITION_TYPE,
+                        KEY_TYPE,
+                        ROW_TYPE,
+                        avro,
+                        new FileStorePathFactory(new Path(path), PARTITION_TYPE, "default"))
+                .create();
     }
 
     private void createData(List<ManifestFileMeta> input, List<ManifestFileMeta> expected) {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestFileTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestFileTest.java
@@ -91,12 +91,13 @@ public class ManifestFileTest {
         FileStorePathFactory pathFactory =
                 new FileStorePathFactory(
                         new Path(path), TestKeyValueGenerator.PARTITION_TYPE, "default");
-        return new ManifestFile(
-                TestKeyValueGenerator.PARTITION_TYPE,
-                TestKeyValueGenerator.KEY_TYPE,
-                TestKeyValueGenerator.ROW_TYPE,
-                avro,
-                pathFactory);
+        return new ManifestFile.Factory(
+                        TestKeyValueGenerator.PARTITION_TYPE,
+                        TestKeyValueGenerator.KEY_TYPE,
+                        TestKeyValueGenerator.ROW_TYPE,
+                        avro,
+                        pathFactory)
+                .create();
     }
 
     private void checkMetaIgnoringFileNameAndSize(

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestListTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestListTest.java
@@ -94,6 +94,7 @@ public class ManifestListTest {
         FileStorePathFactory pathFactory =
                 new FileStorePathFactory(
                         new Path(path), TestKeyValueGenerator.PARTITION_TYPE, "default");
-        return new ManifestList(TestKeyValueGenerator.PARTITION_TYPE, avro, pathFactory);
+        return new ManifestList.Factory(TestKeyValueGenerator.PARTITION_TYPE, avro, pathFactory)
+                .create();
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/sst/SstFileTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/sst/SstFileTest.java
@@ -118,19 +118,18 @@ public class SstFileTest {
     }
 
     private SstFile createSstFile(String path) {
-        FileStorePathFactory fileStorePathFactory = new FileStorePathFactory(new Path(path));
-        SstPathFactory sstPathFactory =
-                fileStorePathFactory.createSstPathFactory(BinaryRowDataUtil.EMPTY_ROW, 0);
+        FileStorePathFactory pathFactory = new FileStorePathFactory(new Path(path));
         int suggestedFileSize = ThreadLocalRandom.current().nextInt(8192) + 1024;
-        return new SstFile(
-                TestKeyValueGenerator.KEY_TYPE,
-                TestKeyValueGenerator.ROW_TYPE,
-                // normal avro format will buffer changes in memory and we can't determine
-                // if the written file size is really larger than suggested, so we use a
-                // special avro format which flushes for every added element
-                flushingAvro,
-                sstPathFactory,
-                suggestedFileSize);
+        return new SstFile.Factory(
+                        TestKeyValueGenerator.KEY_TYPE,
+                        TestKeyValueGenerator.ROW_TYPE,
+                        // normal avro format will buffer changes in memory and we can't determine
+                        // if the written file size is really larger than suggested, so we use a
+                        // special avro format which flushes for every added element
+                        flushingAvro,
+                        pathFactory,
+                        suggestedFileSize)
+                .create(BinaryRowDataUtil.EMPTY_ROW, 0);
     }
 
     private void checkRollingFiles(

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreCommitTestBase.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreCommitTestBase.java
@@ -25,13 +25,8 @@ import org.apache.flink.table.store.file.FileFormat;
 import org.apache.flink.table.store.file.KeyValue;
 import org.apache.flink.table.store.file.TestKeyValueGenerator;
 import org.apache.flink.table.store.file.ValueKind;
-import org.apache.flink.table.store.file.manifest.ManifestEntry;
-import org.apache.flink.table.store.file.manifest.ManifestFile;
-import org.apache.flink.table.store.file.manifest.ManifestList;
-import org.apache.flink.table.store.file.mergetree.sst.SstFile;
 import org.apache.flink.table.store.file.utils.FailingAtomicRenameFileSystem;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
-import org.apache.flink.table.store.file.utils.RecordReaderIterator;
 import org.apache.flink.table.store.file.utils.TestAtomicRenameFileSystem;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -71,7 +66,7 @@ public abstract class FileStoreCommitTestBase {
         root.getFileSystem().mkdirs(new Path(root + "/snapshot"));
     }
 
-    protected abstract String getSchema();
+    protected abstract String getScheme();
 
     @RepeatedTest(10)
     public void testSingleCommitUser() throws Exception {
@@ -94,7 +89,7 @@ public abstract class FileStoreCommitTestBase {
                                 .collect(Collectors.toList()),
                 "input");
         Map<BinaryRowData, BinaryRowData> expected =
-                toKvMap(
+                OperationTestUtils.toKvMap(
                         data.values().stream()
                                 .flatMap(Collection::stream)
                                 .collect(Collectors.toList()));
@@ -114,7 +109,10 @@ public abstract class FileStoreCommitTestBase {
         for (int i = 0; i < numThreads; i++) {
             TestCommitThread thread =
                     new TestCommitThread(
-                            dataPerThread.get(i), createTestPathFactory(), createSafePathFactory());
+                            dataPerThread.get(i),
+                            OperationTestUtils.createPathFactory(getScheme(), tempDir.toString()),
+                            OperationTestUtils.createPathFactory(
+                                    TestAtomicRenameFileSystem.SCHEME, tempDir.toString()));
             thread.start();
             threads.add(thread);
         }
@@ -123,7 +121,16 @@ public abstract class FileStoreCommitTestBase {
         }
 
         // read actual data and compare
-        Map<BinaryRowData, BinaryRowData> actual = toKvMap(readKvsFromLatestSnapshot());
+        FileStorePathFactory safePathFactory =
+                OperationTestUtils.createPathFactory(
+                        TestAtomicRenameFileSystem.SCHEME, tempDir.toString());
+        Long snapshotId = safePathFactory.latestSnapshotId();
+        assertThat(snapshotId).isNotNull();
+        List<KeyValue> actualKvs =
+                OperationTestUtils.readKvsFromSnapshot(snapshotId, avro, safePathFactory);
+        gen.sort(actualKvs);
+        logData(() -> actualKvs, "raw read results");
+        Map<BinaryRowData, BinaryRowData> actual = OperationTestUtils.toKvMap(actualKvs);
         logData(() -> kvMapToKvList(expected), "expected");
         logData(() -> kvMapToKvList(actual), "actual");
         assertThat(actual).isEqualTo(expected);
@@ -136,91 +143,6 @@ public abstract class FileStoreCommitTestBase {
             data.compute(gen.getPartition(kv), (p, l) -> l == null ? new ArrayList<>() : l).add(kv);
         }
         return data;
-    }
-
-    private List<KeyValue> readKvsFromLatestSnapshot() throws IOException {
-        FileStorePathFactory pathFactory = createSafePathFactory();
-        Long latestSnapshotId = pathFactory.latestSnapshotId();
-        assertThat(latestSnapshotId).isNotNull();
-
-        ManifestFile.Factory manifestFileFactory =
-                new ManifestFile.Factory(
-                        TestKeyValueGenerator.PARTITION_TYPE,
-                        TestKeyValueGenerator.KEY_TYPE,
-                        TestKeyValueGenerator.ROW_TYPE,
-                        avro,
-                        pathFactory);
-        ManifestList.Factory manifestListFactory =
-                new ManifestList.Factory(TestKeyValueGenerator.PARTITION_TYPE, avro, pathFactory);
-
-        List<KeyValue> kvs = new ArrayList<>();
-        List<ManifestEntry> entries =
-                new FileStoreScanImpl(pathFactory, manifestFileFactory, manifestListFactory)
-                        .withSnapshot(latestSnapshotId)
-                        .plan()
-                        .files();
-        SstFile.Factory sstFileFactory =
-                new SstFile.Factory(
-                        TestKeyValueGenerator.KEY_TYPE,
-                        TestKeyValueGenerator.ROW_TYPE,
-                        avro,
-                        pathFactory,
-                        1024 * 1024 // not used
-                        );
-        for (ManifestEntry entry : entries) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Reading actual key-values from file " + entry.file().fileName());
-            }
-            SstFile sstFile = sstFileFactory.create(entry.partition(), entry.bucket());
-            RecordReaderIterator iterator =
-                    new RecordReaderIterator(sstFile.read(entry.file().fileName()));
-            while (iterator.hasNext()) {
-                kvs.add(
-                        iterator.next()
-                                .copy(
-                                        TestKeyValueGenerator.KEY_SERIALIZER,
-                                        TestKeyValueGenerator.ROW_SERIALIZER));
-            }
-        }
-
-        gen.sort(kvs);
-        logData(() -> kvs, "raw read results");
-        return kvs;
-    }
-
-    private Map<BinaryRowData, BinaryRowData> toKvMap(List<KeyValue> kvs) {
-        Map<BinaryRowData, BinaryRowData> result = new HashMap<>();
-        for (KeyValue kv : kvs) {
-            BinaryRowData key = TestKeyValueGenerator.KEY_SERIALIZER.toBinaryRow(kv.key()).copy();
-            BinaryRowData value =
-                    TestKeyValueGenerator.ROW_SERIALIZER.toBinaryRow(kv.value()).copy();
-            switch (kv.valueKind()) {
-                case ADD:
-                    result.put(key, value);
-                    break;
-                case DELETE:
-                    result.remove(key);
-                    break;
-                default:
-                    throw new UnsupportedOperationException(
-                            "Unknown value kind " + kv.valueKind().name());
-            }
-        }
-        return result;
-    }
-
-    private FileStorePathFactory createTestPathFactory() {
-        return new FileStorePathFactory(
-                new Path(getSchema() + "://" + tempDir.toString()),
-                TestKeyValueGenerator.PARTITION_TYPE,
-                "default");
-    }
-
-    private FileStorePathFactory createSafePathFactory() {
-        return new FileStorePathFactory(
-                new Path(TestAtomicRenameFileSystem.SCHEME + "://" + tempDir.toString()),
-                TestKeyValueGenerator.PARTITION_TYPE,
-                "default");
     }
 
     private List<KeyValue> kvMapToKvList(Map<BinaryRowData, BinaryRowData> map) {
@@ -245,7 +167,7 @@ public abstract class FileStoreCommitTestBase {
     public static class WithTestAtomicRenameFileSystem extends FileStoreCommitTestBase {
 
         @Override
-        protected String getSchema() {
+        protected String getScheme() {
             return TestAtomicRenameFileSystem.SCHEME;
         }
     }
@@ -262,7 +184,7 @@ public abstract class FileStoreCommitTestBase {
         }
 
         @Override
-        protected String getSchema() {
+        protected String getScheme() {
             return FailingAtomicRenameFileSystem.SCHEME;
         }
     }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreScanTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreScanTest.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.operation;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.store.file.FileFormat;
+import org.apache.flink.table.store.file.KeyValue;
+import org.apache.flink.table.store.file.Snapshot;
+import org.apache.flink.table.store.file.TestKeyValueGenerator;
+import org.apache.flink.table.store.file.manifest.ManifestCommittable;
+import org.apache.flink.table.store.file.manifest.ManifestFileMeta;
+import org.apache.flink.table.store.file.manifest.ManifestList;
+import org.apache.flink.table.store.file.mergetree.Increment;
+import org.apache.flink.table.store.file.utils.FileStorePathFactory;
+import org.apache.flink.table.store.file.utils.RecordWriter;
+import org.apache.flink.table.store.file.utils.TestAtomicRenameFileSystem;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link FileStoreScanImpl}. */
+public class FileStoreScanTest {
+
+    private static final int NUM_BUCKETS = 10;
+
+    private final FileFormat avro =
+            FileFormat.fromIdentifier(
+                    FileStoreCommitTestBase.class.getClassLoader(), "avro", new Configuration());
+
+    private TestKeyValueGenerator gen;
+    @TempDir java.nio.file.Path tempDir;
+    private FileStorePathFactory pathFactory;
+
+    @BeforeEach
+    public void beforeEach() throws IOException {
+        gen = new TestKeyValueGenerator();
+        pathFactory =
+                OperationTestUtils.createPathFactory(
+                        TestAtomicRenameFileSystem.SCHEME, tempDir.toString());
+        Path root = new Path(tempDir.toString());
+        root.getFileSystem().mkdirs(new Path(root + "/snapshot"));
+    }
+
+    @RepeatedTest(10)
+    public void testWithPartitionFilter() throws Exception {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        List<KeyValue> data = generateData(random.nextInt(1000) + 1);
+        List<BinaryRowData> partitions =
+                data.stream()
+                        .map(kv -> gen.getPartition(kv))
+                        .distinct()
+                        .collect(Collectors.toList());
+        Snapshot snapshot = writeData(data);
+
+        Set<BinaryRowData> wantedPartitions = new HashSet<>();
+        for (int i = random.nextInt(partitions.size() + 1); i > 0; i--) {
+            wantedPartitions.add(partitions.get(random.nextInt(partitions.size())));
+        }
+
+        FileStoreScan scan = OperationTestUtils.createScan(avro, pathFactory);
+        scan.withSnapshot(snapshot.id());
+        scan.withPartitionFilter(new ArrayList<>(wantedPartitions));
+
+        Map<BinaryRowData, BinaryRowData> expected =
+                OperationTestUtils.toKvMap(
+                        wantedPartitions.isEmpty()
+                                ? data
+                                : data.stream()
+                                        .filter(
+                                                kv ->
+                                                        wantedPartitions.contains(
+                                                                gen.getPartition(kv)))
+                                        .collect(Collectors.toList()));
+        runTest(scan, snapshot.id(), expected);
+    }
+
+    @RepeatedTest(10)
+    public void testWithBucket() throws Exception {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        List<KeyValue> data = generateData(random.nextInt(1000) + 1);
+        Snapshot snapshot = writeData(data);
+
+        int wantedBucket = random.nextInt(NUM_BUCKETS);
+
+        FileStoreScan scan = OperationTestUtils.createScan(avro, pathFactory);
+        scan.withSnapshot(snapshot.id());
+        scan.withBucket(wantedBucket);
+
+        Map<BinaryRowData, BinaryRowData> expected =
+                OperationTestUtils.toKvMap(
+                        data.stream()
+                                .filter(kv -> getBucket(kv) == wantedBucket)
+                                .collect(Collectors.toList()));
+        runTest(scan, snapshot.id(), expected);
+    }
+
+    @RepeatedTest(10)
+    public void testWithSnapshot() throws Exception {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        int numCommits = random.nextInt(10) + 1;
+        int wantedCommit = random.nextInt(numCommits);
+
+        List<Snapshot> snapshots = new ArrayList<>();
+        List<List<KeyValue>> allData = new ArrayList<>();
+        for (int i = 0; i < numCommits; i++) {
+            List<KeyValue> data = generateData(random.nextInt(100) + 1);
+            snapshots.add(writeData(data));
+            allData.add(data);
+        }
+        long wantedSnapshot = snapshots.get(wantedCommit).id();
+
+        FileStoreScan scan = OperationTestUtils.createScan(avro, pathFactory);
+        scan.withSnapshot(wantedSnapshot);
+
+        Map<BinaryRowData, BinaryRowData> expected =
+                OperationTestUtils.toKvMap(
+                        allData.subList(0, wantedCommit + 1).stream()
+                                .flatMap(Collection::stream)
+                                .collect(Collectors.toList()));
+        runTest(scan, wantedSnapshot, expected);
+    }
+
+    @RepeatedTest(10)
+    public void testWithManifestList() throws Exception {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        int numCommits = random.nextInt(10) + 1;
+        for (int i = 0; i < numCommits; i++) {
+            List<KeyValue> data = generateData(random.nextInt(100) + 1);
+            writeData(data);
+        }
+
+        ManifestList manifestList =
+                new ManifestList.Factory(TestKeyValueGenerator.PARTITION_TYPE, avro, pathFactory)
+                        .create();
+        long wantedSnapshot = random.nextLong(pathFactory.latestSnapshotId()) + 1;
+        List<ManifestFileMeta> wantedManifests =
+                manifestList.read(
+                        Snapshot.fromPath(pathFactory.toSnapshotPath(wantedSnapshot))
+                                .manifestList());
+
+        FileStoreScan scan = OperationTestUtils.createScan(avro, pathFactory);
+        scan.withManifestList(wantedManifests);
+
+        List<KeyValue> expectedKvs =
+                OperationTestUtils.readKvsFromSnapshot(wantedSnapshot, avro, pathFactory);
+        gen.sort(expectedKvs);
+        Map<BinaryRowData, BinaryRowData> expected = OperationTestUtils.toKvMap(expectedKvs);
+        runTest(scan, null, expected);
+    }
+
+    private void runTest(
+            FileStoreScan scan, Long expectedSnapshotId, Map<BinaryRowData, BinaryRowData> expected)
+            throws Exception {
+        FileStoreScan.Plan plan = scan.plan();
+        assertThat(plan.snapshotId()).isEqualTo(expectedSnapshotId);
+
+        List<KeyValue> actualKvs =
+                OperationTestUtils.readKvsFromManifestEntries(plan.files(), avro, pathFactory);
+        gen.sort(actualKvs);
+        Map<BinaryRowData, BinaryRowData> actual = OperationTestUtils.toKvMap(actualKvs);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private List<KeyValue> generateData(int numRecords) {
+        List<KeyValue> data = new ArrayList<>();
+        for (int i = 0; i < numRecords; i++) {
+            data.add(gen.next());
+        }
+        return data;
+    }
+
+    private Snapshot writeData(List<KeyValue> kvs) throws Exception {
+        FileStoreWrite write = OperationTestUtils.createWrite(avro, pathFactory);
+        Map<BinaryRowData, Map<Integer, RecordWriter>> writers = new HashMap<>();
+        for (KeyValue kv : kvs) {
+            BinaryRowData partition = gen.getPartition(kv);
+            int bucket = getBucket(kv);
+            writers.compute(partition, (p, m) -> m == null ? new HashMap<>() : m)
+                    .compute(
+                            bucket,
+                            (b, w) -> {
+                                if (w == null) {
+                                    ExecutorService service = Executors.newSingleThreadExecutor();
+                                    return write.createWriter(partition, bucket, service);
+                                } else {
+                                    return w;
+                                }
+                            })
+                    .write(kv.valueKind(), kv.key(), kv.value());
+        }
+
+        FileStoreCommit commit = OperationTestUtils.createCommit(avro, pathFactory);
+        ManifestCommittable committable = new ManifestCommittable();
+        for (Map.Entry<BinaryRowData, Map<Integer, RecordWriter>> entryWithPartition :
+                writers.entrySet()) {
+            for (Map.Entry<Integer, RecordWriter> entryWithBucket :
+                    entryWithPartition.getValue().entrySet()) {
+                Increment increment = entryWithBucket.getValue().prepareCommit();
+                committable.add(entryWithPartition.getKey(), entryWithBucket.getKey(), increment);
+            }
+        }
+        commit.commit(committable, Collections.emptyMap());
+        writers.values().stream()
+                .flatMap(m -> m.values().stream())
+                .forEach(
+                        w -> {
+                            try {
+                                w.close();
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+
+        return Snapshot.fromPath(pathFactory.toSnapshotPath(pathFactory.latestSnapshotId()));
+    }
+
+    private int getBucket(KeyValue kv) {
+        return (kv.key().hashCode() % NUM_BUCKETS + NUM_BUCKETS) % NUM_BUCKETS;
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/OperationTestUtils.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/OperationTestUtils.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.operation;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.store.file.FileFormat;
+import org.apache.flink.table.store.file.FileStoreOptions;
+import org.apache.flink.table.store.file.KeyValue;
+import org.apache.flink.table.store.file.TestKeyValueGenerator;
+import org.apache.flink.table.store.file.manifest.ManifestCommittableSerializer;
+import org.apache.flink.table.store.file.manifest.ManifestEntry;
+import org.apache.flink.table.store.file.manifest.ManifestFile;
+import org.apache.flink.table.store.file.manifest.ManifestList;
+import org.apache.flink.table.store.file.mergetree.MergeTreeFactory;
+import org.apache.flink.table.store.file.mergetree.MergeTreeOptions;
+import org.apache.flink.table.store.file.mergetree.compact.DeduplicateAccumulator;
+import org.apache.flink.table.store.file.mergetree.sst.SstFile;
+import org.apache.flink.table.store.file.utils.FileStorePathFactory;
+import org.apache.flink.table.store.file.utils.RecordReaderIterator;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+/** Utils for operation tests. */
+public class OperationTestUtils {
+
+    public static MergeTreeOptions getMergeTreeOptions(boolean forceCompact) {
+        Configuration conf = new Configuration();
+        conf.set(MergeTreeOptions.WRITE_BUFFER_SIZE, MemorySize.parse("16 kb"));
+        conf.set(MergeTreeOptions.PAGE_SIZE, MemorySize.parse("4 kb"));
+        conf.set(MergeTreeOptions.TARGET_FILE_SIZE, MemorySize.parse("1 kb"));
+        conf.set(MergeTreeOptions.COMMIT_FORCE_COMPACT, forceCompact);
+        return new MergeTreeOptions(conf);
+    }
+
+    private static FileStoreOptions getFileStoreOptions() {
+        Configuration conf = new Configuration();
+        conf.set(FileStoreOptions.BUCKET, 1);
+        conf.set(
+                FileStoreOptions.MANIFEST_TARGET_FILE_SIZE,
+                MemorySize.parse((ThreadLocalRandom.current().nextInt(16) + 1) + "kb"));
+        return new FileStoreOptions(conf);
+    }
+
+    public static FileStoreScan createScan(
+            FileFormat fileFormat, FileStorePathFactory pathFactory) {
+        return new FileStoreScanImpl(
+                TestKeyValueGenerator.PARTITION_TYPE,
+                pathFactory,
+                createManifestFileFactory(fileFormat, pathFactory),
+                createManifestListFactory(fileFormat, pathFactory));
+    }
+
+    public static FileStoreCommit createCommit(
+            FileFormat fileFormat, FileStorePathFactory pathFactory) {
+        ManifestCommittableSerializer serializer =
+                new ManifestCommittableSerializer(
+                        TestKeyValueGenerator.PARTITION_TYPE,
+                        TestKeyValueGenerator.KEY_TYPE,
+                        TestKeyValueGenerator.ROW_TYPE);
+        ManifestFile.Factory testManifestFileFactory =
+                createManifestFileFactory(fileFormat, pathFactory);
+        ManifestList.Factory testManifestListFactory =
+                createManifestListFactory(fileFormat, pathFactory);
+        return new FileStoreCommitImpl(
+                UUID.randomUUID().toString(),
+                serializer,
+                pathFactory,
+                testManifestFileFactory,
+                testManifestListFactory,
+                createScan(fileFormat, pathFactory),
+                getFileStoreOptions());
+    }
+
+    public static FileStoreWrite createWrite(
+            FileFormat fileFormat, FileStorePathFactory pathFactory) {
+        MergeTreeFactory mergeTreeFactory =
+                new MergeTreeFactory(
+                        TestKeyValueGenerator.KEY_TYPE,
+                        TestKeyValueGenerator.ROW_TYPE,
+                        TestKeyValueGenerator.KEY_COMPARATOR,
+                        new DeduplicateAccumulator(),
+                        fileFormat,
+                        pathFactory,
+                        OperationTestUtils.getMergeTreeOptions(false));
+        return new FileStoreWriteImpl(
+                pathFactory, mergeTreeFactory, createScan(fileFormat, pathFactory));
+    }
+
+    public static FileStorePathFactory createPathFactory(String scheme, String root) {
+        return new FileStorePathFactory(
+                new Path(scheme + "://" + root), TestKeyValueGenerator.PARTITION_TYPE, "default");
+    }
+
+    private static ManifestFile.Factory createManifestFileFactory(
+            FileFormat fileFormat, FileStorePathFactory pathFactory) {
+        return new ManifestFile.Factory(
+                TestKeyValueGenerator.PARTITION_TYPE,
+                TestKeyValueGenerator.KEY_TYPE,
+                TestKeyValueGenerator.ROW_TYPE,
+                fileFormat,
+                pathFactory);
+    }
+
+    private static ManifestList.Factory createManifestListFactory(
+            FileFormat fileFormat, FileStorePathFactory pathFactory) {
+        return new ManifestList.Factory(
+                TestKeyValueGenerator.PARTITION_TYPE, fileFormat, pathFactory);
+    }
+
+    public static List<KeyValue> readKvsFromSnapshot(
+            long snapshotId, FileFormat fileFormat, FileStorePathFactory pathFactory)
+            throws IOException {
+        List<ManifestEntry> entries =
+                createScan(fileFormat, pathFactory).withSnapshot(snapshotId).plan().files();
+        return readKvsFromManifestEntries(entries, fileFormat, pathFactory);
+    }
+
+    public static List<KeyValue> readKvsFromManifestEntries(
+            List<ManifestEntry> entries, FileFormat fileFormat, FileStorePathFactory pathFactory)
+            throws IOException {
+        List<KeyValue> kvs = new ArrayList<>();
+        SstFile.Factory sstFileFactory =
+                new SstFile.Factory(
+                        TestKeyValueGenerator.KEY_TYPE,
+                        TestKeyValueGenerator.ROW_TYPE,
+                        fileFormat,
+                        pathFactory,
+                        1024 * 1024 // not used
+                        );
+        for (ManifestEntry entry : entries) {
+            SstFile sstFile = sstFileFactory.create(entry.partition(), entry.bucket());
+            RecordReaderIterator iterator =
+                    new RecordReaderIterator(sstFile.read(entry.file().fileName()));
+            while (iterator.hasNext()) {
+                kvs.add(
+                        iterator.next()
+                                .copy(
+                                        TestKeyValueGenerator.KEY_SERIALIZER,
+                                        TestKeyValueGenerator.ROW_SERIALIZER));
+            }
+        }
+        return kvs;
+    }
+
+    public static Map<BinaryRowData, BinaryRowData> toKvMap(List<KeyValue> kvs) {
+        Map<BinaryRowData, BinaryRowData> result = new HashMap<>();
+        for (KeyValue kv : kvs) {
+            BinaryRowData key = TestKeyValueGenerator.KEY_SERIALIZER.toBinaryRow(kv.key()).copy();
+            BinaryRowData value =
+                    TestKeyValueGenerator.ROW_SERIALIZER.toBinaryRow(kv.value()).copy();
+            switch (kv.valueKind()) {
+                case ADD:
+                    result.put(key, value);
+                    break;
+                case DELETE:
+                    result.remove(key);
+                    break;
+                default:
+                    throw new UnsupportedOperationException(
+                            "Unknown value kind " + kv.valueKind().name());
+            }
+        }
+        return result;
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
@@ -19,22 +19,11 @@
 package org.apache.flink.table.store.file.operation;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.store.file.FileFormat;
-import org.apache.flink.table.store.file.FileStoreOptions;
 import org.apache.flink.table.store.file.KeyValue;
-import org.apache.flink.table.store.file.TestKeyValueGenerator;
 import org.apache.flink.table.store.file.manifest.ManifestCommittable;
-import org.apache.flink.table.store.file.manifest.ManifestCommittableSerializer;
-import org.apache.flink.table.store.file.manifest.ManifestEntry;
-import org.apache.flink.table.store.file.manifest.ManifestFile;
-import org.apache.flink.table.store.file.manifest.ManifestList;
-import org.apache.flink.table.store.file.mergetree.MergeTree;
-import org.apache.flink.table.store.file.mergetree.MergeTreeOptions;
 import org.apache.flink.table.store.file.mergetree.MergeTreeWriter;
-import org.apache.flink.table.store.file.mergetree.compact.DeduplicateAccumulator;
-import org.apache.flink.table.store.file.mergetree.sst.SstFile;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 
 import org.slf4j.Logger;
@@ -45,38 +34,19 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.stream.Collectors;
 
 /** Testing {@link Thread}s to perform concurrent commits. */
 public class TestCommitThread extends Thread {
 
     private static final Logger LOG = LoggerFactory.getLogger(TestCommitThread.class);
 
-    private static final MergeTreeOptions MERGE_TREE_OPTIONS;
-    private static final long SUGGESTED_SST_FILE_SIZE = 1024;
-
-    static {
-        Configuration mergeTreeConf = new Configuration();
-        mergeTreeConf.set(MergeTreeOptions.WRITE_BUFFER_SIZE, MemorySize.parse("16 kb"));
-        mergeTreeConf.set(MergeTreeOptions.PAGE_SIZE, MemorySize.parse("4 kb"));
-        MERGE_TREE_OPTIONS = new MergeTreeOptions(mergeTreeConf);
-    }
-
-    private final FileFormat avro =
-            FileFormat.fromIdentifier(
-                    FileStoreCommitTestBase.class.getClassLoader(), "avro", new Configuration());
-
     private final Map<BinaryRowData, List<KeyValue>> data;
-    private final FileStorePathFactory safePathFactory;
-
     private final Map<BinaryRowData, MergeTreeWriter> writers;
-    private final SstFile.Factory sstFileFactory;
 
-    private final FileStoreScan scan;
+    private final FileStoreWrite write;
     private final FileStoreCommit commit;
 
     public TestCommitThread(
@@ -84,61 +54,15 @@ public class TestCommitThread extends Thread {
             FileStorePathFactory testPathFactory,
             FileStorePathFactory safePathFactory) {
         this.data = data;
-        this.safePathFactory = safePathFactory;
-
         this.writers = new HashMap<>();
-        this.sstFileFactory =
-                new SstFile.Factory(
-                        TestKeyValueGenerator.KEY_TYPE,
-                        TestKeyValueGenerator.ROW_TYPE,
-                        avro,
-                        safePathFactory,
-                        SUGGESTED_SST_FILE_SIZE);
 
-        this.scan =
-                new FileStoreScanImpl(
-                        safePathFactory,
-                        createManifestFileFactory(safePathFactory),
-                        createManifestListFactory(safePathFactory));
-
-        ManifestCommittableSerializer serializer =
-                new ManifestCommittableSerializer(
-                        TestKeyValueGenerator.PARTITION_TYPE,
-                        TestKeyValueGenerator.KEY_TYPE,
-                        TestKeyValueGenerator.ROW_TYPE);
-        ManifestFile.Factory testManifestFileFactory = createManifestFileFactory(testPathFactory);
-        ManifestList.Factory testManifestListFactory = createManifestListFactory(testPathFactory);
-        Configuration fileStoreConf = new Configuration();
-        fileStoreConf.set(FileStoreOptions.BUCKET, 1);
-        fileStoreConf.set(
-                FileStoreOptions.MANIFEST_TARGET_FILE_SIZE,
-                MemorySize.parse((ThreadLocalRandom.current().nextInt(16) + 1) + "kb"));
-        FileStoreOptions fileStoreOptions = new FileStoreOptions(fileStoreConf);
-        FileStoreScanImpl testScan =
-                new FileStoreScanImpl(
-                        testPathFactory, testManifestFileFactory, testManifestListFactory);
-        this.commit =
-                new FileStoreCommitImpl(
-                        UUID.randomUUID().toString(),
-                        serializer,
-                        testPathFactory,
-                        testManifestFileFactory,
-                        testManifestListFactory,
-                        testScan,
-                        fileStoreOptions);
-    }
-
-    private ManifestFile.Factory createManifestFileFactory(FileStorePathFactory pathFactory) {
-        return new ManifestFile.Factory(
-                TestKeyValueGenerator.PARTITION_TYPE,
-                TestKeyValueGenerator.KEY_TYPE,
-                TestKeyValueGenerator.ROW_TYPE,
-                avro,
-                pathFactory);
-    }
-
-    private ManifestList.Factory createManifestListFactory(FileStorePathFactory pathFactory) {
-        return new ManifestList.Factory(TestKeyValueGenerator.PARTITION_TYPE, avro, pathFactory);
+        FileFormat avro =
+                FileFormat.fromIdentifier(
+                        FileStoreCommitTestBase.class.getClassLoader(),
+                        "avro",
+                        new Configuration());
+        this.write = OperationTestUtils.createWrite(avro, safePathFactory);
+        this.commit = OperationTestUtils.createCommit(avro, testPathFactory);
     }
 
     @Override
@@ -164,11 +88,7 @@ public class TestCommitThread extends Thread {
                     break;
                 } catch (Throwable e) {
                     if (LOG.isDebugEnabled()) {
-                        LOG.warn(
-                                "["
-                                        + Thread.currentThread().getName()
-                                        + "] Failed to commit because of exception, try again",
-                                e);
+                        LOG.warn("Failed to commit because of exception, try again", e);
                     }
                     writers.clear();
                     shouldCheckFilter = true;
@@ -223,7 +143,6 @@ public class TestCommitThread extends Thread {
     }
 
     private MergeTreeWriter createWriter(BinaryRowData partition) {
-        SstFile sstFile = sstFileFactory.create(partition, 0);
         ExecutorService service =
                 Executors.newSingleThreadExecutor(
                         r -> {
@@ -231,23 +150,6 @@ public class TestCommitThread extends Thread {
                             t.setName(Thread.currentThread().getName() + "-writer-service-pool");
                             return t;
                         });
-        MergeTree mergeTree =
-                new MergeTree(
-                        MERGE_TREE_OPTIONS,
-                        sstFile,
-                        TestKeyValueGenerator.KEY_COMPARATOR,
-                        service,
-                        new DeduplicateAccumulator());
-        Long latestSnapshotId = safePathFactory.latestSnapshotId();
-        if (latestSnapshotId == null) {
-            return (MergeTreeWriter) mergeTree.createWriter(Collections.emptyList());
-        } else {
-            return (MergeTreeWriter)
-                    mergeTree.createWriter(
-                            scan.withSnapshot(latestSnapshotId).plan().files().stream()
-                                    .filter(e -> partition.equals(e.partition()))
-                                    .map(ManifestEntry::file)
-                                    .collect(Collectors.toList()));
-        }
+        return (MergeTreeWriter) write.createWriter(partition, 0, service);
     }
 }


### PR DESCRIPTION
This PR implements partition and bucket filter in `FileStoreScanImpl`. It also perform some small optimizations such as concurrent reads in `FileStoreScanImpl`.