### PR TITLE
[hotfix] Fix ClassCastException when StoreSinkWriter#writeToFileStore encountered non-pk record

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSinkWriter.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSinkWriter.java
@@ -102,7 +102,7 @@ public class StoreSinkWriter<WriterStateT>
             case INSERT:
             case UPDATE_AFTER:
                 if (record.key().getArity() == 0) {
-                    writer.write(ValueKind.ADD, record.row(), GenericRowData.of(1));
+                    writer.write(ValueKind.ADD, record.row(), GenericRowData.of(1L));
                 } else {
                     writer.write(ValueKind.ADD, record.key(), record.row());
                 }
@@ -110,7 +110,7 @@ public class StoreSinkWriter<WriterStateT>
             case UPDATE_BEFORE:
             case DELETE:
                 if (record.key().getArity() == 0) {
-                    writer.write(ValueKind.ADD, record.row(), GenericRowData.of(-1));
+                    writer.write(ValueKind.ADD, record.row(), GenericRowData.of(-1L));
                 } else {
                     writer.write(ValueKind.DELETE, record.key(), record.row());
                 }

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/StoreSinkTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/StoreSinkTest.java
@@ -56,6 +56,7 @@ public class StoreSinkTest {
     @Test
     public void testChangelogs() throws Exception {
         StoreSink<?, ?> sink = newSink(null);
+        fileStore.enablePk();
         writeAndCommit(
                 sink,
                 GenericRowData.ofKind(RowKind.INSERT, 0, 0, 1),
@@ -82,6 +83,7 @@ public class StoreSinkTest {
                         2,
                         () -> lock,
                         new HashMap<>());
+        fileStore.disablePk();
         writeAndCommit(
                 sink,
                 GenericRowData.ofKind(RowKind.INSERT, 0, 0, 1),
@@ -99,6 +101,7 @@ public class StoreSinkTest {
     @Test
     public void testAppend() throws Exception {
         StoreSink<?, ?> sink = newSink(null);
+        fileStore.enablePk();
         writeAndAssert(sink);
 
         writeAndCommit(sink, GenericRowData.of(0, 8, 9), GenericRowData.of(1, 10, 11));
@@ -111,6 +114,7 @@ public class StoreSinkTest {
     @Test
     public void testOverwrite() throws Exception {
         StoreSink<?, ?> sink = newSink(new HashMap<>());
+        fileStore.enablePk();
         writeAndAssert(sink);
 
         writeAndCommit(sink, GenericRowData.of(0, 8, 9), GenericRowData.of(1, 10, 11));
@@ -126,6 +130,7 @@ public class StoreSinkTest {
         HashMap<String, String> partition = new HashMap<>();
         partition.put("part", "0");
         StoreSink<?, ?> sink = newSink(partition);
+        fileStore.enablePk();
         writeAndAssert(sink);
 
         writeAndCommit(sink, GenericRowData.of(0, 8, 9), GenericRowData.of(1, 10, 11));

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/TestFileStore.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/TestFileStore.java
@@ -53,9 +53,13 @@ public class TestFileStore implements FileStore {
 
     public final Map<BinaryRowData, Map<Integer, List<String>>> committedFiles = new HashMap<>();
 
+    public final boolean hasPk;
+
     public boolean expired = false;
 
-    public boolean hasPk;
+    public TestFileStore(boolean hasPk) {
+        this.hasPk = hasPk;
+    }
 
     @Override
     public FileStoreWrite newWrite() {
@@ -98,14 +102,6 @@ public class TestFileStore implements FileStore {
     @Override
     public FileStoreScan newScan() {
         throw new UnsupportedOperationException();
-    }
-
-    public void enablePk() {
-        this.hasPk = true;
-    }
-
-    public void disablePk() {
-        this.hasPk = false;
     }
 
     static class TestRecordWriter implements RecordWriter {

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/TestFileStore.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/TestFileStore.java
@@ -55,13 +55,15 @@ public class TestFileStore implements FileStore {
 
     public boolean expired = false;
 
+    public boolean hasPk;
+
     @Override
     public FileStoreWrite newWrite() {
         return new FileStoreWrite() {
             @Override
             public RecordWriter createWriter(
                     BinaryRowData partition, int bucket, ExecutorService compactExecutor) {
-                TestRecordWriter writer = new TestRecordWriter();
+                TestRecordWriter writer = new TestRecordWriter(hasPk);
                 writer.records.addAll(
                         committedFiles
                                 .computeIfAbsent(partition, k -> new HashMap<>())
@@ -73,7 +75,7 @@ public class TestFileStore implements FileStore {
             @Override
             public RecordWriter createEmptyWriter(
                     BinaryRowData partition, int bucket, ExecutorService compactExecutor) {
-                return new TestRecordWriter();
+                return new TestRecordWriter(hasPk);
             }
         };
     }
@@ -98,33 +100,58 @@ public class TestFileStore implements FileStore {
         throw new UnsupportedOperationException();
     }
 
+    public void enablePk() {
+        this.hasPk = true;
+    }
+
+    public void disablePk() {
+        this.hasPk = false;
+    }
+
     static class TestRecordWriter implements RecordWriter {
 
         final List<String> records = new ArrayList<>();
+        final boolean hasPk;
 
         boolean synced = false;
 
         boolean closed = false;
 
-        private String rowToString(RowData row) {
+        TestRecordWriter(boolean hasPk) {
+            this.hasPk = hasPk;
+        }
+
+        private String rowToString(RowData row, boolean key) {
             StringBuilder builder = new StringBuilder();
             for (int i = 0; i < row.getArity(); i++) {
                 if (i != 0) {
                     builder.append("/");
                 }
-                builder.append(row.getInt(i));
+                if (key) {
+                    builder.append(row.getInt(i));
+                } else {
+                    if (i < row.getArity() - 1) {
+                        builder.append(row.getInt(i));
+                    } else {
+                        builder.append(hasPk ? row.getInt(i) : row.getLong(i));
+                    }
+                }
             }
             return builder.toString();
         }
 
         @Override
         public void write(ValueKind valueKind, RowData key, RowData value) {
+            if (!hasPk) {
+                assert value.getArity() == 1;
+                assert value.getLong(0) >= -1L;
+            }
             records.add(
                     valueKind.toString()
                             + "-key-"
-                            + rowToString(key)
+                            + rowToString(key, true)
                             + "-value-"
-                            + rowToString(value));
+                            + rowToString(value, false));
         }
 
         @Override


### PR DESCRIPTION
# What is the purpose of the change

This PR tries to fix the `ClassCastException` thrown when  `StoreSinkWriter#writeToFileStore` encountered non-pk value. When a record has no pk, the value should be a count with `long` type, while the initial value assigns `int` and will cause a `ClassCastException` at runtime (thrown by `SortBufferMemTable#put` caused by `buffer.write`).

# Verifying this change
`StoreSinkTest` is modified slightly to check the value type. Rollback the src code change will reproduce the issue.