### PR TITLE
[FLINK-26530] Introduce TableStore API and refactor ITCases

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStore.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStore.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.hybrid.HybridSource;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.transformations.PartitionTransformation;
+import org.apache.flink.table.catalog.CatalogLock;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.store.connector.sink.BucketStreamPartitioner;
+import org.apache.flink.table.store.connector.sink.StoreSink;
+import org.apache.flink.table.store.connector.sink.global.GlobalCommittingSinkTranslator;
+import org.apache.flink.table.store.connector.source.FileStoreSource;
+import org.apache.flink.table.store.connector.source.LogHybridSourceFactory;
+import org.apache.flink.table.store.connector.source.StaticFileStoreSplitEnumerator;
+import org.apache.flink.table.store.file.FileStore;
+import org.apache.flink.table.store.file.FileStoreImpl;
+import org.apache.flink.table.store.file.mergetree.compact.Accumulator;
+import org.apache.flink.table.store.file.mergetree.compact.DeduplicateAccumulator;
+import org.apache.flink.table.store.file.mergetree.compact.ValueCountAccumulator;
+import org.apache.flink.table.store.file.predicate.Predicate;
+import org.apache.flink.table.store.log.LogSinkProvider;
+import org.apache.flink.table.store.log.LogSourceProvider;
+import org.apache.flink.table.store.utils.ProjectionUtils;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.RowType;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.table.store.file.FileStoreOptions.BUCKET;
+
+/** A table store api to create source and sink. */
+@Experimental
+public class TableStore {
+
+    private final Configuration options;
+
+    /** commit user, default uuid. */
+    private String user = UUID.randomUUID().toString();
+
+    /** partition keys, default no partition. */
+    private int[] partitions = new int[0];
+
+    /** primary keys, default no key. */
+    private int[] primaryKeys = new int[0];
+
+    private RowType type;
+
+    private ObjectIdentifier tableIdentifier;
+
+    public TableStore(Configuration options) {
+        this.options = options;
+    }
+
+    public TableStore withUser(String user) {
+        this.user = user;
+        return this;
+    }
+
+    public TableStore withSchema(RowType type) {
+        this.type = type;
+        return this;
+    }
+
+    public TableStore withPartitions(int[] partitions) {
+        this.partitions = partitions;
+        return this;
+    }
+
+    public TableStore withPrimaryKeys(int[] primaryKeys) {
+        this.primaryKeys = primaryKeys;
+        return this;
+    }
+
+    public TableStore withTableIdentifier(ObjectIdentifier tableIdentifier) {
+        this.tableIdentifier = tableIdentifier;
+        return this;
+    }
+
+    public SourceBuilder sourceBuilder() {
+        return new SourceBuilder();
+    }
+
+    public SinkBuilder sinkBuilder() {
+        return new SinkBuilder();
+    }
+
+    private FileStore buildFileStore() {
+        RowType partitionType = ProjectionUtils.project(type, partitions);
+        RowType keyType;
+        RowType valueType;
+        Accumulator accumulator;
+        if (primaryKeys.length == 0) {
+            keyType = type;
+            valueType = RowType.of(new BigIntType(false));
+            accumulator = new ValueCountAccumulator();
+        } else {
+            List<RowType.RowField> fields = ProjectionUtils.project(type, primaryKeys).getFields();
+            // add _KEY_ prefix to avoid conflict with value
+            keyType =
+                    new RowType(
+                            fields.stream()
+                                    .map(
+                                            f ->
+                                                    new RowType.RowField(
+                                                            "_KEY_" + f.getName(),
+                                                            f.getType(),
+                                                            f.getDescription().orElse(null)))
+                                    .collect(Collectors.toList()));
+            valueType = type;
+            accumulator = new DeduplicateAccumulator();
+        }
+        return new FileStoreImpl(options, user, partitionType, keyType, valueType, accumulator);
+    }
+
+    /** Source builder to build a flink {@link Source}. */
+    public class SourceBuilder {
+
+        private boolean isContinuous = false;
+
+        private boolean isHybrid = true;
+
+        @Nullable private int[][] projectedFields;
+
+        @Nullable private Predicate predicate;
+
+        @Nullable private LogSourceProvider logSourceProvider;
+
+        public SourceBuilder withProjection(int[][] projectedFields) {
+            this.projectedFields = projectedFields;
+            return this;
+        }
+
+        public SourceBuilder withPredicate(Predicate predicate) {
+            this.predicate = predicate;
+            return this;
+        }
+
+        public SourceBuilder withContinuousMode(boolean isContinuous) {
+            this.isContinuous = isContinuous;
+            return this;
+        }
+
+        public SourceBuilder withHybridMode(boolean isHybrid) {
+            this.isHybrid = isHybrid;
+            return this;
+        }
+
+        public SourceBuilder withLogSourceProvider(LogSourceProvider logSourceProvider) {
+            this.logSourceProvider = logSourceProvider;
+            return this;
+        }
+
+        private FileStoreSource buildFileStoreSource() {
+            FileStore fileStore = buildFileStore();
+            return new FileStoreSource(
+                    fileStore, primaryKeys.length == 0, projectedFields, predicate);
+        }
+
+        public Source<RowData, ?, ?> build() {
+            if (isContinuous) {
+                if (logSourceProvider == null) {
+                    throw new UnsupportedOperationException(
+                            "File store continuous mode is not supported yet.");
+                }
+
+                // TODO project log source
+
+                if (isHybrid) {
+                    return HybridSource.<RowData, StaticFileStoreSplitEnumerator>builder(
+                                    buildFileStoreSource())
+                            .addSource(
+                                    new LogHybridSourceFactory(logSourceProvider),
+                                    Boundedness.CONTINUOUS_UNBOUNDED)
+                            .build();
+                } else {
+                    return logSourceProvider.createSource(null);
+                }
+            } else {
+                return buildFileStoreSource();
+            }
+        }
+
+        public DataStreamSource<RowData> build(StreamExecutionEnvironment env) {
+            return env.fromSource(
+                    build(),
+                    WatermarkStrategy.noWatermarks(),
+                    tableIdentifier.asSummaryString(),
+                    InternalTypeInfo.of(type));
+        }
+    }
+
+    /** Sink builder to build a flink sink from input. */
+    public class SinkBuilder {
+
+        private DataStream<RowData> input;
+
+        @Nullable private CatalogLock.Factory lockFactory;
+
+        @Nullable private Map<String, String> overwritePartition;
+
+        @Nullable private LogSinkProvider logSinkProvider;
+
+        public SinkBuilder withInput(DataStream<RowData> input) {
+            this.input = input;
+            return this;
+        }
+
+        public SinkBuilder withLockFactory(CatalogLock.Factory lockFactory) {
+            this.lockFactory = lockFactory;
+            return this;
+        }
+
+        public SinkBuilder withOverwritePartition(Map<String, String> overwritePartition) {
+            this.overwritePartition = overwritePartition;
+            return this;
+        }
+
+        public SinkBuilder withLogSinkProvider(LogSinkProvider logSinkProvider) {
+            this.logSinkProvider = logSinkProvider;
+            return this;
+        }
+
+        public DataStreamSink<?> build() {
+            FileStore fileStore = buildFileStore();
+            int numBucket = options.get(BUCKET);
+
+            BucketStreamPartitioner partitioner =
+                    new BucketStreamPartitioner(numBucket, type, partitions, primaryKeys);
+            DataStream<RowData> partitioned =
+                    new DataStream<>(
+                            input.getExecutionEnvironment(),
+                            new PartitionTransformation<>(input.getTransformation(), partitioner));
+
+            StoreSink<?, ?> sink =
+                    new StoreSink<>(
+                            tableIdentifier,
+                            fileStore,
+                            partitions,
+                            primaryKeys,
+                            numBucket,
+                            lockFactory,
+                            overwritePartition,
+                            logSinkProvider);
+            return GlobalCommittingSinkTranslator.translate(partitioned, sink);
+        }
+    }
+}

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/BucketStreamPartitioner.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/BucketStreamPartitioner.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector.sink;
+
+import org.apache.flink.runtime.io.network.api.writer.SubtaskStateMapper;
+import org.apache.flink.runtime.plugable.SerializationDelegate;
+import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.sink.SinkRecordConverter;
+import org.apache.flink.table.types.logical.RowType;
+
+/** A {@link StreamPartitioner} to partition records by bucket. */
+public class BucketStreamPartitioner extends StreamPartitioner<RowData> {
+
+    private final int numBucket;
+    private final RowType inputType;
+    private final int[] partitions;
+    private final int[] primaryKeys;
+
+    private transient SinkRecordConverter recordConverter;
+
+    public BucketStreamPartitioner(
+            int numBucket, RowType inputType, int[] partitions, int[] primaryKeys) {
+        this.numBucket = numBucket;
+        this.inputType = inputType;
+        this.partitions = partitions;
+        this.primaryKeys = primaryKeys;
+    }
+
+    @Override
+    public void setup(int numberOfChannels) {
+        super.setup(numberOfChannels);
+        this.recordConverter =
+                new SinkRecordConverter(numBucket, inputType, partitions, primaryKeys);
+    }
+
+    @Override
+    public int selectChannel(SerializationDelegate<StreamRecord<RowData>> record) {
+        RowData row = record.getInstance().getValue();
+        int bucket = recordConverter.bucket(row, recordConverter.key(row));
+        return bucket % numberOfChannels;
+    }
+
+    @Override
+    public StreamPartitioner<RowData> copy() {
+        return this;
+    }
+
+    @Override
+    public SubtaskStateMapper getDownstreamSubtaskStateMapper() {
+        return SubtaskStateMapper.FULL;
+    }
+
+    @Override
+    public boolean isPointwise() {
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return "bucket-assigner";
+    }
+}

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitGenerator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitGenerator.java
@@ -35,10 +35,6 @@ public class FileStoreSourceSplitGenerator {
      */
     private final char[] currentId = "0000000000".toCharArray();
 
-    public List<FileStoreSourceSplit> createSplits(FileStoreScan scan) {
-        return createSplits(scan.plan());
-    }
-
     public List<FileStoreSourceSplit> createSplits(FileStoreScan.Plan plan) {
         return plan.groupByPartFiles().entrySet().stream()
                 .flatMap(

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/LogHybridSourceFactory.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/LogHybridSourceFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector.source;
+
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.connector.base.source.hybrid.HybridSource;
+import org.apache.flink.connector.base.source.hybrid.HybridSource.SourceFactory;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.file.Snapshot;
+import org.apache.flink.table.store.log.LogSourceProvider;
+
+import java.util.Map;
+
+/** Log {@link SourceFactory} from {@link StaticFileStoreSplitEnumerator}. */
+public class LogHybridSourceFactory
+        implements SourceFactory<RowData, Source<RowData, ?, ?>, StaticFileStoreSplitEnumerator> {
+
+    private final LogSourceProvider provider;
+
+    public LogHybridSourceFactory(LogSourceProvider provider) {
+        this.provider = provider;
+    }
+
+    @Override
+    public Source<RowData, ?, ?> create(
+            HybridSource.SourceSwitchContext<StaticFileStoreSplitEnumerator> context) {
+        StaticFileStoreSplitEnumerator enumerator = context.getPreviousEnumerator();
+        Snapshot snapshot = enumerator.snapshot();
+        Map<Integer, Long> logOffsets = null;
+        if (snapshot != null) {
+            // TODO
+            // logOffsets = snapshot.getLogOffsets();
+        }
+        return provider.createSource(logOffsets);
+    }
+}

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/PendingSplitsCheckpoint.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/PendingSplitsCheckpoint.java
@@ -26,30 +26,24 @@ import java.util.Collection;
  */
 public class PendingSplitsCheckpoint {
 
+    public static final long INVALID_SNAPSHOT = -1L;
+
     /** The splits in the checkpoint. */
     private final Collection<FileStoreSourceSplit> splits;
 
-    private final long nextSnapshotId;
+    private final long currentSnapshotId;
 
-    private PendingSplitsCheckpoint(Collection<FileStoreSourceSplit> splits, long nextSnapshotId) {
+    public PendingSplitsCheckpoint(
+            Collection<FileStoreSourceSplit> splits, long currentSnapshotId) {
         this.splits = splits;
-        this.nextSnapshotId = nextSnapshotId;
+        this.currentSnapshotId = currentSnapshotId;
     }
 
     public Collection<FileStoreSourceSplit> splits() {
         return splits;
     }
 
-    public long nextSnapshotId() {
-        return nextSnapshotId;
-    }
-
-    public static PendingSplitsCheckpoint fromStatic(Collection<FileStoreSourceSplit> splits) {
-        return new PendingSplitsCheckpoint(splits, -1);
-    }
-
-    public static PendingSplitsCheckpoint fromContinuous(
-            Collection<FileStoreSourceSplit> splits, long nextSnapshotId) {
-        return new PendingSplitsCheckpoint(splits, nextSnapshotId);
+    public long currentSnapshotId() {
+        return currentSnapshotId;
     }
 }

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/PendingSplitsCheckpointSerializer.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/PendingSplitsCheckpointSerializer.java
@@ -52,7 +52,7 @@ public class PendingSplitsCheckpointSerializer
             view.writeInt(bytes.length);
             view.write(bytes);
         }
-        view.writeLong(pendingSplitsCheckpoint.nextSnapshotId());
+        view.writeLong(pendingSplitsCheckpoint.currentSnapshotId());
         return out.toByteArray();
     }
 
@@ -67,7 +67,7 @@ public class PendingSplitsCheckpointSerializer
             view.readFully(bytes);
             splits.add(splitSerializer.deserialize(version, bytes));
         }
-        long nextSnapshotId = view.readLong();
-        return PendingSplitsCheckpoint.fromContinuous(splits, nextSnapshotId);
+        long currentSnapshotId = view.readLong();
+        return new PendingSplitsCheckpoint(splits, currentSnapshotId);
     }
 }

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileStoreITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileStoreITCase.java
@@ -55,6 +55,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.apache.flink.table.store.file.FileStoreOptions.BUCKET;
 import static org.apache.flink.table.store.file.FileStoreOptions.FILE_FORMAT;
