### PR TITLE
[FLINK-26247] Optimize expire by only reading new changes in a snapshot

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreImpl.java
@@ -78,7 +78,8 @@ public class FileStoreImpl implements FileStore {
                 options.path(), partitionType, options.partitionDefaultName());
     }
 
-    private ManifestFile.Factory manifestFileFactory() {
+    @VisibleForTesting
+    public ManifestFile.Factory manifestFileFactory() {
         return new ManifestFile.Factory(
                 partitionType,
                 keyType,
@@ -141,8 +142,8 @@ public class FileStoreImpl implements FileStore {
                 options.snapshotNumRetain(),
                 options.snapshotTimeRetain().toMillis(),
                 pathFactory(),
-                manifestListFactory(),
-                newScan());
+                manifestFileFactory(),
+                manifestListFactory());
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/Snapshot.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/Snapshot.java
@@ -35,7 +35,8 @@ public class Snapshot {
     public static final long FIRST_SNAPSHOT_ID = 1;
 
     private static final String FIELD_ID = "id";
-    private static final String FIELD_MANIFEST_LIST = "manifestList";
+    private static final String FIELD_PREVIOUS_CHANGES = "previousChanges";
+    private static final String FIELD_NEW_CHANGES = "newChanges";
     private static final String FIELD_COMMIT_USER = "commitUser";
     private static final String FIELD_COMMIT_IDENTIFIER = "commitIdentifier";
     private static final String FIELD_COMMIT_KIND = "commitKind";
@@ -44,8 +45,14 @@ public class Snapshot {
     @JsonProperty(FIELD_ID)
     private final long id;
 
-    @JsonProperty(FIELD_MANIFEST_LIST)
-    private final String manifestList;
+    // a manifest list recording all changes from the previous snapshots
+    @JsonProperty(FIELD_PREVIOUS_CHANGES)
+    private final String previousChanges;
+
+    // a manifest list recording all new changes occurred in this snapshot
+    // for faster expire and streaming reads
+    @JsonProperty(FIELD_NEW_CHANGES)
+    private final String newChanges;
 
     @JsonProperty(FIELD_COMMIT_USER)
     private final String commitUser;
@@ -63,13 +70,15 @@ public class Snapshot {
     @JsonCreator
     public Snapshot(
             @JsonProperty(FIELD_ID) long id,
-            @JsonProperty(FIELD_MANIFEST_LIST) String manifestList,
+            @JsonProperty(FIELD_PREVIOUS_CHANGES) String previousChanges,
+            @JsonProperty(FIELD_NEW_CHANGES) String newChanges,
             @JsonProperty(FIELD_COMMIT_USER) String commitUser,
             @JsonProperty(FIELD_COMMIT_IDENTIFIER) String commitIdentifier,
             @JsonProperty(FIELD_COMMIT_KIND) CommitKind commitKind,
             @JsonProperty(FIELD_TIME_MILLIS) long timeMillis) {
         this.id = id;
-        this.manifestList = manifestList;
+        this.previousChanges = previousChanges;
+        this.newChanges = newChanges;
         this.commitUser = commitUser;
         this.commitIdentifier = commitIdentifier;
         this.commitKind = commitKind;
@@ -81,9 +90,14 @@ public class Snapshot {
         return id;
     }
 
-    @JsonGetter(FIELD_MANIFEST_LIST)
-    public String manifestList() {
-        return manifestList;
+    @JsonGetter(FIELD_PREVIOUS_CHANGES)
+    public String previousChanges() {
+        return previousChanges;
+    }
+
+    @JsonGetter(FIELD_NEW_CHANGES)
+    public String newChanges() {
+        return newChanges;
     }
 
     @JsonGetter(FIELD_COMMIT_USER)

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/Snapshot.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/Snapshot.java
@@ -19,6 +19,8 @@
 package org.apache.flink.table.store.file;
 
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.store.file.manifest.ManifestFileMeta;
+import org.apache.flink.table.store.file.manifest.ManifestList;
 import org.apache.flink.table.store.file.utils.FileUtils;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
@@ -28,6 +30,8 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessin
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /** This file is the entrance to all data committed at some specific time point. */
 public class Snapshot {
@@ -35,8 +39,8 @@ public class Snapshot {
     public static final long FIRST_SNAPSHOT_ID = 1;
 
     private static final String FIELD_ID = "id";
-    private static final String FIELD_PREVIOUS_CHANGES = "previousChanges";
-    private static final String FIELD_NEW_CHANGES = "newChanges";
+    private static final String FIELD_BASE_MANIFEST_LIST = "baseManifestList";
+    private static final String FIELD_DELTA_MANIFEST_LIST = "deltaManifestList";
     private static final String FIELD_COMMIT_USER = "commitUser";
     private static final String FIELD_COMMIT_IDENTIFIER = "commitIdentifier";
     private static final String FIELD_COMMIT_KIND = "commitKind";
@@ -46,13 +50,13 @@ public class Snapshot {
     private final long id;
 
     // a manifest list recording all changes from the previous snapshots
-    @JsonProperty(FIELD_PREVIOUS_CHANGES)
-    private final String previousChanges;
+    @JsonProperty(FIELD_BASE_MANIFEST_LIST)
+    private final String baseManifestList;
 
     // a manifest list recording all new changes occurred in this snapshot
     // for faster expire and streaming reads
-    @JsonProperty(FIELD_NEW_CHANGES)
-    private final String newChanges;
+    @JsonProperty(FIELD_DELTA_MANIFEST_LIST)
+    private final String deltaManifestList;
 
     @JsonProperty(FIELD_COMMIT_USER)
     private final String commitUser;
@@ -70,15 +74,15 @@ public class Snapshot {
     @JsonCreator
     public Snapshot(
             @JsonProperty(FIELD_ID) long id,
-            @JsonProperty(FIELD_PREVIOUS_CHANGES) String previousChanges,
-            @JsonProperty(FIELD_NEW_CHANGES) String newChanges,
+            @JsonProperty(FIELD_BASE_MANIFEST_LIST) String baseManifestList,
+            @JsonProperty(FIELD_DELTA_MANIFEST_LIST) String deltaManifestList,
             @JsonProperty(FIELD_COMMIT_USER) String commitUser,
             @JsonProperty(FIELD_COMMIT_IDENTIFIER) String commitIdentifier,
             @JsonProperty(FIELD_COMMIT_KIND) CommitKind commitKind,
             @JsonProperty(FIELD_TIME_MILLIS) long timeMillis) {
         this.id = id;
-        this.previousChanges = previousChanges;
-        this.newChanges = newChanges;
+        this.baseManifestList = baseManifestList;
+        this.deltaManifestList = deltaManifestList;
         this.commitUser = commitUser;
         this.commitIdentifier = commitIdentifier;
         this.commitKind = commitKind;
@@ -90,14 +94,14 @@ public class Snapshot {
         return id;
     }
 
-    @JsonGetter(FIELD_PREVIOUS_CHANGES)
-    public String previousChanges() {
-        return previousChanges;
+    @JsonGetter(FIELD_BASE_MANIFEST_LIST)
+    public String baseManifestList() {
+        return baseManifestList;
     }
 
-    @JsonGetter(FIELD_NEW_CHANGES)
-    public String newChanges() {
-        return newChanges;
+    @JsonGetter(FIELD_DELTA_MANIFEST_LIST)
+    public String deltaManifestList() {
+        return deltaManifestList;
     }
 
     @JsonGetter(FIELD_COMMIT_USER)
@@ -126,6 +130,13 @@ public class Snapshot {
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public List<ManifestFileMeta> readAllManifests(ManifestList manifestList) {
+        List<ManifestFileMeta> result = new ArrayList<>();
+        result.addAll(manifestList.read(baseManifestList));
+        result.addAll(manifestList.read(deltaManifestList));
+        return result;
     }
 
     public static Snapshot fromJson(String json) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestFile.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestFile.java
@@ -31,7 +31,6 @@ import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 import org.apache.flink.table.store.file.utils.FileUtils;
 import org.apache.flink.table.store.file.utils.RollingFile;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,9 +89,6 @@ public class ManifestFile {
      * <p>NOTE: This method is atomic.
      */
     public List<ManifestFileMeta> write(List<ManifestEntry> entries) {
-        Preconditions.checkArgument(
-                entries.size() > 0, "Manifest entries to write must not be empty.");
-
         ManifestRollingFile rollingFile = new ManifestRollingFile();
         List<ManifestFileMeta> result = new ArrayList<>();
         List<Path> filesToCleanUp = new ArrayList<>();

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
@@ -301,13 +301,15 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         }
 
         Snapshot newSnapshot;
-        String manifestListName = null;
+        String previousChangesListName = null;
+        String newChangesListName = null;
         List<ManifestFileMeta> oldMetas = new ArrayList<>();
         List<ManifestFileMeta> newMetas = new ArrayList<>();
         try {
             if (latestSnapshot != null) {
                 // read all previous manifest files
-                oldMetas.addAll(manifestList.read(latestSnapshot.manifestList()));
+                oldMetas.addAll(manifestList.read(latestSnapshot.previousChanges()));
+                oldMetas.addAll(manifestList.read(latestSnapshot.newChanges()));
             }
             // merge manifest files with changes
             newMetas.addAll(
@@ -316,16 +318,22 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                             manifestFile,
                             manifestTargetSize.getBytes(),
                             manifestMergeMinCount));
+            previousChangesListName = manifestList.write(newMetas);
+
             // write new changes into manifest files
+            List<ManifestFileMeta> newChangesManifests = new ArrayList<>();
             if (!changes.isEmpty()) {
-                newMetas.addAll(manifestFile.write(changes));
+                newChangesManifests.addAll(manifestFile.write(changes));
             }
+            newMetas.addAll(newChangesManifests);
+            newChangesListName = manifestList.write(newChangesManifests);
+
             // prepare snapshot file
-            manifestListName = manifestList.write(newMetas);
             newSnapshot =
                     new Snapshot(
                             newSnapshotId,
-                            manifestListName,
+                            previousChangesListName,
+                            newChangesListName,
                             commitUser,
                             identifier,
                             commitKind,
@@ -333,7 +341,12 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             FileUtils.writeFileUtf8(tmpSnapshotPath, newSnapshot.toJson());
         } catch (Throwable e) {
             // fails when preparing for commit, we should clean up
-            cleanUpTmpSnapshot(tmpSnapshotPath, manifestListName, oldMetas, newMetas);
+            cleanUpTmpSnapshot(
+                    tmpSnapshotPath,
+                    previousChangesListName,
+                    newChangesListName,
+                    oldMetas,
+                    newMetas);
             throw new RuntimeException(
                     String.format(
                             "Exception occurs when preparing snapshot #%d (path %s) by user %s "
@@ -406,7 +419,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                         commitUser,
                         identifier,
                         commitKind.name()));
-        cleanUpTmpSnapshot(tmpSnapshotPath, manifestListName, oldMetas, newMetas);
+        cleanUpTmpSnapshot(
+                tmpSnapshotPath, previousChangesListName, newChangesListName, oldMetas, newMetas);
         return false;
     }
 
@@ -457,14 +471,18 @@ public class FileStoreCommitImpl implements FileStoreCommit {
 
     private void cleanUpTmpSnapshot(
             Path tmpSnapshotPath,
-            String manifestListName,
+            String previousChangesListName,
+            String newChangesListName,
             List<ManifestFileMeta> oldMetas,
             List<ManifestFileMeta> newMetas) {
         // clean up tmp snapshot file
         FileUtils.deleteOrWarn(tmpSnapshotPath);
         // clean up newly created manifest list
-        if (manifestListName != null) {
-            manifestList.delete(manifestListName);
+        if (previousChangesListName != null) {
+            manifestList.delete(previousChangesListName);
+        }
+        if (newChangesListName != null) {
+            manifestList.delete(newChangesListName);
         }
         // clean up newly merged manifest files
         Set<ManifestFileMeta> oldMetaSet = new HashSet<>(oldMetas); // for faster searching

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
@@ -308,8 +308,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         try {
             if (latestSnapshot != null) {
                 // read all previous manifest files
-                oldMetas.addAll(manifestList.read(latestSnapshot.previousChanges()));
-                oldMetas.addAll(manifestList.read(latestSnapshot.newChanges()));
+                oldMetas.addAll(latestSnapshot.readAllManifests(manifestList));
             }
             // merge manifest files with changes
             newMetas.addAll(
@@ -321,10 +320,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             previousChangesListName = manifestList.write(newMetas);
 
             // write new changes into manifest files
-            List<ManifestFileMeta> newChangesManifests = new ArrayList<>();
-            if (!changes.isEmpty()) {
-                newChangesManifests.addAll(manifestFile.write(changes));
-            }
+            List<ManifestFileMeta> newChangesManifests = manifestFile.write(changes);
             newMetas.addAll(newChangesManifests);
             newChangesListName = manifestList.write(newChangesManifests);
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreScanImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreScanImpl.java
@@ -155,7 +155,9 @@ public class FileStoreScanImpl implements FileStoreScan {
                 manifests = Collections.emptyList();
             } else {
                 Snapshot snapshot = Snapshot.fromPath(pathFactory.toSnapshotPath(snapshotId));
-                manifests = manifestList.read(snapshot.manifestList());
+                manifests = new ArrayList<>();
+                manifests.addAll(manifestList.read(snapshot.previousChanges()));
+                manifests.addAll(manifestList.read(snapshot.newChanges()));
             }
         }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreScanImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreScanImpl.java
@@ -155,9 +155,7 @@ public class FileStoreScanImpl implements FileStoreScan {
                 manifests = Collections.emptyList();
             } else {
                 Snapshot snapshot = Snapshot.fromPath(pathFactory.toSnapshotPath(snapshotId));
-                manifests = new ArrayList<>();
-                manifests.addAll(manifestList.read(snapshot.previousChanges()));
-                manifests.addAll(manifestList.read(snapshot.newChanges()));
+                manifests = snapshot.readAllManifests(manifestList);
             }
         }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/FileUtils.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/FileUtils.java
@@ -110,6 +110,10 @@ public class FileUtils {
     }
 
     public static void deleteOrWarn(Path file) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Ready to delete " + file.toString());
+        }
+
         try {
             FileSystem fs = file.getFileSystem();
             if (!fs.delete(file, false) && fs.exists(file)) {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -102,7 +102,11 @@ public class TestFileStore extends FileStoreImpl {
 
     public FileStoreExpireImpl newExpire(int numRetained, long millisRetained) {
         return new FileStoreExpireImpl(
-                numRetained, millisRetained, pathFactory(), manifestListFactory(), newScan());
+                numRetained,
+                millisRetained,
+                pathFactory(),
+                manifestFileFactory(),
+                manifestListFactory());
     }
 
     public List<Snapshot> commitData(

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -20,10 +20,13 @@ package org.apache.flink.table.store.file;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.store.file.manifest.ManifestCommittable;
 import org.apache.flink.table.store.file.manifest.ManifestEntry;
+import org.apache.flink.table.store.file.manifest.ManifestFileMeta;
+import org.apache.flink.table.store.file.manifest.ManifestList;
 import org.apache.flink.table.store.file.mergetree.Increment;
 import org.apache.flink.table.store.file.mergetree.MergeTreeOptions;
 import org.apache.flink.table.store.file.mergetree.compact.Accumulator;
@@ -31,6 +34,7 @@ import org.apache.flink.table.store.file.mergetree.sst.SstFileMeta;
 import org.apache.flink.table.store.file.operation.FileStoreCommit;
 import org.apache.flink.table.store.file.operation.FileStoreExpireImpl;
 import org.apache.flink.table.store.file.operation.FileStoreRead;
+import org.apache.flink.table.store.file.operation.FileStoreScan;
 import org.apache.flink.table.store.file.operation.FileStoreWrite;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 import org.apache.flink.table.store.file.utils.RecordReaderIterator;
@@ -42,24 +46,32 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** {@link FileStore} for tests. */
 public class TestFileStore extends FileStoreImpl {
 
     private static final Logger LOG = LoggerFactory.getLogger(TestFileStore.class);
 
+    private final String root;
     private final RowDataSerializer keySerializer;
     private final RowDataSerializer valueSerializer;
 
@@ -96,6 +108,7 @@ public class TestFileStore extends FileStoreImpl {
             RowType valueType,
             Accumulator accumulator) {
         super(conf, UUID.randomUUID().toString(), partitionType, keyType, valueType, accumulator);
+        this.root = conf.getString(FileStoreOptions.FILE_PATH);
         this.keySerializer = new RowDataSerializer(keyType);
         this.valueSerializer = new RowDataSerializer(valueType);
     }
@@ -264,6 +277,74 @@ public class TestFileStore extends FileStoreImpl {
                 default:
                     throw new UnsupportedOperationException(
                             "Unknown value kind " + kv.valueKind().name());
+            }
+        }
+        return result;
+    }
+
+    public void assertCleaned() {
+        Set<Path> filesInUse = getFilesInUse();
+        Set<Path> actualFiles;
+        try {
+            actualFiles =
+                    Files.walk(Paths.get(root))
+                            .filter(p -> Files.isRegularFile(p))
+                            .map(p -> new Path(p.toString()))
+                            .collect(Collectors.toSet());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        assertThat(actualFiles).isEqualTo(filesInUse);
+    }
+
+    private Set<Path> getFilesInUse() {
+        FileStorePathFactory pathFactory = pathFactory();
+        ManifestList manifestList = manifestListFactory().create();
+        FileStoreScan scan = newScan();
+        FileStorePathFactory.SstPathFactoryCache sstPathFactoryCache =
+                new FileStorePathFactory.SstPathFactoryCache(pathFactory);
+
+        Long latestSnapshotId = pathFactory.latestSnapshotId();
+        if (latestSnapshotId == null) {
+            return Collections.emptySet();
+        }
+
+        long firstInUseSnapshotId = Snapshot.FIRST_SNAPSHOT_ID;
+        for (long id = latestSnapshotId - 1; id >= Snapshot.FIRST_SNAPSHOT_ID; id--) {
+            Path snapshotPath = pathFactory.toSnapshotPath(id);
+            try {
+                if (!snapshotPath.getFileSystem().exists(snapshotPath)) {
+                    firstInUseSnapshotId = id + 1;
+                    break;
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        Set<Path> result = new HashSet<>();
+        for (long id = firstInUseSnapshotId; id <= latestSnapshotId; id++) {
+            Path snapshotPath = pathFactory.toSnapshotPath(id);
+            Snapshot snapshot = Snapshot.fromPath(snapshotPath);
+
+            // snapshot file
+            result.add(snapshotPath);
+
+            // manifest lists
+            result.add(pathFactory.toManifestListPath(snapshot.baseManifestList()));
+            result.add(pathFactory.toManifestListPath(snapshot.deltaManifestList()));
+
+            // manifests
+            List<ManifestFileMeta> manifests = snapshot.readAllManifests(manifestList);
+            manifests.forEach(m -> result.add(pathFactory.toManifestFilePath(m.fileName())));
+
+            // sst
+            List<ManifestEntry> entries = scan.withManifestList(manifests).plan().files();
+            for (ManifestEntry entry : entries) {
+                result.add(
+                        sstPathFactoryCache
+                                .getSstPathFactory(entry.partition(), entry.bucket())
+                                .toPath(entry.file().fileName()));
             }
         }
         return result;

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreExpireTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreExpireTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.store.file.TestKeyValueGenerator;
 import org.apache.flink.table.store.file.mergetree.compact.DeduplicateAccumulator;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -63,6 +64,11 @@ public class FileStoreExpireTest {
                         TestKeyValueGenerator.ROW_TYPE,
                         new DeduplicateAccumulator());
         pathFactory = store.pathFactory();
+    }
+
+    @AfterEach
+    public void afterEach() {
+        store.assertCleaned();
     }
 
     @Test

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreScanTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreScanTest.java
@@ -163,9 +163,7 @@ public class FileStoreScanTest {
         ManifestList manifestList = store.manifestListFactory().create();
         long wantedSnapshotId = random.nextLong(pathFactory.latestSnapshotId()) + 1;
         Snapshot wantedSnapshot = Snapshot.fromPath(pathFactory.toSnapshotPath(wantedSnapshotId));
-        List<ManifestFileMeta> wantedManifests = new ArrayList<>();
-        wantedManifests.addAll(manifestList.read(wantedSnapshot.previousChanges()));
-        wantedManifests.addAll(manifestList.read(wantedSnapshot.newChanges()));
+        List<ManifestFileMeta> wantedManifests = wantedSnapshot.readAllManifests(manifestList);
 
         FileStoreScan scan = store.newScan();
         scan.withManifestList(wantedManifests);

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreScanTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreScanTest.java
@@ -161,16 +161,16 @@ public class FileStoreScanTest {
         }
 
         ManifestList manifestList = store.manifestListFactory().create();
-        long wantedSnapshot = random.nextLong(pathFactory.latestSnapshotId()) + 1;
-        List<ManifestFileMeta> wantedManifests =
-                manifestList.read(
-                        Snapshot.fromPath(pathFactory.toSnapshotPath(wantedSnapshot))
-                                .manifestList());
+        long wantedSnapshotId = random.nextLong(pathFactory.latestSnapshotId()) + 1;
+        Snapshot wantedSnapshot = Snapshot.fromPath(pathFactory.toSnapshotPath(wantedSnapshotId));
+        List<ManifestFileMeta> wantedManifests = new ArrayList<>();
+        wantedManifests.addAll(manifestList.read(wantedSnapshot.previousChanges()));
+        wantedManifests.addAll(manifestList.read(wantedSnapshot.newChanges()));
 
         FileStoreScan scan = store.newScan();
         scan.withManifestList(wantedManifests);
 
-        List<KeyValue> expectedKvs = store.readKvsFromSnapshot(wantedSnapshot);
+        List<KeyValue> expectedKvs = store.readKvsFromSnapshot(wantedSnapshotId);
         gen.sort(expectedKvs);
         Map<BinaryRowData, BinaryRowData> expected = store.toKvMap(expectedKvs);
         runTest(scan, null, expected);


### PR DESCRIPTION
Current implementation of `FileStoreExpire` will read the whole snapshot for each snapshot to be expired. This is unnecessary because later snapshots also contain changes from previous snapshots.

This PR optimizes this by only reading new changes in a snapshot.