### PR TITLE
[[FLINK-26031] Support projection pushdown on keys and values

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileFormat.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileFormat.java
@@ -37,18 +37,29 @@ import java.util.List;
 public interface FileFormat {
 
     /**
-     * Create a {@link BulkFormat} from the type.
+     * Create a {@link BulkFormat} from the type, with projection pushed down.
      *
+     * @param type Type without projection.
+     * @param projection See {@link org.apache.flink.table.connector.Projection#toNestedIndexes()}.
      * @param filters A list of filters in conjunctive form for filtering on a best-effort basis.
      */
     BulkFormat<RowData, FileSourceSplit> createReaderFactory(
-            RowType type, List<ResolvedExpression> filters);
+            RowType type, int[][] projection, List<ResolvedExpression> filters);
 
     /** Create a {@link BulkWriter.Factory} from the type. */
     BulkWriter.Factory<RowData> createWriterFactory(RowType type);
 
     default BulkFormat<RowData, FileSourceSplit> createReaderFactory(RowType rowType) {
-        return createReaderFactory(rowType, new ArrayList<>());
+        int[][] projection = new int[rowType.getFieldCount()][];
+        for (int i = 0; i < projection.length; i++) {
+            projection[i] = new int[] {i};
+        }
+        return createReaderFactory(rowType, projection);
+    }
+
+    default BulkFormat<RowData, FileSourceSplit> createReaderFactory(
+            RowType rowType, int[][] projection) {
+        return createReaderFactory(rowType, projection, new ArrayList<>());
     }
 
     /** Create a {@link FileFormatImpl} from format identifier and format options. */

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValue.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValue.java
@@ -78,6 +78,33 @@ public class KeyValue {
         return new RowType(fields);
     }
 
+    public static int[][] project(
+            int[][] keyProjection, int[][] valueProjection, int numKeyFields) {
+        int[][] projection = new int[keyProjection.length + 2 + valueProjection.length][];
+
+        // key
+        for (int i = 0; i < keyProjection.length; i++) {
+            projection[i] = new int[keyProjection[i].length];
+            System.arraycopy(keyProjection[i], 0, projection[i], 0, keyProjection[i].length);
+        }
+
+        // seq
+        projection[keyProjection.length] = new int[] {numKeyFields};
+
+        // value kind
+        projection[keyProjection.length + 1] = new int[] {numKeyFields + 1};
+
+        // value
+        for (int i = 0; i < valueProjection.length; i++) {
+            int idx = keyProjection.length + 2 + i;
+            projection[idx] = new int[valueProjection[i].length];
+            System.arraycopy(valueProjection[i], 0, projection[idx], 0, valueProjection[i].length);
+            projection[idx][0] += numKeyFields + 2;
+        }
+
+        return projection;
+    }
+
     @VisibleForTesting
     public KeyValue copy(RowDataSerializer keySerializer, RowDataSerializer valueSerializer) {
         return new KeyValue()

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreRead.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreRead.java
@@ -34,7 +34,18 @@ public interface FileStoreRead {
     /** With value nested projection. */
     void withValueProjection(int[][] projectedFields);
 
-    /** Create a {@link RecordReader} from partition and bucket and files. */
+    /**
+     * Create a {@link RecordReader} from partition and bucket and files.
+     *
+     * <p>The resulting reader has the following characteristics:
+     *
+     * <ul>
+     *   <li>If {@link FileStoreRead#withKeyProjection} is called, key-values produced by this
+     *       reader may be unordered and may contain duplicated keys.
+     *   <li>If {@link FileStoreRead#withKeyProjection} is not called, key-values produced by this
+     *       reader is guaranteed to be ordered by keys and does not contain duplicated keys.
+     * </ul>
+     */
     RecordReader createReader(BinaryRowData partition, int bucket, List<SstFileMeta> files)
             throws IOException;
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreReadTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreReadTest.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.operation;
+
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.table.store.file.KeyValue;
+import org.apache.flink.table.store.file.TestFileStore;
+import org.apache.flink.table.store.file.TestKeyValueGenerator;
+import org.apache.flink.table.store.file.ValueKind;
+import org.apache.flink.table.store.file.manifest.ManifestEntry;
+import org.apache.flink.table.store.file.mergetree.compact.Accumulator;
+import org.apache.flink.table.store.file.mergetree.compact.DeduplicateAccumulator;
+import org.apache.flink.table.store.file.mergetree.compact.ValueCountAccumulator;
+import org.apache.flink.table.store.file.utils.RecordReader;
+import org.apache.flink.table.store.file.utils.RecordReaderIterator;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link FileStoreReadImpl}. */
+public class FileStoreReadTest {
+
+    @TempDir java.nio.file.Path tempDir;
+
+    @BeforeEach
+    public void beforeEach() throws IOException {
+        Path root = new Path(tempDir.toString());
+        root.getFileSystem().mkdirs(new Path(root + "/snapshot"));
+    }
+
+    @Test
+    public void testKeyProjection() throws Exception {
+        // (a, b, c) -> (b, a), c is the partition, all integers are in range [0, 2]
+
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        int numRecords = random.nextInt(1000) + 1;
+        List<KeyValue> data = new ArrayList<>();
+        Map<Integer, Long> expected = new HashMap<>();
+        for (int i = 0; i < numRecords; i++) {
+            int a = random.nextInt(3);
+            int b = random.nextInt(3);
+            int c = random.nextInt(3);
+            long delta = random.nextLong(21) - 10;
+            expected.compute(b * 10 + a, (k, v) -> v == null ? delta : v + delta);
+            data.add(
+                    new KeyValue()
+                            .replace(
+                                    GenericRowData.of(a, b, c),
+                                    i,
+                                    ValueKind.ADD,
+                                    GenericRowData.of(delta)));
+        }
+
+        RowType partitionType =
+                RowType.of(new LogicalType[] {new IntType(false)}, new String[] {"c"});
+        RowDataSerializer partitionSerializer = new RowDataSerializer(partitionType);
+        RowType keyType =
+                RowType.of(
+                        new LogicalType[] {
+                            new IntType(false), new IntType(false), new IntType(false)
+                        },
+                        new String[] {"a", "b", "c"});
+        RowType projectedKeyType = RowType.of(new IntType(false), new IntType(false));
+        RowDataSerializer projectedKeySerializer = new RowDataSerializer(projectedKeyType);
+        RowType valueType =
+                RowType.of(new LogicalType[] {new BigIntType(false)}, new String[] {"count"});
+        RowDataSerializer valueSerializer = new RowDataSerializer(valueType);
+
+        TestFileStore store =
+                createStore(partitionType, keyType, valueType, new ValueCountAccumulator());
+        List<KeyValue> readData =
+                writeThenRead(
+                        data,
+                        new int[][] {new int[] {1}, new int[] {0}},
+                        null,
+                        projectedKeySerializer,
+                        valueSerializer,
+                        store,
+                        kv ->
+                                partitionSerializer
+                                        .toBinaryRow(GenericRowData.of(kv.key().getInt(2)))
+                                        .copy());
+        Map<Integer, Long> actual = new HashMap<>();
+        for (KeyValue kv : readData) {
+            assertThat(kv.key().getArity()).isEqualTo(2);
+            int key = kv.key().getInt(0) * 10 + kv.key().getInt(1);
+            long delta = kv.value().getLong(0);
+            actual.compute(key, (k, v) -> v == null ? delta : v + delta);
+        }
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void testValueProjection() throws Exception {
+        // (dt, hr, shopId, orderId, itemId, priceAmount, comment) -> (shopId, itemId, dt, hr)
+
+        TestKeyValueGenerator gen = new TestKeyValueGenerator();
+        int numRecords = ThreadLocalRandom.current().nextInt(1000) + 1;
+        List<KeyValue> data = new ArrayList<>();
+        for (int i = 0; i < numRecords; i++) {
+            data.add(gen.next());
+        }
+        TestFileStore store =
+                createStore(
+                        TestKeyValueGenerator.PARTITION_TYPE,
+                        TestKeyValueGenerator.KEY_TYPE,
+                        TestKeyValueGenerator.ROW_TYPE,
+                        new DeduplicateAccumulator());
+
+        RowDataSerializer projectedValueSerializer =
+                new RowDataSerializer(
+                        new IntType(false),
+                        new BigIntType(),
+                        new VarCharType(false, 8),
+                        new IntType(false));
+        Map<BinaryRowData, BinaryRowData> expected = store.toKvMap(data);
+        expected.replaceAll(
+                (k, v) ->
+                        projectedValueSerializer
+                                .toBinaryRow(
+                                        GenericRowData.of(
+                                                v.getInt(2),
+                                                v.isNullAt(4) ? null : v.getLong(4),
+                                                v.getString(0),
+                                                v.getInt(1)))
+                                .copy());
+
+        List<KeyValue> readData =
+                writeThenRead(
+                        data,
+                        null,
+                        new int[][] {new int[] {2}, new int[] {4}, new int[] {0}, new int[] {1}},
+                        TestKeyValueGenerator.KEY_SERIALIZER,
+                        projectedValueSerializer,
+                        store,
+                        gen::getPartition);
+        for (KeyValue kv : readData) {
+            assertThat(kv.value().getArity()).isEqualTo(4);
+            BinaryRowData key = TestKeyValueGenerator.KEY_SERIALIZER.toBinaryRow(kv.key());
+            BinaryRowData value = projectedValueSerializer.toBinaryRow(kv.value());
+            assertThat(expected).containsKey(key);
+            assertThat(value).isEqualTo(expected.get(key));
+        }
+    }
+
+    private List<KeyValue> writeThenRead(
+            List<KeyValue> data,
+            int[][] keyProjection,
+            int[][] valueProjection,
+            RowDataSerializer projectedKeySerializer,
+            RowDataSerializer projectedValueSerializer,
+            TestFileStore store,
+            Function<KeyValue, BinaryRowData> partitionCalculator)
+            throws Exception {
+        store.commitData(data, partitionCalculator, kv -> 0);
+        FileStoreScan scan = store.newScan();
+        Map<BinaryRowData, List<ManifestEntry>> filesGroupedByPartition =
+                scan.withSnapshot(store.pathFactory().latestSnapshotId()).plan().files().stream()
+                        .collect(Collectors.groupingBy(ManifestEntry::partition));
+        FileStoreRead read = store.newRead();
+        if (keyProjection != null) {
+            read.withKeyProjection(keyProjection);
+        }
+        if (valueProjection != null) {
+            read.withValueProjection(valueProjection);
+        }
+
+        List<KeyValue> result = new ArrayList<>();
+        for (Map.Entry<BinaryRowData, List<ManifestEntry>> entry :
+                filesGroupedByPartition.entrySet()) {
+            RecordReader reader =
+                    read.createReader(
+                            entry.getKey(),
+                            0,
+                            entry.getValue().stream()
+                                    .map(ManifestEntry::file)
+                                    .collect(Collectors.toList()));
+            RecordReaderIterator actualIterator = new RecordReaderIterator(reader);
+            while (actualIterator.hasNext()) {
+                result.add(
+                        actualIterator
+                                .next()
+                                .copy(projectedKeySerializer, projectedValueSerializer));
+            }
+        }
+        return result;
+    }
+
+    private TestFileStore createStore(
+            RowType partitionType, RowType keyType, RowType valueType, Accumulator accumulator) {
+        return TestFileStore.create(
+                "avro", tempDir.toString(), 1, partitionType, keyType, valueType, accumulator);
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/FlushingAvroFormat.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/FlushingAvroFormat.java
@@ -40,8 +40,8 @@ public class FlushingAvroFormat implements FileFormat {
 
     @Override
     public BulkFormat<RowData, FileSourceSplit> createReaderFactory(
-            RowType type, List<ResolvedExpression> filters) {
-        return avro.createReaderFactory(type, filters);
+            RowType type, int[][] projection, List<ResolvedExpression> filters) {
+        return avro.createReaderFactory(type, projection, filters);
     }
 
     @Override


### PR DESCRIPTION
Projection pushdown is an optimization for sources. With this optimization, we can avoid reading useless columns and thus improve performance.