### PR TITLE
[hotfix] Set authority as thread name for FailingAtomicRenameFileSystem to support multi-thread testing

### DIFF
--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileStoreITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileStoreITCase.java
@@ -38,6 +38,7 @@ import org.apache.flink.table.store.connector.source.FileStoreSource;
 import org.apache.flink.table.store.file.FileStore;
 import org.apache.flink.table.store.file.FileStoreImpl;
 import org.apache.flink.table.store.file.mergetree.compact.DeduplicateAccumulator;
+import org.apache.flink.table.store.file.utils.FailingAtomicRenameFileSystem;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
@@ -214,8 +215,8 @@ public class FileStoreITCase extends AbstractTestBase {
         if (isBatch) {
             options.set(FILE_PATH, folder.toURI().toString());
         } else {
-            options.set(FILE_PATH, "fail://" + folder.getPath());
-            // FailingAtomicRenameFileSystem.setFailPossibility(20);
+            FailingAtomicRenameFileSystem.get().reset(3, 100);
+            options.set(FILE_PATH, FailingAtomicRenameFileSystem.getFailingPath(folder.getPath()));
         }
         options.set(FILE_FORMAT, "avro");
         return options;

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestFileMetaTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestFileMetaTest.java
@@ -110,15 +110,13 @@ public class ManifestFileMetaTest {
 
     @RepeatedTest(10)
     public void testCleanUpForException() throws IOException {
-        FailingAtomicRenameFileSystem.resetFailCounter(1);
-        FailingAtomicRenameFileSystem.setFailPossibility(10);
-
+        FailingAtomicRenameFileSystem.get().reset(1, 10);
         List<ManifestFileMeta> input = new ArrayList<>();
         List<ManifestEntry> entries = new ArrayList<>();
         createData(input, entries, null);
         ManifestFile failingManifestFile =
                 createManifestFile(
-                        FailingAtomicRenameFileSystem.SCHEME + "://" + tempDir.toString());
+                        FailingAtomicRenameFileSystem.getFailingPath(tempDir.toString()));
 
         try {
             ManifestFileMeta.merge(input, entries, failingManifestFile, 500, 30);

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestFileTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestFileTest.java
@@ -60,12 +60,11 @@ public class ManifestFileTest {
 
     @RepeatedTest(10)
     public void testCleanUpForException() throws IOException {
-        FailingAtomicRenameFileSystem.resetFailCounter(1);
-        FailingAtomicRenameFileSystem.setFailPossibility(10);
+        FailingAtomicRenameFileSystem.get().reset(1, 10);
         List<ManifestEntry> entries = generateData();
         ManifestFile manifestFile =
                 createManifestFile(
-                        FailingAtomicRenameFileSystem.SCHEME + "://" + tempDir.toString());
+                        FailingAtomicRenameFileSystem.getFailingPath(tempDir.toString()));
 
         try {
             manifestFile.write(entries);

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestListTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestListTest.java
@@ -58,12 +58,11 @@ public class ManifestListTest {
 
     @RepeatedTest(10)
     public void testCleanUpForException() throws IOException {
-        FailingAtomicRenameFileSystem.resetFailCounter(1);
-        FailingAtomicRenameFileSystem.setFailPossibility(3);
+        FailingAtomicRenameFileSystem.get().reset(1, 3);
         List<ManifestFileMeta> metas = generateData();
         ManifestList manifestList =
                 createManifestList(
-                        FailingAtomicRenameFileSystem.SCHEME + "://" + tempDir.toString());
+                        FailingAtomicRenameFileSystem.getFailingPath(tempDir.toString()));
 
         try {
             manifestList.write(metas);

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/sst/SstFileTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/sst/SstFileTest.java
@@ -98,12 +98,11 @@ public class SstFileTest {
 
     @RepeatedTest(10)
     public void testCleanUpForException() throws IOException {
-        FailingAtomicRenameFileSystem.resetFailCounter(1);
-        FailingAtomicRenameFileSystem.setFailPossibility(10);
+        FailingAtomicRenameFileSystem.get().reset(1, 10);
         SstTestDataGenerator.Data data = gen.next();
         SstFileWriter writer =
                 createSstFileWriter(
-                        FailingAtomicRenameFileSystem.SCHEME + "://" + tempDir.toString());
+                        FailingAtomicRenameFileSystem.getFailingPath(tempDir.toString()));
 
         try {
             writer.write(CloseableIterator.fromList(data.content, kv -> {}), 0);

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreExpireTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreExpireTest.java
@@ -27,7 +27,6 @@ import org.apache.flink.table.store.file.KeyValue;
 import org.apache.flink.table.store.file.Snapshot;
 import org.apache.flink.table.store.file.TestKeyValueGenerator;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
-import org.apache.flink.table.store.file.utils.TestAtomicRenameFileSystem;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,9 +54,7 @@ public class FileStoreExpireTest {
     @BeforeEach
     public void beforeEach() throws IOException {
         gen = new TestKeyValueGenerator();
-        pathFactory =
-                OperationTestUtils.createPathFactory(
-                        TestAtomicRenameFileSystem.SCHEME, tempDir.toString());
+        pathFactory = OperationTestUtils.createPathFactory(false, tempDir.toString());
         Path root = new Path(tempDir.toString());
         root.getFileSystem().mkdirs(new Path(root + "/snapshot"));
     }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreScanTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreScanTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.table.store.file.TestKeyValueGenerator;
 import org.apache.flink.table.store.file.manifest.ManifestFileMeta;
 import org.apache.flink.table.store.file.manifest.ManifestList;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
-import org.apache.flink.table.store.file.utils.TestAtomicRenameFileSystem;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
@@ -62,9 +61,7 @@ public class FileStoreScanTest {
     @BeforeEach
     public void beforeEach() throws IOException {
         gen = new TestKeyValueGenerator();
-        pathFactory =
-                OperationTestUtils.createPathFactory(
-                        TestAtomicRenameFileSystem.SCHEME, tempDir.toString());
+        pathFactory = OperationTestUtils.createPathFactory(false, tempDir.toString());
         Path root = new Path(tempDir.toString());
         root.getFileSystem().mkdirs(new Path(root + "/snapshot"));
     }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/OperationTestUtils.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/OperationTestUtils.java
@@ -34,9 +34,11 @@ import org.apache.flink.table.store.file.mergetree.Increment;
 import org.apache.flink.table.store.file.mergetree.MergeTreeOptions;
 import org.apache.flink.table.store.file.mergetree.compact.DeduplicateAccumulator;
 import org.apache.flink.table.store.file.mergetree.sst.SstFileMeta;
+import org.apache.flink.table.store.file.utils.FailingAtomicRenameFileSystem;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 import org.apache.flink.table.store.file.utils.RecordReaderIterator;
 import org.apache.flink.table.store.file.utils.RecordWriter;
+import org.apache.flink.table.store.file.utils.TestAtomicRenameFileSystem;
 import org.apache.flink.util.function.QuadFunction;
 
 import java.io.IOException;
@@ -129,9 +131,13 @@ public class OperationTestUtils {
                 pathFactory);
     }
 
-    public static FileStorePathFactory createPathFactory(String scheme, String root) {
+    public static FileStorePathFactory createPathFactory(boolean failing, String root) {
+        String path =
+                failing
+                        ? FailingAtomicRenameFileSystem.getFailingPath(root)
+                        : TestAtomicRenameFileSystem.SCHEME + "://" + root;
         return new FileStorePathFactory(
-                new Path(scheme + "://" + root), TestKeyValueGenerator.PARTITION_TYPE, "default");
+                new Path(path), TestKeyValueGenerator.PARTITION_TYPE, "default");
     }
 
     private static ManifestFile.Factory createManifestFileFactory(

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
@@ -137,7 +137,7 @@ public class TestCommitThread extends Thread {
                 break;
             } catch (Throwable e) {
                 if (LOG.isDebugEnabled()) {
-                    LOG.warn("Failed to commit because of exception, try again", e);
+                    LOG.debug("Failed to commit because of exception, try again", e);
                 }
                 writers.clear();
                 shouldCheckFilter = true;


### PR DESCRIPTION
Currently `FailingAtomicRenameFileSystem` uses a static method to reset the failing counter and set failing possibility. This may cause conflicts when there are multiple testing threads running different test cases. This PR fixes the issue.