### PR TITLE
[FLINK-25876] Implement overwrite in FlinkStoreCommitImpl

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/Snapshot.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/Snapshot.java
@@ -37,7 +37,7 @@ public class Snapshot {
     private static final String FIELD_ID = "id";
     private static final String FIELD_MANIFEST_LIST = "manifestList";
     private static final String FIELD_COMMIT_USER = "commitUser";
-    private static final String FIELD_COMMIT_DIGEST = "commitDigest";
+    private static final String FIELD_COMMIT_UUID = "commitUuid";
     private static final String FIELD_COMMIT_KIND = "commitKind";
     private static final String FIELD_TIME_MILLIS = "timeMillis";
 
@@ -51,8 +51,8 @@ public class Snapshot {
     private final String commitUser;
 
     // for deduplication
-    @JsonProperty(FIELD_COMMIT_DIGEST)
-    private final String commitDigest;
+    @JsonProperty(FIELD_COMMIT_UUID)
+    private final String commitUuid;
 
     @JsonProperty(FIELD_COMMIT_KIND)
     private final CommitKind commitKind;
@@ -65,13 +65,13 @@ public class Snapshot {
             @JsonProperty(FIELD_ID) long id,
             @JsonProperty(FIELD_MANIFEST_LIST) String manifestList,
             @JsonProperty(FIELD_COMMIT_USER) String commitUser,
-            @JsonProperty(FIELD_COMMIT_DIGEST) String commitDigest,
+            @JsonProperty(FIELD_COMMIT_UUID) String commitUuid,
             @JsonProperty(FIELD_COMMIT_KIND) CommitKind commitKind,
             @JsonProperty(FIELD_TIME_MILLIS) long timeMillis) {
         this.id = id;
         this.manifestList = manifestList;
         this.commitUser = commitUser;
-        this.commitDigest = commitDigest;
+        this.commitUuid = commitUuid;
         this.commitKind = commitKind;
         this.timeMillis = timeMillis;
     }
@@ -91,9 +91,9 @@ public class Snapshot {
         return commitUser;
     }
 
-    @JsonGetter(FIELD_COMMIT_DIGEST)
-    public String commitDigest() {
-        return commitDigest;
+    @JsonGetter(FIELD_COMMIT_UUID)
+    public String commitUuid() {
+        return commitUuid;
     }
 
     @JsonGetter(FIELD_COMMIT_KIND)

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestCommittable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestCommittable.java
@@ -27,26 +27,26 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 
 /** Manifest commit message. */
 public class ManifestCommittable {
 
+    private final String uuid;
     private final Map<BinaryRowData, Map<Integer, List<SstFileMeta>>> newFiles;
-
     private final Map<BinaryRowData, Map<Integer, List<SstFileMeta>>> compactBefore;
-
     private final Map<BinaryRowData, Map<Integer, List<SstFileMeta>>> compactAfter;
 
     public ManifestCommittable() {
-        this.newFiles = new HashMap<>();
-        this.compactBefore = new HashMap<>();
-        this.compactAfter = new HashMap<>();
+        this(UUID.randomUUID().toString(), new HashMap<>(), new HashMap<>(), new HashMap<>());
     }
 
     public ManifestCommittable(
+            String uuid,
             Map<BinaryRowData, Map<Integer, List<SstFileMeta>>> newFiles,
             Map<BinaryRowData, Map<Integer, List<SstFileMeta>>> compactBefore,
             Map<BinaryRowData, Map<Integer, List<SstFileMeta>>> compactAfter) {
+        this.uuid = uuid;
         this.newFiles = newFiles;
         this.compactBefore = compactBefore;
         this.compactAfter = compactAfter;
@@ -66,6 +66,10 @@ public class ManifestCommittable {
         map.computeIfAbsent(partition, k -> new HashMap<>())
                 .computeIfAbsent(bucket, k -> new ArrayList<>())
                 .addAll(files);
+    }
+
+    public String uuid() {
+        return uuid;
     }
 
     public Map<BinaryRowData, Map<Integer, List<SstFileMeta>>> newFiles() {
@@ -89,19 +93,22 @@ public class ManifestCommittable {
             return false;
         }
         ManifestCommittable that = (ManifestCommittable) o;
-        return Objects.equals(newFiles, that.newFiles)
+        return Objects.equals(uuid, that.uuid)
+                && Objects.equals(newFiles, that.newFiles)
                 && Objects.equals(compactBefore, that.compactBefore)
                 && Objects.equals(compactAfter, that.compactAfter);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(newFiles, compactBefore, compactAfter);
+        return Objects.hash(uuid, newFiles, compactBefore, compactAfter);
     }
 
     @Override
     public String toString() {
-        return "new files:\n"
+        return "uuid: "
+                + uuid
+                + "\nnew files:\n"
                 + filesToString(newFiles)
                 + "compact before:\n"
                 + filesToString(compactBefore)

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestCommittableSerializer.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestCommittableSerializer.java
@@ -55,6 +55,8 @@ public class ManifestCommittableSerializer
     public byte[] serialize(ManifestCommittable obj) throws IOException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         DataOutputViewStreamWrapper view = new DataOutputViewStreamWrapper(out);
+        view.writeInt(obj.uuid().length());
+        view.writeBytes(obj.uuid());
         serializeFiles(view, obj.newFiles());
         serializeFiles(view, obj.compactBefore());
         serializeFiles(view, obj.compactAfter());
@@ -104,7 +106,13 @@ public class ManifestCommittableSerializer
     @Override
     public ManifestCommittable deserialize(int version, byte[] serialized) throws IOException {
         DataInputDeserializer view = new DataInputDeserializer(serialized);
+        int uuidLength = view.readInt();
+        byte[] uuidBytes = new byte[uuidLength];
+        view.readFully(uuidBytes);
         return new ManifestCommittable(
-                deserializeFiles(view), deserializeFiles(view), deserializeFiles(view));
+                new String(uuidBytes),
+                deserializeFiles(view),
+                deserializeFiles(view),
+                deserializeFiles(view));
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestCommittableSerializer.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestCommittableSerializer.java
@@ -55,8 +55,7 @@ public class ManifestCommittableSerializer
     public byte[] serialize(ManifestCommittable obj) throws IOException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         DataOutputViewStreamWrapper view = new DataOutputViewStreamWrapper(out);
-        view.writeInt(obj.uuid().length());
-        view.writeBytes(obj.uuid());
+        view.writeUTF(obj.uuid());
         serializeFiles(view, obj.newFiles());
         serializeFiles(view, obj.compactBefore());
         serializeFiles(view, obj.compactAfter());
@@ -106,11 +105,8 @@ public class ManifestCommittableSerializer
     @Override
     public ManifestCommittable deserialize(int version, byte[] serialized) throws IOException {
         DataInputDeserializer view = new DataInputDeserializer(serialized);
-        int uuidLength = view.readInt();
-        byte[] uuidBytes = new byte[uuidLength];
-        view.readFully(uuidBytes);
         return new ManifestCommittable(
-                new String(uuidBytes),
+                view.readUTF(),
                 deserializeFiles(view),
                 deserializeFiles(view),
                 deserializeFiles(view));

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestList.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestList.java
@@ -29,7 +29,6 @@ import org.apache.flink.table.store.file.FileFormat;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 import org.apache.flink.table.store.file.utils.FileUtils;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
 import java.util.List;
@@ -71,9 +70,6 @@ public class ManifestList {
      * <p>NOTE: This method is atomic.
      */
     public String write(List<ManifestFileMeta> metas) {
-        Preconditions.checkArgument(
-                metas.size() > 0, "Manifest file metas to write must not be empty.");
-
         Path path = pathFactory.newManifestList();
         try {
             return write(metas, path);

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommit.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommit.java
@@ -39,7 +39,9 @@ public interface FileStoreCommit {
      * Overwrite from manifest committable and partition.
      *
      * @param partition A single partition maps each partition key to a partition value. Depending
-     *     on the * user-defined statement, the partition might not include all partition keys.
+     *     on the user-defined statement, the partition might not include all partition keys. Also
+     *     note that this partition does not necessarily equal to the partitions of the newly added
+     *     key-values. This is just the partition to be cleaned up.
      */
     void overwrite(
             Map<String, String> partition,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
@@ -147,7 +147,9 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         List<ManifestEntry> compactChanges = new ArrayList<>();
         compactChanges.addAll(collectChanges(committable.compactBefore(), ValueKind.DELETE));
         compactChanges.addAll(collectChanges(committable.compactAfter(), ValueKind.ADD));
-        tryCommit(compactChanges, committable.uuid(), Snapshot.CommitKind.COMPACT);
+        if (!compactChanges.isEmpty()) {
+            tryCommit(compactChanges, committable.uuid(), Snapshot.CommitKind.COMPACT);
+        }
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
@@ -25,7 +25,6 @@ import org.apache.flink.table.store.file.FileStoreOptions;
 import org.apache.flink.table.store.file.Snapshot;
 import org.apache.flink.table.store.file.ValueKind;
 import org.apache.flink.table.store.file.manifest.ManifestCommittable;
-import org.apache.flink.table.store.file.manifest.ManifestCommittableSerializer;
 import org.apache.flink.table.store.file.manifest.ManifestEntry;
 import org.apache.flink.table.store.file.manifest.ManifestFile;
 import org.apache.flink.table.store.file.manifest.ManifestFileMeta;
@@ -33,17 +32,16 @@ import org.apache.flink.table.store.file.manifest.ManifestList;
 import org.apache.flink.table.store.file.mergetree.sst.SstFileMeta;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 import org.apache.flink.table.store.file.utils.FileUtils;
+import org.apache.flink.table.store.file.utils.TypeUtils;
+import org.apache.flink.table.types.logical.RowType;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
-import java.io.IOException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
-import java.util.Base64;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -72,7 +70,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
     private static final Logger LOG = LoggerFactory.getLogger(FileStoreCommitImpl.class);
 
     private final String commitUser;
-    private final ManifestCommittableSerializer committableSerializer;
+    private final RowType partitionType;
     private final FileStorePathFactory pathFactory;
     private final ManifestFile manifestFile;
     private final ManifestList manifestList;
@@ -83,14 +81,14 @@ public class FileStoreCommitImpl implements FileStoreCommit {
 
     public FileStoreCommitImpl(
             String commitUser,
-            ManifestCommittableSerializer committableSerializer,
+            RowType partitionType,
             FileStorePathFactory pathFactory,
             ManifestFile.Factory manifestFileFactory,
             ManifestList.Factory manifestListFactory,
             FileStoreScan scan,
             FileStoreOptions fileStoreOptions) {
         this.commitUser = commitUser;
-        this.committableSerializer = committableSerializer;
+        this.partitionType = partitionType;
         this.pathFactory = pathFactory;
         this.manifestFile = manifestFileFactory.create();
         this.manifestList = manifestListFactory.create();
@@ -108,29 +106,24 @@ public class FileStoreCommitImpl implements FileStoreCommit {
 
     @Override
     public List<ManifestCommittable> filterCommitted(List<ManifestCommittable> committableList) {
-        committableList = new ArrayList<>(committableList);
-
-        // filter out commits with no new files
-        committableList.removeIf(committable -> committable.newFiles().isEmpty());
-
         // if there is no previous snapshots then nothing should be filtered
         Long latestSnapshotId = pathFactory.latestSnapshotId();
         if (latestSnapshotId == null) {
             return committableList;
         }
 
-        // check if a committable is already committed by its hash
-        Map<String, ManifestCommittable> digests = new LinkedHashMap<>();
+        // check if a committable is already committed by its uuid
+        Map<String, ManifestCommittable> uuids = new LinkedHashMap<>();
         for (ManifestCommittable committable : committableList) {
-            digests.put(digestManifestCommittable(committable), committable);
+            uuids.put(committable.uuid(), committable);
         }
 
         for (long id = latestSnapshotId; id >= Snapshot.FIRST_SNAPSHOT_ID; id--) {
             Path snapshotPath = pathFactory.toSnapshotPath(id);
             Snapshot snapshot = Snapshot.fromPath(snapshotPath);
             if (commitUser.equals(snapshot.commitUser())) {
-                if (digests.containsKey(snapshot.commitDigest())) {
-                    digests.remove(snapshot.commitDigest());
+                if (uuids.containsKey(snapshot.commitUuid())) {
+                    uuids.remove(snapshot.commitUuid());
                 } else {
                     // early exit, because committableList must be the latest commits by this
                     // commit user
@@ -139,7 +132,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             }
         }
 
-        return new ArrayList<>(digests.values());
+        return new ArrayList<>(uuids.values());
     }
 
     @Override
@@ -148,19 +141,13 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             LOG.debug("Ready to commit\n" + committable.toString());
         }
 
-        String hash = digestManifestCommittable(committable);
-
         List<ManifestEntry> appendChanges = collectChanges(committable.newFiles(), ValueKind.ADD);
-        if (!appendChanges.isEmpty()) {
-            tryCommit(appendChanges, hash, Snapshot.CommitKind.APPEND);
-        }
+        tryCommit(appendChanges, committable.uuid(), Snapshot.CommitKind.APPEND);
 
         List<ManifestEntry> compactChanges = new ArrayList<>();
         compactChanges.addAll(collectChanges(committable.compactBefore(), ValueKind.DELETE));
         compactChanges.addAll(collectChanges(committable.compactAfter(), ValueKind.ADD));
-        if (!compactChanges.isEmpty()) {
-            tryCommit(compactChanges, hash, Snapshot.CommitKind.COMPACT);
-        }
+        tryCommit(compactChanges, committable.uuid(), Snapshot.CommitKind.COMPACT);
     }
 
     @Override
@@ -168,21 +155,67 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             Map<String, String> partition,
             ManifestCommittable committable,
             Map<String, String> properties) {
-        throw new UnsupportedOperationException();
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(
+                    "Ready to overwrite partition "
+                            + partition.toString()
+                            + "\n"
+                            + committable.toString());
+        }
+
+        BinaryRowData partitionRowData =
+                TypeUtils.partitionMapToBinaryRowData(partition, partitionType);
+
+        List<ManifestEntry> appendChanges = collectChanges(committable.newFiles(), ValueKind.ADD);
+        tryOverwrite(
+                partitionRowData, appendChanges, committable.uuid(), Snapshot.CommitKind.APPEND);
+
+        List<ManifestEntry> compactChanges = new ArrayList<>();
+        compactChanges.addAll(collectChanges(committable.compactBefore(), ValueKind.DELETE));
+        compactChanges.addAll(collectChanges(committable.compactAfter(), ValueKind.ADD));
+        tryCommit(compactChanges, committable.uuid(), Snapshot.CommitKind.COMPACT);
     }
 
-    private String digestManifestCommittable(ManifestCommittable committable) {
-        try {
-            return new String(
-                    Base64.getEncoder()
-                            .encode(
-                                    MessageDigest.getInstance("MD5")
-                                            .digest(committableSerializer.serialize(committable))));
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("MD5 algorithm not found. This is impossible.", e);
-        } catch (IOException e) {
-            throw new RuntimeException(
-                    "Failed to serialize ManifestCommittable. This is unexpected.", e);
+    private void tryCommit(
+            List<ManifestEntry> changes, String hash, Snapshot.CommitKind commitKind) {
+        while (true) {
+            Long latestSnapshotId = pathFactory.latestSnapshotId();
+            if (tryCommitOnce(changes, hash, commitKind, latestSnapshotId)) {
+                break;
+            }
+        }
+    }
+
+    private void tryOverwrite(
+            BinaryRowData partition,
+            List<ManifestEntry> changes,
+            String hash,
+            Snapshot.CommitKind commitKind) {
+        while (true) {
+            Long latestSnapshotId = pathFactory.latestSnapshotId();
+
+            List<ManifestEntry> changesWithOverwrite = new ArrayList<>();
+            if (latestSnapshotId != null) {
+                List<ManifestEntry> currentEntries =
+                        scan.withSnapshot(latestSnapshotId)
+                                .withPartitionFilter(Collections.singletonList(partition))
+                                .plan()
+                                .files();
+                for (ManifestEntry entry : currentEntries) {
+                    changesWithOverwrite.add(
+                            new ManifestEntry(
+                                    ValueKind.DELETE,
+                                    entry.partition(),
+                                    entry.bucket(),
+                                    entry.totalBuckets(),
+                                    entry.file()));
+                }
+            }
+            changesWithOverwrite.addAll(changes);
+
+            if (tryCommitOnce(changesWithOverwrite, hash, commitKind, latestSnapshotId)) {
+                break;
+            }
         }
     }
 
@@ -209,114 +242,122 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         return changes;
     }
 
-    private void tryCommit(
-            List<ManifestEntry> changes, String hash, Snapshot.CommitKind commitKind) {
-        while (true) {
-            Long latestSnapshotId = pathFactory.latestSnapshotId();
-            long newSnapshotId =
-                    latestSnapshotId == null ? Snapshot.FIRST_SNAPSHOT_ID : latestSnapshotId + 1;
-            Path newSnapshotPath = pathFactory.toSnapshotPath(newSnapshotId);
-            Path tmpSnapshotPath = pathFactory.toTmpSnapshotPath(newSnapshotId);
+    private boolean tryCommitOnce(
+            List<ManifestEntry> changes,
+            String hash,
+            Snapshot.CommitKind commitKind,
+            Long latestSnapshotId) {
+        long newSnapshotId =
+                latestSnapshotId == null ? Snapshot.FIRST_SNAPSHOT_ID : latestSnapshotId + 1;
+        Path newSnapshotPath = pathFactory.toSnapshotPath(newSnapshotId);
+        Path tmpSnapshotPath = pathFactory.toTmpSnapshotPath(newSnapshotId);
 
-            Snapshot latestSnapshot = null;
-            if (latestSnapshotId != null) {
-                noConflictsOrFail(latestSnapshotId, changes);
-                latestSnapshot = Snapshot.fromPath(pathFactory.toSnapshotPath(latestSnapshotId));
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Ready to commit changes to snapshot #" + newSnapshotId);
+            for (ManifestEntry entry : changes) {
+                LOG.debug("  * " + entry.toString());
             }
+        }
 
-            Snapshot newSnapshot;
-            String manifestListName = null;
-            List<ManifestFileMeta> oldMetas = new ArrayList<>();
-            List<ManifestFileMeta> newMetas = new ArrayList<>();
-            try {
-                if (latestSnapshot != null) {
-                    // read all previous manifest files
-                    oldMetas.addAll(manifestList.read(latestSnapshot.manifestList()));
-                }
-                // merge manifest files with changes
-                newMetas.addAll(
-                        ManifestFileMeta.merge(
-                                oldMetas,
-                                changes,
-                                manifestFile,
-                                fileStoreOptions.manifestSuggestedSize.getBytes()));
-                // prepare snapshot file
-                manifestListName = manifestList.write(newMetas);
-                newSnapshot =
-                        new Snapshot(
-                                newSnapshotId,
-                                manifestListName,
-                                commitUser,
-                                hash,
-                                commitKind,
-                                System.currentTimeMillis());
-                FileUtils.writeFileUtf8(tmpSnapshotPath, newSnapshot.toJson());
-            } catch (Throwable e) {
-                // fails when preparing for commit, we should clean up
-                cleanUpTmpSnapshot(tmpSnapshotPath, manifestListName, oldMetas, newMetas);
-                throw new RuntimeException(
-                        String.format(
-                                "Exception occurs when preparing snapshot #%d (path %s) by user %s "
-                                        + "with hash %s and kind %s. Clean up.",
-                                newSnapshotId,
-                                newSnapshotPath.toString(),
-                                commitUser,
-                                hash,
-                                commitKind.name()),
-                        e);
+        Snapshot latestSnapshot = null;
+        if (latestSnapshotId != null) {
+            noConflictsOrFail(latestSnapshotId, changes);
+            latestSnapshot = Snapshot.fromPath(pathFactory.toSnapshotPath(latestSnapshotId));
+        }
+
+        Snapshot newSnapshot;
+        String manifestListName = null;
+        List<ManifestFileMeta> oldMetas = new ArrayList<>();
+        List<ManifestFileMeta> newMetas = new ArrayList<>();
+        try {
+            if (latestSnapshot != null) {
+                // read all previous manifest files
+                oldMetas.addAll(manifestList.read(latestSnapshot.manifestList()));
             }
-
-            boolean success;
-            try {
-                FileSystem fs = tmpSnapshotPath.getFileSystem();
-                // atomic rename
-                if (lock != null) {
-                    success =
-                            lock.runWithLock(
-                                    () ->
-                                            // fs.rename may not returns false if target file
-                                            // already exists, or even not atomic
-                                            // as we're relying on external locking, we can first
-                                            // check if file exist then rename to work around this
-                                            // case
-                                            !fs.exists(newSnapshotPath)
-                                                    && fs.rename(tmpSnapshotPath, newSnapshotPath));
-                } else {
-                    success = fs.rename(tmpSnapshotPath, newSnapshotPath);
-                }
-            } catch (Throwable e) {
-                // exception when performing the atomic rename,
-                // we cannot clean up because we can't determine the success
-                throw new RuntimeException(
-                        String.format(
-                                "Exception occurs when committing snapshot #%d (path %s) by user %s "
-                                        + "with hash %s and kind %s. "
-                                        + "Cannot clean up because we can't determine the success.",
-                                newSnapshotId,
-                                newSnapshotPath.toString(),
-                                commitUser,
-                                hash,
-                                commitKind.name()),
-                        e);
-            }
-
-            if (success) {
-                return;
-            }
-
-            // atomic rename fails, clean up and try again
-            LOG.warn(
+            // merge manifest files with changes
+            newMetas.addAll(
+                    ManifestFileMeta.merge(
+                            oldMetas,
+                            changes,
+                            manifestFile,
+                            fileStoreOptions.manifestSuggestedSize.getBytes()));
+            // prepare snapshot file
+            manifestListName = manifestList.write(newMetas);
+            newSnapshot =
+                    new Snapshot(
+                            newSnapshotId,
+                            manifestListName,
+                            commitUser,
+                            hash,
+                            commitKind,
+                            System.currentTimeMillis());
+            FileUtils.writeFileUtf8(tmpSnapshotPath, newSnapshot.toJson());
+        } catch (Throwable e) {
+            // fails when preparing for commit, we should clean up
+            cleanUpTmpSnapshot(tmpSnapshotPath, manifestListName, oldMetas, newMetas);
+            throw new RuntimeException(
                     String.format(
-                            "Atomic rename failed for snapshot #%d (path %s) by user %s "
-                                    + "with hash %s and kind %s. "
-                                    + "Clean up and try again.",
+                            "Exception occurs when preparing snapshot #%d (path %s) by user %s "
+                                    + "with hash %s and kind %s. Clean up.",
                             newSnapshotId,
                             newSnapshotPath.toString(),
                             commitUser,
                             hash,
-                            commitKind.name()));
-            cleanUpTmpSnapshot(tmpSnapshotPath, manifestListName, oldMetas, newMetas);
+                            commitKind.name()),
+                    e);
         }
+
+        boolean success;
+        try {
+            FileSystem fs = tmpSnapshotPath.getFileSystem();
+            // atomic rename
+            if (lock != null) {
+                success =
+                        lock.runWithLock(
+                                () ->
+                                        // fs.rename may not returns false if target file
+                                        // already exists, or even not atomic
+                                        // as we're relying on external locking, we can first
+                                        // check if file exist then rename to work around this
+                                        // case
+                                        !fs.exists(newSnapshotPath)
+                                                && fs.rename(tmpSnapshotPath, newSnapshotPath));
+            } else {
+                success = fs.rename(tmpSnapshotPath, newSnapshotPath);
+            }
+        } catch (Throwable e) {
+            // exception when performing the atomic rename,
+            // we cannot clean up because we can't determine the success
+            throw new RuntimeException(
+                    String.format(
+                            "Exception occurs when committing snapshot #%d (path %s) by user %s "
+                                    + "with hash %s and kind %s. "
+                                    + "Cannot clean up because we can't determine the success.",
+                            newSnapshotId,
+                            newSnapshotPath.toString(),
+                            commitUser,
+                            hash,
+                            commitKind.name()),
+                    e);
+        }
+
+        if (success) {
+            return true;
+        }
+
+        // atomic rename fails, clean up and try again
+        LOG.warn(
+                String.format(
+                        "Atomic rename failed for snapshot #%d (path %s) by user %s "
+                                + "with hash %s and kind %s. "
+                                + "Clean up and try again.",
+                        newSnapshotId,
+                        newSnapshotPath.toString(),
+                        commitUser,
+                        hash,
+                        commitKind.name()));
+        cleanUpTmpSnapshot(tmpSnapshotPath, manifestListName, oldMetas, newMetas);
+        return false;
     }
 
     private void noConflictsOrFail(long snapshotId, List<ManifestEntry> changes) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/TypeUtils.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/TypeUtils.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.utils;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.data.binary.BinaryStringDataUtil;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.List;
+import java.util.Map;
+
+/** Utils for parsing among different types. */
+public class TypeUtils {
+
+    public static BinaryRowData partitionMapToBinaryRowData(
+            Map<String, String> partition, RowType partitionType) {
+        List<String> fieldNames = partitionType.getFieldNames();
+        RowDataSerializer serializer = new RowDataSerializer(partitionType);
+        GenericRowData rowData = new GenericRowData(partitionType.getFieldCount());
+        for (Map.Entry<String, String> entry : partition.entrySet()) {
+            int idx = fieldNames.indexOf(entry.getKey());
+            rowData.setField(idx, castFromString(entry.getValue(), partitionType.getTypeAt(idx)));
+        }
+        return serializer.toBinaryRow(rowData);
+    }
+
+    private static Object castFromString(String s, LogicalType type) {
+        BinaryStringData str = BinaryStringData.fromString(s);
+        switch (type.getTypeRoot()) {
+            case CHAR:
+            case VARCHAR:
+                return str;
+            case BOOLEAN:
+                return BinaryStringDataUtil.toBoolean(str);
+            case BINARY:
+            case VARBINARY:
+                // this implementation does not match the new behavior of StringToBinaryCastRule,
+                // change this if needed
+                return s.getBytes();
+            case DECIMAL:
+                DecimalType decimalType = (DecimalType) type;
+                return BinaryStringDataUtil.toDecimal(
+                        str, decimalType.getPrecision(), decimalType.getScale());
+            case TINYINT:
+                return BinaryStringDataUtil.toByte(str);
+            case SMALLINT:
+                return BinaryStringDataUtil.toShort(str);
+            case INTEGER:
+                return BinaryStringDataUtil.toInt(str);
+            case BIGINT:
+                return BinaryStringDataUtil.toLong(str);
+            case FLOAT:
+                return BinaryStringDataUtil.toFloat(str);
+            case DOUBLE:
+                return BinaryStringDataUtil.toDouble(str);
+            case DATE:
+                return BinaryStringDataUtil.toDate(str);
+            case TIME_WITHOUT_TIME_ZONE:
+                return BinaryStringDataUtil.toTime(str);
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+                return BinaryStringDataUtil.toTimestamp(str);
+            default:
+                throw new UnsupportedOperationException("Unsupported type " + type.toString());
+        }
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestKeyValueGenerator.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestKeyValueGenerator.java
@@ -34,7 +34,9 @@ import org.apache.flink.table.types.logical.VarCharType;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 
 /** Random {@link KeyValue} generator. */
@@ -157,6 +159,13 @@ public class TestKeyValueGenerator {
         return PARTITION_SERIALIZER
                 .toBinaryRow(GenericRowData.of(kv.value().getString(0), kv.value().getInt(1)))
                 .copy();
+    }
+
+    public static Map<String, String> toPartitionMap(BinaryRowData partition) {
+        Map<String, String> map = new HashMap<>();
+        map.put("dt", partition.getString(0).toString());
+        map.put("hr", String.valueOf(partition.getInt(1)));
+        return map;
     }
 
     public void sort(List<KeyValue> kvs) {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreExpireTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreExpireTest.java
@@ -46,7 +46,7 @@ public class FileStoreExpireTest {
 
     private final FileFormat avro =
             FileFormat.fromIdentifier(
-                    FileStoreCommitTestBase.class.getClassLoader(), "avro", new Configuration());
+                    FileStoreCommitTest.class.getClassLoader(), "avro", new Configuration());
 
     private TestKeyValueGenerator gen;
     @TempDir java.nio.file.Path tempDir;
@@ -187,7 +187,7 @@ public class FileStoreExpireTest {
             }
             allData.addAll(data);
             List<Snapshot> snapshots =
-                    OperationTestUtils.writeAndCommitData(
+                    OperationTestUtils.commitData(
                             data, gen::getPartition, kv -> 0, avro, pathFactory);
             for (int j = 0; j < snapshots.size(); j++) {
                 snapshotPositions.add(allData.size());

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreScanTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreScanTest.java
@@ -53,7 +53,7 @@ public class FileStoreScanTest {
 
     private final FileFormat avro =
             FileFormat.fromIdentifier(
-                    FileStoreCommitTestBase.class.getClassLoader(), "avro", new Configuration());
+                    FileStoreCommitTest.class.getClassLoader(), "avro", new Configuration());
 
     private TestKeyValueGenerator gen;
     @TempDir java.nio.file.Path tempDir;
@@ -199,7 +199,7 @@ public class FileStoreScanTest {
 
     private Snapshot writeData(List<KeyValue> kvs) throws Exception {
         List<Snapshot> snapshots =
-                OperationTestUtils.writeAndCommitData(
+                OperationTestUtils.commitData(
                         kvs, gen::getPartition, this::getBucket, avro, pathFactory);
         return snapshots.get(snapshots.size() - 1);
     }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/OperationTestUtils.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/OperationTestUtils.java
@@ -28,7 +28,6 @@ import org.apache.flink.table.store.file.KeyValue;
 import org.apache.flink.table.store.file.Snapshot;
 import org.apache.flink.table.store.file.TestKeyValueGenerator;
 import org.apache.flink.table.store.file.manifest.ManifestCommittable;
-import org.apache.flink.table.store.file.manifest.ManifestCommittableSerializer;
 import org.apache.flink.table.store.file.manifest.ManifestEntry;
 import org.apache.flink.table.store.file.manifest.ManifestFile;
 import org.apache.flink.table.store.file.manifest.ManifestList;
@@ -85,18 +84,13 @@ public class OperationTestUtils {
 
     public static FileStoreCommit createCommit(
             FileFormat fileFormat, FileStorePathFactory pathFactory) {
-        ManifestCommittableSerializer serializer =
-                new ManifestCommittableSerializer(
-                        TestKeyValueGenerator.PARTITION_TYPE,
-                        TestKeyValueGenerator.KEY_TYPE,
-                        TestKeyValueGenerator.ROW_TYPE);
         ManifestFile.Factory testManifestFileFactory =
                 createManifestFileFactory(fileFormat, pathFactory);
         ManifestList.Factory testManifestListFactory =
                 createManifestListFactory(fileFormat, pathFactory);
         return new FileStoreCommitImpl(
                 UUID.randomUUID().toString(),
-                serializer,
+                TestKeyValueGenerator.PARTITION_TYPE,
                 pathFactory,
                 testManifestFileFactory,
                 testManifestListFactory,

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/OperationTestUtils.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/OperationTestUtils.java
@@ -39,6 +39,7 @@ import org.apache.flink.table.store.file.mergetree.sst.SstFile;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 import org.apache.flink.table.store.file.utils.RecordReaderIterator;
 import org.apache.flink.table.store.file.utils.RecordWriter;
+import org.apache.flink.util.function.QuadFunction;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -50,6 +51,7 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 /** Utils for operation tests. */
@@ -147,12 +149,51 @@ public class OperationTestUtils {
                 TestKeyValueGenerator.PARTITION_TYPE, fileFormat, pathFactory);
     }
 
-    public static List<Snapshot> writeAndCommitData(
+    public static List<Snapshot> commitData(
             List<KeyValue> kvs,
             Function<KeyValue, BinaryRowData> partitionCalculator,
             Function<KeyValue, Integer> bucketCalculator,
             FileFormat fileFormat,
             FileStorePathFactory pathFactory)
+            throws Exception {
+        return commitDataImpl(
+                kvs,
+                partitionCalculator,
+                bucketCalculator,
+                fileFormat,
+                pathFactory,
+                FileStoreWrite::createWriter,
+                (commit, committable) -> commit.commit(committable, Collections.emptyMap()));
+    }
+
+    public static List<Snapshot> overwriteData(
+            List<KeyValue> kvs,
+            Function<KeyValue, BinaryRowData> partitionCalculator,
+            Function<KeyValue, Integer> bucketCalculator,
+            FileFormat fileFormat,
+            FileStorePathFactory pathFactory,
+            Map<String, String> partition)
+            throws Exception {
+        return commitDataImpl(
+                kvs,
+                partitionCalculator,
+                bucketCalculator,
+                fileFormat,
+                pathFactory,
+                FileStoreWrite::createEmptyWriter,
+                (commit, committable) ->
+                        commit.overwrite(partition, committable, Collections.emptyMap()));
+    }
+
+    private static List<Snapshot> commitDataImpl(
+            List<KeyValue> kvs,
+            Function<KeyValue, BinaryRowData> partitionCalculator,
+            Function<KeyValue, Integer> bucketCalculator,
+            FileFormat fileFormat,
+            FileStorePathFactory pathFactory,
+            QuadFunction<FileStoreWrite, BinaryRowData, Integer, ExecutorService, RecordWriter>
+                    createWriterFunction,
+            BiConsumer<FileStoreCommit, ManifestCommittable> commitFunction)
             throws Exception {
         FileStoreWrite write = createWrite(fileFormat, pathFactory);
         Map<BinaryRowData, Map<Integer, RecordWriter>> writers = new HashMap<>();
@@ -165,7 +206,8 @@ public class OperationTestUtils {
                             (b, w) -> {
                                 if (w == null) {
                                     ExecutorService service = Executors.newSingleThreadExecutor();
-                                    return write.createWriter(partition, bucket, service);
+                                    return createWriterFunction.apply(
+                                            write, partition, bucket, service);
                                 } else {
                                     return w;
                                 }
@@ -188,7 +230,7 @@ public class OperationTestUtils {
         if (snapshotIdBeforeCommit == null) {
             snapshotIdBeforeCommit = Snapshot.FIRST_SNAPSHOT_ID - 1;
         }
-        commit.commit(committable, Collections.emptyMap());
+        commitFunction.accept(commit, committable);
         Long snapshotIdAfterCommit = pathFactory.latestSnapshotId();
         if (snapshotIdAfterCommit == null) {
             snapshotIdAfterCommit = Snapshot.FIRST_SNAPSHOT_ID - 1;

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
@@ -61,9 +61,7 @@ public class TestCommitThread extends Thread {
 
         FileFormat avro =
                 FileFormat.fromIdentifier(
-                        FileStoreCommitTestBase.class.getClassLoader(),
-                        "avro",
-                        new Configuration());
+                        FileStoreCommitTest.class.getClassLoader(), "avro", new Configuration());
         this.write = OperationTestUtils.createWrite(avro, safePathFactory);
         this.commit = OperationTestUtils.createCommit(avro, testPathFactory);
     }

--- a/flink-table-store-core/src/test/resources/log4j2-test.xml
+++ b/flink-table-store-core/src/test/resources/log4j2-test.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
+        </Console>
+    </Appenders>
+    <Loggers>
+        <!-- <Logger name="org.apache.flink.table.store.file.operation" level="DEBUG" /> -->
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
Overwrite is a useful transaction for batch jobs to completely update a partition for data correction. Currently FileStoreScanImpl doesn't implement this transaction so we need to implement that.