### PR TITLE
[FLINK-26217] Introduce manifest.merge-min-count in commit

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreOptions.java
@@ -38,15 +38,29 @@ public class FileStoreOptions {
                     .defaultValue(MemorySize.ofMebiBytes(8))
                     .withDescription("Suggested file size of a manifest file.");
 
+    public static final ConfigOption<Integer> MANIFEST_MERGE_MIN_COUNT =
+            ConfigOptions.key("manifest.merge-min-count")
+                    .intType()
+                    .defaultValue(30)
+                    .withDescription(
+                            "To avoid frequent manifest merges, this parameter specifies the minimum number "
+                                    + "of ManifestFileMeta to merge.");
+
     public final int bucket;
     public final MemorySize manifestSuggestedSize;
+    public final int manifestMergeMinCount;
 
-    public FileStoreOptions(int bucket, MemorySize manifestSuggestedSize) {
+    public FileStoreOptions(
+            int bucket, MemorySize manifestSuggestedSize, int manifestMergeMinCount) {
         this.bucket = bucket;
         this.manifestSuggestedSize = manifestSuggestedSize;
+        this.manifestMergeMinCount = manifestMergeMinCount;
     }
 
     public FileStoreOptions(ReadableConfig config) {
-        this(config.get(BUCKET), config.get(MANIFEST_TARGET_FILE_SIZE));
+        this(
+                config.get(BUCKET),
+                config.get(MANIFEST_TARGET_FILE_SIZE),
+                config.get(MANIFEST_MERGE_MIN_COUNT));
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
@@ -307,7 +307,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                             oldMetas,
                             changes,
                             manifestFile,
-                            fileStoreOptions.manifestSuggestedSize.getBytes()));
+                            fileStoreOptions.manifestSuggestedSize.getBytes(),
+                            fileStoreOptions.manifestMergeMinCount));
             // prepare snapshot file
             manifestListName = manifestList.write(newMetas);
             newSnapshot =


### PR DESCRIPTION
Changes in this PR:
- Introduce `manifest.merge-min-count` option in `FileStoreOptions.java`
- Update `merge` function in `ManifestFileMata.java` to take that option