### PR TITLE
[FLINK-26441] Add a new OVERWRITE snapshot commit kind

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/Snapshot.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/Snapshot.java
@@ -163,6 +163,9 @@ public class Snapshot {
         APPEND,
 
         /** Changes by compacting existing sst files. */
-        COMPACT
+        COMPACT,
+
+        /** Changes that clear up the whole partition and then add new records. */
+        OVERWRITE
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
@@ -194,7 +194,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                 partitionFilter,
                 appendChanges,
                 committable.identifier(),
-                Snapshot.CommitKind.APPEND);
+                Snapshot.CommitKind.OVERWRITE);
 
         List<ManifestEntry> compactChanges = new ArrayList<>();
         compactChanges.addAll(collectChanges(committable.compactBefore(), ValueKind.DELETE));

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
@@ -190,11 +190,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             }
         }
         // overwrite new files
-        tryOverwrite(
-                partitionFilter,
-                appendChanges,
-                committable.identifier(),
-                Snapshot.CommitKind.OVERWRITE);
+        tryOverwrite(partitionFilter, appendChanges, committable.identifier());
 
         List<ManifestEntry> compactChanges = new ArrayList<>();
         compactChanges.addAll(collectChanges(committable.compactBefore(), ValueKind.DELETE));
@@ -218,10 +214,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
     }
 
     private void tryOverwrite(
-            Predicate partitionFilter,
-            List<ManifestEntry> changes,
-            String identifier,
-            Snapshot.CommitKind commitKind) {
+            Predicate partitionFilter, List<ManifestEntry> changes, String identifier) {
         while (true) {
             Long latestSnapshotId = pathFactory.latestSnapshotId();
 
@@ -245,7 +238,11 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             changesWithOverwrite.addAll(changes);
 
             if (tryCommitOnce(
-                    changesWithOverwrite, identifier, commitKind, latestSnapshotId, false)) {
+                    changesWithOverwrite,
+                    identifier,
+                    Snapshot.CommitKind.OVERWRITE,
+                    latestSnapshotId,
+                    false)) {
                 break;
             }
         }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreCommitTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreCommitTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.store.file.operation;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.store.file.KeyValue;
+import org.apache.flink.table.store.file.Snapshot;
 import org.apache.flink.table.store.file.TestFileStore;
 import org.apache.flink.table.store.file.TestKeyValueGenerator;
 import org.apache.flink.table.store.file.ValueKind;
@@ -176,11 +177,15 @@ public class FileStoreCommitTest {
                                 .flatMap(Collection::stream)
                                 .collect(Collectors.toList()),
                 "data2");
-        store.overwriteData(
-                data2.values().stream().flatMap(Collection::stream).collect(Collectors.toList()),
-                gen::getPartition,
-                kv -> 0,
-                partitionToOverwrite);
+        List<Snapshot> overwriteSnapshots =
+                store.overwriteData(
+                        data2.values().stream()
+                                .flatMap(Collection::stream)
+                                .collect(Collectors.toList()),
+                        gen::getPartition,
+                        kv -> 0,
+                        partitionToOverwrite);
+        assertThat(overwriteSnapshots.get(0).commitKind()).isEqualTo(Snapshot.CommitKind.OVERWRITE);
 
         List<KeyValue> expectedKvs = new ArrayList<>();
         for (Map.Entry<BinaryRowData, List<KeyValue>> entry : data1.entrySet()) {


### PR DESCRIPTION
Overwriting a snapshot is different from the normal commit. It firstly clears up the whole partition then append new entries. So we need a new snapshot commit kind to describe it.