@@ -200,7 +201,12 @@ public class FileStoreITCase extends AbstractTestBase {
         List<Row> results = executeAndCollect(store.sourceBuilder().build(env));
 
         // assert
-        Row[] expected = SOURCE_DATA.stream().map(CONVERTER::toExternal).toArray(Row[]::new);
+        // in streaming mode, expect origin data X 2 (FiniteTestSource)
+        Stream<RowData> expectedStream =
+                isBatch
+                        ? SOURCE_DATA.stream()
+                        : Stream.concat(SOURCE_DATA.stream(), SOURCE_DATA.stream());
+        Row[] expected = expectedStream.map(CONVERTER::toExternal).toArray(Row[]::new);
         assertThat(results).containsExactlyInAnyOrder(expected);
     }
 

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/LogStoreSinkITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/LogStoreSinkITCase.java
@@ -18,13 +18,9 @@
 
 package org.apache.flink.table.store.connector.sink;
 
-import org.apache.flink.api.common.eventtime.WatermarkStrategy;
-import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.DynamicTableFactory;
-import org.apache.flink.table.store.connector.FileStoreITCase;
-import org.apache.flink.table.store.file.FileStore;
+import org.apache.flink.table.store.connector.TableStore;
 import org.apache.flink.table.store.kafka.KafkaLogSinkProvider;
 import org.apache.flink.table.store.kafka.KafkaLogSourceProvider;
 import org.apache.flink.table.store.kafka.KafkaLogStoreFactory;
