### PR TITLE
[hotfix] Refactor OperationTestUtils into TestFileStore and remove unnecessary repeated tests

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreImpl.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.store.file;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.planner.codegen.sort.SortCodeGenerator;
@@ -71,7 +72,8 @@ public class FileStoreImpl implements FileStore {
                         .generateRecordComparator("KeyComparator");
     }
 
-    private FileStorePathFactory pathFactory() {
+    @VisibleForTesting
+    public FileStorePathFactory pathFactory() {
         return new FileStorePathFactory(
                 options.path(), partitionType, options.partitionDefaultName());
     }
@@ -81,7 +83,8 @@ public class FileStoreImpl implements FileStore {
                 partitionType, keyType, valueType, options.manifestFormat(), pathFactory());
     }
 
-    private ManifestList.Factory manifestListFactory() {
+    @VisibleForTesting
+    public ManifestList.Factory manifestListFactory() {
         return new ManifestList.Factory(partitionType, options.manifestFormat(), pathFactory());
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestCommittable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestCommittable.java
@@ -126,16 +126,16 @@ public class ManifestCommittable {
 
     @Override
     public String toString() {
-        return "ManifestCommittable{"
-                + "identifier="
+        return "ManifestCommittable { "
+                + "identifier = "
                 + identifier
-                + ", logOffsets="
+                + ", logOffsets = "
                 + logOffsets
-                + ", newFiles="
+                + ", newFiles =\n"
                 + filesToString(newFiles)
-                + ", compactBefore="
+                + ", compactBefore =\n"
                 + filesToString(compactBefore)
-                + ", compactAfter="
+                + ", compactAfter =\n"
                 + filesToString(compactAfter)
                 + '}';
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
@@ -378,6 +378,17 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         }
 
         if (success) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        String.format(
+                                "Successfully commit snapshot #%d (path %s) by user %s "
+                                        + "with identifier %s and kind %s.",
+                                newSnapshotId,
+                                newSnapshotPath.toString(),
+                                commitUser,
+                                identifier,
+                                commitKind.name()));
+            }
             return true;
         }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreCommitTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreCommitTest.java
@@ -18,15 +18,15 @@
 
 package org.apache.flink.table.store.file.operation;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.data.binary.BinaryRowData;
-import org.apache.flink.table.store.file.FileFormat;
 import org.apache.flink.table.store.file.KeyValue;
+import org.apache.flink.table.store.file.TestFileStore;
 import org.apache.flink.table.store.file.TestKeyValueGenerator;
 import org.apache.flink.table.store.file.ValueKind;
+import org.apache.flink.table.store.file.mergetree.compact.DeduplicateAccumulator;
 import org.apache.flink.table.store.file.utils.FailingAtomicRenameFileSystem;
-import org.apache.flink.table.store.file.utils.FileStorePathFactory;
+import org.apache.flink.table.store.file.utils.TestAtomicRenameFileSystem;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,10 +52,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class FileStoreCommitTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(FileStoreCommitTest.class);
-
-    private final FileFormat avro =
-            FileFormat.fromIdentifier(
-                    FileStoreCommitTest.class.getClassLoader(), "avro", new Configuration());
 
     private TestKeyValueGenerator gen;
     @TempDir java.nio.file.Path tempDir;
@@ -108,12 +104,12 @@ public class FileStoreCommitTest {
         for (int i = 0; i < numThreads; i++) {
             TestCommitThread thread =
                     new TestCommitThread(
-                            dataPerThread.get(i),
-                            OperationTestUtils.createPathFactory(failing, tempDir.toString()),
-                            OperationTestUtils.createPathFactory(false, tempDir.toString()));
+                            dataPerThread.get(i), createStore(failing), createStore(false));
             thread.start();
             threads.add(thread);
         }
+
+        TestFileStore store = createStore(false);
 
         // calculate expected results
         Map<BinaryRowData, List<KeyValue>> threadResults = new HashMap<>();
@@ -124,21 +120,18 @@ public class FileStoreCommitTest {
             }
         }
         Map<BinaryRowData, BinaryRowData> expected =
