### PR TITLE
[FLINK-26442] Allow ManifestFile to write a list of ManifestFileMeta into multiple files if too many

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreImpl.java
@@ -80,7 +80,12 @@ public class FileStoreImpl implements FileStore {
 
     private ManifestFile.Factory manifestFileFactory() {
         return new ManifestFile.Factory(
-                partitionType, keyType, valueType, options.manifestFormat(), pathFactory());
+                partitionType,
+                keyType,
+                valueType,
+                options.manifestFormat(),
+                pathFactory(),
+                options.manifestTargetSize().getBytes());
     }
 
     @VisibleForTesting

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestFile.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestFile.java
@@ -18,21 +18,26 @@
 
 package org.apache.flink.table.store.file.manifest;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.serialization.BulkWriter;
 import org.apache.flink.connector.file.src.FileSourceSplit;
 import org.apache.flink.connector.file.src.reader.BulkFormat;
 import org.apache.flink.core.fs.FSDataOutputStream;
-import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.file.FileFormat;
 import org.apache.flink.table.store.file.stats.FieldStatsCollector;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 import org.apache.flink.table.store.file.utils.FileUtils;
+import org.apache.flink.table.store.file.utils.RollingFile;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Preconditions;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -41,23 +46,33 @@ import java.util.List;
  */
 public class ManifestFile {
 
+    private static final Logger LOG = LoggerFactory.getLogger(ManifestFile.class);
+
     private final RowType partitionType;
     private final ManifestEntrySerializer serializer;
     private final BulkFormat<RowData, FileSourceSplit> readerFactory;
     private final BulkWriter.Factory<RowData> writerFactory;
     private final FileStorePathFactory pathFactory;
+    private final long suggestedFileSize;
 
     private ManifestFile(
             RowType partitionType,
             ManifestEntrySerializer serializer,
             BulkFormat<RowData, FileSourceSplit> readerFactory,
             BulkWriter.Factory<RowData> writerFactory,
-            FileStorePathFactory pathFactory) {
+            FileStorePathFactory pathFactory,
+            long suggestedFileSize) {
         this.partitionType = partitionType;
         this.serializer = serializer;
         this.readerFactory = readerFactory;
         this.writerFactory = writerFactory;
         this.pathFactory = pathFactory;
+        this.suggestedFileSize = suggestedFileSize;
+    }
+
+    @VisibleForTesting
+    public long suggestedFileSize() {
+        return suggestedFileSize;
     }
 
     public List<ManifestEntry> read(String fileName) {
@@ -70,34 +85,60 @@ public class ManifestFile {
     }
 
     /**
-     * Write several {@link ManifestEntry}s into a manifest file.
+     * Write several {@link ManifestEntry}s into manifest files.
      *
      * <p>NOTE: This method is atomic.
      */
-    public ManifestFileMeta write(List<ManifestEntry> entries) {
+    public List<ManifestFileMeta> write(List<ManifestEntry> entries) {
         Preconditions.checkArgument(
                 entries.size() > 0, "Manifest entries to write must not be empty.");
 
-        Path path = pathFactory.newManifestFile();
+        List<ManifestFileMeta> result = new ArrayList<>();
+        List<Path> filesToCleanUp = new ArrayList<>();
         try {
-            return write(entries, path);
+            RollingFile.write(
+                    entries.iterator(),
+                    suggestedFileSize,
+                    new RollingFileContext(),
+                    result,
+                    filesToCleanUp);
         } catch (Throwable e) {
-            FileUtils.deleteOrWarn(path);
-            throw new RuntimeException(
-                    "Exception occurs when writing manifest file " + path + ". Clean up.", e);
+            LOG.warn("Exception occurs when writing manifest files. Cleaning up.", e);
+            for (Path path : filesToCleanUp) {
+                FileUtils.deleteOrWarn(path);
+            }
+            throw new RuntimeException(e);
         }
+        return result;
     }
 
-    private ManifestFileMeta write(List<ManifestEntry> entries, Path path) throws IOException {
-        FSDataOutputStream out =
-                path.getFileSystem().create(path, FileSystem.WriteMode.NO_OVERWRITE);
-        BulkWriter<RowData> writer = writerFactory.create(out);
-        long numAddedFiles = 0;
-        long numDeletedFiles = 0;
-        FieldStatsCollector statsCollector = new FieldStatsCollector(partitionType);
+    public void delete(String fileName) {
+        FileUtils.deleteOrWarn(pathFactory.toManifestFilePath(fileName));
+    }
 
-        for (ManifestEntry entry : entries) {
-            writer.addElement(serializer.toRow(entry));
+    private class RollingFileContext
+            implements RollingFile.Context<ManifestEntry, ManifestFileMeta> {
+
+        private long numAddedFiles;
+        private long numDeletedFiles;
+        private FieldStatsCollector statsCollector;
+
+        private RollingFileContext() {
+            resetMeta();
+        }
+
+        @Override
+        public Path newPath() {
+            return pathFactory.newManifestFile();
+        }
+
+        @Override
+        public BulkWriter<RowData> newWriter(FSDataOutputStream out) throws IOException {
+            return writerFactory.create(out);
+        }
+
+        @Override
+        public RowData serialize(ManifestEntry entry) {
             switch (entry.kind()) {
                 case ADD:
                     numAddedFiles++;
@@ -107,20 +148,28 @@ public class ManifestFile {
                     break;
             }
             statsCollector.collect(entry.partition());
+
+            return serializer.toRow(entry);
         }
-        writer.finish();
-        out.close();
 
-        return new ManifestFileMeta(
-                path.getName(),
-                path.getFileSystem().getFileStatus(path).getLen(),
-                numAddedFiles,
-                numDeletedFiles,
-                statsCollector.extract());
-    }
+        @Override
+        public ManifestFileMeta collectFile(Path path) throws IOException {
+            ManifestFileMeta result =
+                    new ManifestFileMeta(
+                            path.getName(),
+                            path.getFileSystem().getFileStatus(path).getLen(),
+                            numAddedFiles,
+                            numDeletedFiles,
+                            statsCollector.extract());
+            resetMeta();
+            return result;
+        }
 
-    public void delete(String fileName) {
-        FileUtils.deleteOrWarn(pathFactory.toManifestFilePath(fileName));
+        private void resetMeta() {
+            numAddedFiles = 0;
+            numDeletedFiles = 0;
+            statsCollector = new FieldStatsCollector(partitionType);
+        }
     }
 
     /**
@@ -135,13 +184,15 @@ public class ManifestFile {
         private final BulkFormat<RowData, FileSourceSplit> readerFactory;
         private final BulkWriter.Factory<RowData> writerFactory;
         private final FileStorePathFactory pathFactory;
+        private final long suggestedFileSize;
 
         public Factory(
                 RowType partitionType,
                 RowType keyType,
                 RowType rowType,
                 FileFormat fileFormat,
-                FileStorePathFactory pathFactory) {
+                FileStorePathFactory pathFactory,
+                long suggestedFileSize) {
             this.partitionType = partitionType;
             this.keyType = keyType;
             this.rowType = rowType;
@@ -149,6 +200,7 @@ public class ManifestFile {
             this.readerFactory = fileFormat.createReaderFactory(entryType);
             this.writerFactory = fileFormat.createWriterFactory(entryType);
             this.pathFactory = pathFactory;
+            this.suggestedFileSize = suggestedFileSize;
         }
 
         public ManifestFile create() {
@@ -157,7 +209,8 @@ public class ManifestFile {
                     new ManifestEntrySerializer(partitionType, keyType, rowType),
                     readerFactory,
                     writerFactory,
-                    pathFactory);
+                    pathFactory,
+                    suggestedFileSize);
         }
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
@@ -313,10 +313,13 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             newMetas.addAll(
                     ManifestFileMeta.merge(
                             oldMetas,
-                            changes,
                             manifestFile,
                             manifestTargetSize.getBytes(),
                             manifestMergeMinCount));
+            // write new changes into manifest files
+            if (!changes.isEmpty()) {
+                newMetas.addAll(manifestFile.write(changes));
+            }
             // prepare snapshot file
             manifestListName = manifestList.write(newMetas);
             newSnapshot =

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RollingFile.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RollingFile.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.utils;
+
+import org.apache.flink.api.common.serialization.BulkWriter;
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.data.RowData;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+/** A utility class to write a list of objects into several files, each with a size limit. */
+public class RollingFile {
+
+    /**
+     * Provide logic for serializing records and producing file metas.
+     *
+     * @param <R> record type
+     * @param <F> file meta type
+     */
+    public interface Context<R, F> {
+
+        /** Create the path for a new file. */
+        Path newPath();
+
+        /** Create a new object writer. */
+        BulkWriter<RowData> newWriter(FSDataOutputStream out) throws IOException;
+
+        /**
+         * Called before writing a record into file. Per-record calculation can be performed here.
+         *
+         * @param record record to write
+         * @return serialized record
+         */
+        RowData serialize(R record);
+
+        /** Called before closing the current file. Per-file calculation can be performed here. */
+        F collectFile(Path path) throws IOException;
+    }
+
+    public static <R, F> void write(
+            Iterator<R> iterator,
+            long suggestedFileSize,
+            Context<R, F> context,
+            List<F> result,
+            List<Path> filesToCleanUp)
+            throws IOException {
+        RollingFile rollingFile = null;
+        Path currentPath = null;
+
+        while (iterator.hasNext()) {
+            if (rollingFile == null) {
+                // create new rolling file
+                currentPath = context.newPath();
+                filesToCleanUp.add(currentPath);
+                rollingFile = new RollingFile(currentPath, suggestedFileSize, context);
+            }
+
+            RowData serialized = context.serialize(iterator.next());
+            rollingFile.write(serialized);
+
+            if (rollingFile.exceedsSuggestedFileSize()) {
+                // exceeds suggested size, close current file
+                rollingFile.finish();
+                result.add(context.collectFile(currentPath));
+                rollingFile = null;
+            }
+        }
+
+        // finish last file
+        if (rollingFile != null) {
+            rollingFile.finish();
+            result.add(context.collectFile(currentPath));
+        }
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(RollingFile.class);
+
+    private final long suggestedFileSize;
+    private final FSDataOutputStream out;
+    private final BulkWriter<RowData> writer;
+
+    private RollingFile(Path path, long suggestedFileSize, Context<?, ?> context)
+            throws IOException {
+        this.suggestedFileSize = suggestedFileSize;
+        this.out = path.getFileSystem().create(path, FileSystem.WriteMode.NO_OVERWRITE);
+        this.writer = context.newWriter(out);
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Create new rolling file " + path.toString());
+        }
+    }
+
+    private void write(RowData record) throws IOException {
+        writer.addElement(record);
+    }
+
+    private boolean exceedsSuggestedFileSize() throws IOException {
+        // NOTE: this method is inaccurate for formats buffering changes in memory
+        return out.getPos() >= suggestedFileSize;
+    }
+
+    private void finish() throws IOException {
+        writer.finish();
+        out.close();
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/sst/SstFileTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/sst/SstFileTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.table.store.file.FileFormat;
 import org.apache.flink.table.store.file.KeyValue;
 import org.apache.flink.table.store.file.KeyValueSerializerTest;
 import org.apache.flink.table.store.file.TestKeyValueGenerator;
-import org.apache.flink.table.store.file.stats.FieldStats;
 import org.apache.flink.table.store.file.utils.FailingAtomicRenameFileSystem;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 import org.apache.flink.table.store.file.utils.FlushingAvroFormat;
@@ -296,36 +295,5 @@ public class SstFileTest {
         for (SstFileMeta meta : actual) {
             assertThat(meta.level()).isEqualTo(expected.level());
         }
-    }
-
-    @SuppressWarnings("unchecked")
-    private void checkRollingFileStats(FieldStats expected, List<FieldStats> actual) {
-        if (expected.minValue() instanceof Comparable) {
-            Object actualMin = null;
-            Object actualMax = null;
-            for (FieldStats stats : actual) {
-                if (stats.minValue() != null
-                        && (actualMin == null
-                                || ((Comparable<Object>) stats.minValue()).compareTo(actualMin)
-                                        < 0)) {
-                    actualMin = stats.minValue();
-                }
-                if (stats.maxValue() != null
-                        && (actualMax == null
-                                || ((Comparable<Object>) stats.maxValue()).compareTo(actualMax)
-                                        > 0)) {
-                    actualMax = stats.maxValue();
-                }
-            }
-            assertThat(actualMin).isEqualTo(expected.minValue());
-            assertThat(actualMax).isEqualTo(expected.maxValue());
-        } else {
-            for (FieldStats stats : actual) {
-                assertThat(stats.minValue()).isNull();
-                assertThat(stats.maxValue()).isNull();
-            }
-        }
-        assertThat(actual.stream().mapToLong(FieldStats::nullCount).sum())
-                .isEqualTo(expected.nullCount());
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/stats/StatsTestUtils.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/stats/StatsTestUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.stats;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Utils for stats related tests. */
+public class StatsTestUtils {
+
+    @SuppressWarnings("unchecked")
+    public static void checkRollingFileStats(FieldStats expected, List<FieldStats> actual) {
+        if (expected.minValue() instanceof Comparable) {
+            Object actualMin = null;
+            Object actualMax = null;
+            for (FieldStats stats : actual) {
+                if (stats.minValue() != null
+                        && (actualMin == null
+                                || ((Comparable<Object>) stats.minValue()).compareTo(actualMin)
+                                        < 0)) {
+                    actualMin = stats.minValue();
+                }
+                if (stats.maxValue() != null
+                        && (actualMax == null
+                                || ((Comparable<Object>) stats.maxValue()).compareTo(actualMax)
+                                        > 0)) {
+                    actualMax = stats.maxValue();
+                }
+            }
+            assertThat(actualMin).isEqualTo(expected.minValue());
+            assertThat(actualMax).isEqualTo(expected.maxValue());
+        } else {
+            for (FieldStats stats : actual) {
+                assertThat(stats.minValue()).isNull();
+                assertThat(stats.maxValue()).isNull();
+            }
+        }
+        assertThat(actual.stream().mapToLong(FieldStats::nullCount).sum())
+                .isEqualTo(expected.nullCount());
+    }
+}


### PR DESCRIPTION
Currently `ManifestFile#write` will only produce a single file no matter how large the given `ManifestFileMeta` list is. However batch jobs are likely to produce a lot of changes hence the list might be very long. We need to allow `ManifestFile#write` to produce multiple files for effective merging and filtering.