@@ -38,11 +34,14 @@ import org.junit.Test;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.table.store.connector.FileStoreITCase.CONVERTER;
+import static org.apache.flink.table.store.connector.FileStoreITCase.SOURCE_DATA;
+import static org.apache.flink.table.store.connector.FileStoreITCase.TABLE_TYPE;
 import static org.apache.flink.table.store.connector.FileStoreITCase.buildBatchEnv;
-import static org.apache.flink.table.store.connector.FileStoreITCase.buildConfiguration;
-import static org.apache.flink.table.store.connector.FileStoreITCase.buildFileStore;
 import static org.apache.flink.table.store.connector.FileStoreITCase.buildStreamEnv;
+import static org.apache.flink.table.store.connector.FileStoreITCase.buildTableStore;
 import static org.apache.flink.table.store.connector.FileStoreITCase.buildTestSource;
+import static org.apache.flink.table.store.connector.FileStoreITCase.executeAndCollect;
 import static org.apache.flink.table.store.kafka.KafkaLogTestUtils.SINK_CONTEXT;
 import static org.apache.flink.table.store.kafka.KafkaLogTestUtils.SOURCE_CONTEXT;
 import static org.apache.flink.table.store.kafka.KafkaLogTestUtils.discoverKafkaLogFactory;
@@ -53,33 +52,43 @@ public class LogStoreSinkITCase extends KafkaTableTestBase {
 
     @Test
     public void testStreamingPartitioned() throws Exception {
-        innerTest("testStreamingPartitioned", false, true, true);
+        innerTest("testStreamingPartitioned", false, true, true, true);
     }
 
     @Test
     public void testStreamingNonPartitioned() throws Exception {
-        innerTest("testStreamingNonPartitioned", false, false, true);
+        innerTest("testStreamingNonPartitioned", false, false, true, true);
     }
 
     @Test
     public void testBatchPartitioned() throws Exception {
-        innerTest("testBatchPartitioned", true, true, true);
+        innerTest("testBatchPartitioned", true, true, true, true);
     }
 
     @Test
     public void testStreamingEventual() throws Exception {
-        innerTest("testStreamingEventual", false, true, false);
+        innerTest("testStreamingEventual", false, true, false, true);
     }
 
-    private void innerTest(String name, boolean isBatch, boolean partitioned, boolean transaction)
+    @Test
+    public void testStreamingPartitionedNonKey() throws Exception {
+        innerTest("testStreamingPartitionedNonKey", false, true, true, false);
+    }
+
+    private void innerTest(
+            String name, boolean isBatch, boolean partitioned, boolean transaction, boolean keyed)
             throws Exception {
         StreamExecutionEnvironment env = isBatch ? buildBatchEnv() : buildStreamEnv();
 
         // in eventual mode, failure will result in duplicate data
-        FileStore fileStore =
-                buildFileStore(
-                        buildConfiguration(isBatch || !transaction, TEMPORARY_FOLDER.newFolder()),
-                        partitioned);
+        TableStore store = buildTableStore(isBatch || !transaction, TEMPORARY_FOLDER);
+        if (partitioned) {
+            store.withPartitions(new int[] {1});
+        }
+
+        if (!keyed) {
+            store.withPrimaryKeys(new int[0]);
+        }
 
         // prepare log
         DynamicTableFactory.Context context =
@@ -90,8 +99,8 @@ public class LogStoreSinkITCase extends KafkaTableTestBase {
                         transaction
                                 ? LogOptions.LogConsistency.TRANSACTIONAL
                                 : LogOptions.LogConsistency.EVENTUAL,
-                        FileStoreITCase.VALUE_TYPE,
-                        new int[] {2});
+                        TABLE_TYPE,
+                        keyed ? new int[] {2} : new int[0]);
 
         KafkaLogStoreFactory factory = discoverKafkaLogFactory();
         KafkaLogSinkProvider sinkProvider = factory.createSinkProvider(context, SINK_CONTEXT);
@@ -102,64 +111,40 @@ public class LogStoreSinkITCase extends KafkaTableTestBase {
 
         try {
             // write
-            DataStreamSource<RowData> finiteSource = buildTestSource(env, isBatch);
-            FileStoreITCase.write(finiteSource, fileStore, partitioned, null, sinkProvider);
+            store.sinkBuilder()
+                    .withInput(buildTestSource(env, isBatch))
+                    .withLogSinkProvider(sinkProvider)
+                    .build();
+            env.execute();
 
             // read
-            List<Row> results = FileStoreITCase.read(env, fileStore);
+            List<Row> results = executeAndCollect(store.sourceBuilder().build(env));
 
-            Row[] expected =
-                    partitioned
-                            ? new Row[] {
-                                Row.of(5, "p2", 1),
-                                Row.of(3, "p2", 5),
-                                Row.of(5, "p1", 1),
-                                Row.of(0, "p1", 2)
-                            }
-                            : new Row[] {
-                                Row.of(5, "p2", 1), Row.of(0, "p1", 2), Row.of(3, "p2", 5)
-                            };
+            Row[] expected;
+            if (keyed) {
+                expected =
+                        partitioned
+                                ? new Row[] {
+                                    Row.of(5, "p2", 1),
+                                    Row.of(3, "p2", 5),
+                                    Row.of(5, "p1", 1),
+                                    Row.of(0, "p1", 2)
+                                }
+                                : new Row[] {
+                                    Row.of(5, "p2", 1), Row.of(0, "p1", 2), Row.of(3, "p2", 5)
+                                };
+            } else {
+                expected = SOURCE_DATA.stream().map(CONVERTER::toExternal).toArray(Row[]::new);
+            }
+
             assertThat(results).containsExactlyInAnyOrder(expected);
 
             results =
-                    buildStreamEnv()
-                            .fromSource(
-                                    sourceProvider.createSource(null),
-                                    WatermarkStrategy.noWatermarks(),
-                                    "source")
-                            .executeAndCollect(isBatch ? 6 : 12).stream()
-                            .map(FileStoreITCase.CONVERTER::toExternal)
+                    store.sourceBuilder().withContinuousMode(true)
+                            .withLogSourceProvider(sourceProvider).build(buildStreamEnv())
+                            .executeAndCollect(expected.length).stream()
+                            .map(CONVERTER::toExternal)
                             .collect(Collectors.toList());
-
-            if (isBatch) {
-                expected =
-                        new Row[] {
-                            Row.of(0, "p1", 1),
-                            Row.of(0, "p1", 2),
-                            Row.of(5, "p1", 1),
-                            Row.of(6, "p2", 1),
-                            Row.of(3, "p2", 5),
-                            Row.of(5, "p2", 1)
-                        };
-            } else {
-                // read log
-                // expect origin data X 2 (FiniteTestSource)
-                expected =
-                        new Row[] {
-                            Row.of(0, "p1", 1),
-                            Row.of(0, "p1", 2),
-                            Row.of(5, "p1", 1),
-                            Row.of(6, "p2", 1),
-                            Row.of(3, "p2", 5),
-                            Row.of(5, "p2", 1),
-                            Row.of(0, "p1", 1),
-                            Row.of(0, "p1", 2),
-                            Row.of(5, "p1", 1),
-                            Row.of(6, "p2", 1),
-                            Row.of(3, "p2", 5),
-                            Row.of(5, "p2", 1)
-                        };
-            }
             assertThat(results).containsExactlyInAnyOrder(expected);
         } finally {
             factory.onDropTable(context, true);

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/PendingSplitsCheckpointSerializerTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/PendingSplitsCheckpointSerializerTest.java
@@ -38,7 +38,7 @@ public class PendingSplitsCheckpointSerializerTest {
     @Test
     public void serializeEmptyCheckpoint() throws Exception {
         final PendingSplitsCheckpoint checkpoint =
-                PendingSplitsCheckpoint.fromStatic(Collections.emptyList());
+                new PendingSplitsCheckpoint(Collections.emptyList(), 5);
 
         final PendingSplitsCheckpoint deSerialized = serializeAndDeserialize(checkpoint);
 
@@ -48,8 +48,8 @@ public class PendingSplitsCheckpointSerializerTest {
     @Test
     public void serializeSomeSplits() throws Exception {
         final PendingSplitsCheckpoint checkpoint =
-                PendingSplitsCheckpoint.fromStatic(
-                        Arrays.asList(testSplit1(), testSplit2(), testSplit3()));
+                new PendingSplitsCheckpoint(
+                        Arrays.asList(testSplit1(), testSplit2(), testSplit3()), 3);
 
         final PendingSplitsCheckpoint deSerialized = serializeAndDeserialize(checkpoint);
 
@@ -59,7 +59,7 @@ public class PendingSplitsCheckpointSerializerTest {
     @Test
     public void serializeSplitsAndContinuous() throws Exception {
         final PendingSplitsCheckpoint checkpoint =
-                PendingSplitsCheckpoint.fromContinuous(
+                new PendingSplitsCheckpoint(
                         Arrays.asList(testSplit1(), testSplit2(), testSplit3()), 20);
 
         final PendingSplitsCheckpoint deSerialized = serializeAndDeserialize(checkpoint);
@@ -70,7 +70,7 @@ public class PendingSplitsCheckpointSerializerTest {
     @Test
     public void repeatedSerialization() throws Exception {
         final PendingSplitsCheckpoint checkpoint =
-                PendingSplitsCheckpoint.fromStatic(Arrays.asList(testSplit3(), testSplit1()));
+                new PendingSplitsCheckpoint(Arrays.asList(testSplit3(), testSplit1()), 5);
 
         serializeAndDeserialize(checkpoint);
         serializeAndDeserialize(checkpoint);
@@ -112,6 +112,6 @@ public class PendingSplitsCheckpointSerializerTest {
     private static void assertCheckpointsEqual(
             final PendingSplitsCheckpoint expected, final PendingSplitsCheckpoint actual) {
         assertThat(actual.splits()).isEqualTo(expected.splits());
-        assertThat(actual.nextSnapshotId()).isEqualTo(expected.nextSnapshotId());
+        assertThat(actual.currentSnapshotId()).isEqualTo(expected.currentSnapshotId());
     }
 }

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/StaticFileStoreSplitEnumeratorTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/StaticFileStoreSplitEnumeratorTest.java
@@ -102,7 +102,6 @@ public class StaticFileStoreSplitEnumeratorTest {
     private static StaticFileStoreSplitEnumerator createEnumerator(
             final SplitEnumeratorContext<FileStoreSourceSplit> context,
             final FileStoreSourceSplit... splits) {
-
-        return new StaticFileStoreSplitEnumerator(context, Arrays.asList(splits));
+        return new StaticFileStoreSplitEnumerator(context, null, Arrays.asList(splits));
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreScan.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.store.file.operation;
 
 import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.store.file.Snapshot;
 import org.apache.flink.table.store.file.ValueKind;
 import org.apache.flink.table.store.file.manifest.ManifestEntry;
 import org.apache.flink.table.store.file.manifest.ManifestFileMeta;
@@ -36,6 +37,8 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 
 /** Scan operation which produces a plan. */
 public interface FileStoreScan {
+
+    Snapshot snapshot(long snapshotId);
 
     FileStoreScan withPartitionFilter(Predicate predicate);
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreScanImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreScanImpl.java
@@ -75,6 +75,11 @@ public class FileStoreScanImpl implements FileStoreScan {
     }
 
     @Override
+    public Snapshot snapshot(long snapshotId) {
+        return Snapshot.fromPath(pathFactory.toSnapshotPath(snapshotId));
+    }
+
+    @Override
     public FileStoreScan withPartitionFilter(Predicate predicate) {
         this.partitionFilter = predicate;
         return this;
@@ -154,8 +159,7 @@ public class FileStoreScanImpl implements FileStoreScan {
             if (snapshotId == null) {
                 manifests = Collections.emptyList();
             } else {
-                Snapshot snapshot = Snapshot.fromPath(pathFactory.toSnapshotPath(snapshotId));
-                manifests = snapshot.readAllManifests(manifestList);
+                manifests = snapshot(snapshotId).readAllManifests(manifestList);
             }
         }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/sink/SinkRecordConverter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/sink/SinkRecordConverter.java
@@ -49,10 +49,18 @@ public class SinkRecordConverter {
 
     public SinkRecord convert(RowData row) {
         BinaryRowData partition = partProjection.apply(row);
-        BinaryRowData key = keyProjection.apply(row);
-        int hash = key.getArity() == 0 ? hashRow(row) : key.hashCode();
-        int bucket = Math.abs(hash % numBucket);
+        BinaryRowData key = key(row);
+        int bucket = bucket(row, key);
         return new SinkRecord(partition, bucket, key, row);
+    }
+
+    public BinaryRowData key(RowData row) {
+        return keyProjection.apply(row);
+    }
+
+    public int bucket(RowData row, BinaryRowData key) {
+        int hash = key.getArity() == 0 ? hashRow(row) : key.hashCode();
+        return Math.abs(hash % numBucket);
     }
 
     private int hashRow(RowData row) {


### PR DESCRIPTION
Introduce TableStore API to provide a clear and simple API for the upper level:
- Create a TableStore source.
- Create a TableStore sink.

The TableStore API automatically handles:
- handles key-related things
- handles mixing / hybrid with log store
- before sink, and it also handles partitioner to avoid message disorder