### PR TITLE
[FLINK-26544] Apply key & value filter in FileStoreScanImpl

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreScanImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreScanImpl.java
@@ -228,10 +228,12 @@ public class FileStoreScanImpl implements FileStoreScan {
     }
 
     private boolean filterManifestEntry(ManifestEntry entry) {
-        // TODO apply key & value filter after field stats are collected in
-        //  SstFile.RollingFile#finish
         return (partitionFilter == null
                         || partitionFilter.test(partitionConverter.convert(entry.partition())))
+                && (keyFilter == null
+                        || keyFilter.test(entry.file().rowCount(), entry.file().keyStats()))
+                && (valueFilter == null
+                        || valueFilter.test(entry.file().rowCount(), entry.file().valueStats()))
                 && (specifiedBucket == null || entry.bucket() == specifiedBucket);
     }
 


### PR DESCRIPTION
Now that we've implemented sst file statistics in [FLINK-26346](https://issues.apache.org/jira/browse/FLINK-26346), we can apply key & value filter in `FileStoreScanImpl`.