-                OperationTestUtils.toKvMap(
+                store.toKvMap(
                         threadResults.values().stream()
                                 .flatMap(Collection::stream)
                                 .collect(Collectors.toList()));
 
         // read actual data and compare
-        FileStorePathFactory safePathFactory =
-                OperationTestUtils.createPathFactory(false, tempDir.toString());
-        Long snapshotId = safePathFactory.latestSnapshotId();
+        Long snapshotId = store.pathFactory().latestSnapshotId();
         assertThat(snapshotId).isNotNull();
-        List<KeyValue> actualKvs =
-                OperationTestUtils.readKvsFromSnapshot(snapshotId, avro, safePathFactory);
+        List<KeyValue> actualKvs = store.readKvsFromSnapshot(snapshotId);
         gen.sort(actualKvs);
         logData(() -> actualKvs, "raw read results");
-        Map<BinaryRowData, BinaryRowData> actual = OperationTestUtils.toKvMap(actualKvs);
+        Map<BinaryRowData, BinaryRowData> actual = store.toKvMap(actualKvs);
         logData(() -> kvMapToKvList(expected), "expected");
         logData(() -> kvMapToKvList(actual), "actual");
         assertThat(actual).isEqualTo(expected);
@@ -155,14 +148,11 @@ public class FileStoreCommitTest {
                                 .collect(Collectors.toList()),
                 "data1");
 
-        FileStorePathFactory pathFactory =
-                OperationTestUtils.createPathFactory(false, tempDir.toString());
-        OperationTestUtils.commitData(
+        TestFileStore store = createStore(false);
+        store.commitData(
                 data1.values().stream().flatMap(Collection::stream).collect(Collectors.toList()),
                 gen::getPartition,
-                kv -> 0,
-                avro,
-                pathFactory);
+                kv -> 0);
 
         ThreadLocalRandom random = ThreadLocalRandom.current();
         String dtToOverwrite =
@@ -186,12 +176,10 @@ public class FileStoreCommitTest {
                                 .flatMap(Collection::stream)
                                 .collect(Collectors.toList()),
                 "data2");
-        OperationTestUtils.overwriteData(
+        store.overwriteData(
                 data2.values().stream().flatMap(Collection::stream).collect(Collectors.toList()),
                 gen::getPartition,
                 kv -> 0,
-                avro,
-                pathFactory,
                 partitionToOverwrite);
 
         List<KeyValue> expectedKvs = new ArrayList<>();
@@ -203,17 +191,31 @@ public class FileStoreCommitTest {
         }
         data2.values().forEach(expectedKvs::addAll);
         gen.sort(expectedKvs);
-        Map<BinaryRowData, BinaryRowData> expected = OperationTestUtils.toKvMap(expectedKvs);
+        Map<BinaryRowData, BinaryRowData> expected = store.toKvMap(expectedKvs);
 
         List<KeyValue> actualKvs =
-                OperationTestUtils.readKvsFromSnapshot(
-                        pathFactory.latestSnapshotId(), avro, pathFactory);
+                store.readKvsFromSnapshot(store.pathFactory().latestSnapshotId());
         gen.sort(actualKvs);
-        Map<BinaryRowData, BinaryRowData> actual = OperationTestUtils.toKvMap(actualKvs);
+        Map<BinaryRowData, BinaryRowData> actual = store.toKvMap(actualKvs);
 
         logData(() -> kvMapToKvList(expected), "expected");
         logData(() -> kvMapToKvList(actual), "actual");
         assertThat(actual).isEqualTo(expected);
+    }
+
+    private TestFileStore createStore(boolean failing) {
+        String root =
+                failing
+                        ? FailingAtomicRenameFileSystem.getFailingPath(tempDir.toString())
+                        : TestAtomicRenameFileSystem.SCHEME + "://" + tempDir.toString();
+        return TestFileStore.create(
+                "avro",
+                root,
+                1,
+                TestKeyValueGenerator.PARTITION_TYPE,
+                TestKeyValueGenerator.KEY_TYPE,
+                TestKeyValueGenerator.ROW_TYPE,
+                new DeduplicateAccumulator());
     }
 
     private Map<BinaryRowData, List<KeyValue>> generateData(int numRecords) {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
@@ -18,14 +18,12 @@
 
 package org.apache.flink.table.store.file.operation;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.data.binary.BinaryRowData;
-import org.apache.flink.table.store.file.FileFormat;
 import org.apache.flink.table.store.file.KeyValue;
+import org.apache.flink.table.store.file.TestFileStore;
 import org.apache.flink.table.store.file.TestKeyValueGenerator;
 import org.apache.flink.table.store.file.manifest.ManifestCommittable;
 import org.apache.flink.table.store.file.mergetree.MergeTreeWriter;
-import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,17 +52,14 @@ public class TestCommitThread extends Thread {
 
     public TestCommitThread(
             Map<BinaryRowData, List<KeyValue>> data,
-            FileStorePathFactory testPathFactory,
-            FileStorePathFactory safePathFactory) {
+            TestFileStore testStore,
+            TestFileStore safeStore) {
         this.data = data;
         this.result = new HashMap<>();
         this.writers = new HashMap<>();
 
-        FileFormat avro =
-                FileFormat.fromIdentifier(
-                        FileStoreCommitTest.class.getClassLoader(), "avro", new Configuration());
-        this.write = OperationTestUtils.createWrite(avro, safePathFactory);
-        this.commit = OperationTestUtils.createCommit(avro, testPathFactory);
+        this.write = safeStore.newWrite();
+        this.commit = testStore.newCommit();
     }
 
     public Map<BinaryRowData, List<KeyValue>> getResult() {


### PR DESCRIPTION
This PR refactor `OperationTestUtils` into `TestFileStore` to clean up operation test cases.