### PR TITLE
[FLINK-26567] FileStoreSourceSplitReader should deal with value count

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSource.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSource.java
@@ -42,7 +42,7 @@ public class FileStoreSource
 
     private final FileStore fileStore;
 
-    private final boolean keyAsRecord;
+    private final boolean valueCountMode;
 
     @Nullable private final int[][] projectedFields;
 
@@ -52,12 +52,12 @@ public class FileStoreSource
 
     public FileStoreSource(
             FileStore fileStore,
-            boolean keyAsRecord,
+            boolean valueCountMode,
             @Nullable int[][] projectedFields,
             @Nullable Predicate partitionPredicate,
             @Nullable Predicate fieldsPredicate) {
         this.fileStore = fileStore;
-        this.keyAsRecord = keyAsRecord;
+        this.valueCountMode = valueCountMode;
         this.projectedFields = projectedFields;
         this.partitionPredicate = partitionPredicate;
         this.fieldsPredicate = fieldsPredicate;
@@ -73,13 +73,13 @@ public class FileStoreSource
     public SourceReader<RowData, FileStoreSourceSplit> createReader(SourceReaderContext context) {
         FileStoreRead read = fileStore.newRead();
         if (projectedFields != null) {
-            if (keyAsRecord) {
+            if (valueCountMode) {
                 read.withKeyProjection(projectedFields);
             } else {
                 read.withValueProjection(projectedFields);
             }
         }
-        return new FileStoreSourceReader(context, read, keyAsRecord);
+        return new FileStoreSourceReader(context, read, valueCountMode);
     }
 
     @Override
@@ -90,7 +90,7 @@ public class FileStoreSource
             scan.withPartitionFilter(partitionPredicate);
         }
         if (fieldsPredicate != null) {
-            if (keyAsRecord) {
+            if (valueCountMode) {
                 scan.withKeyFilter(fieldsPredicate);
             } else {
                 scan.withValueFilter(fieldsPredicate);

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceReader.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceReader.java
@@ -36,9 +36,11 @@ public final class FileStoreSourceReader
                 FileStoreSourceSplitState> {
 
     public FileStoreSourceReader(
-            SourceReaderContext readerContext, FileStoreRead fileStoreRead, boolean keyAsRecord) {
+            SourceReaderContext readerContext,
+            FileStoreRead fileStoreRead,
+            boolean valueCountMode) {
         super(
-                () -> new FileStoreSourceSplitReader(fileStoreRead, keyAsRecord),
+                () -> new FileStoreSourceSplitReader(fileStoreRead, valueCountMode),
                 (element, output, splitState) -> {
                     output.collect(element.getRecord());
                     splitState.setPosition(element);

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitReader.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitReader.java
@@ -29,6 +29,7 @@ import org.apache.flink.connector.file.src.util.Pool;
 import org.apache.flink.connector.file.src.util.RecordAndPosition;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.file.KeyValue;
+import org.apache.flink.table.store.file.ValueKind;
 import org.apache.flink.table.store.file.operation.FileStoreRead;
 import org.apache.flink.table.store.file.utils.RecordReader;
 import org.apache.flink.types.RowKind;
@@ -202,7 +203,11 @@ public class FileStoreSourceSplitReader
                 if (kv == null) {
                     return null;
                 }
-                recordAndPosition.setNext(kv.value());
+                RowData row = kv.value();
+                if (kv.valueKind() == ValueKind.DELETE) {
+                    row.setRowKind(RowKind.DELETE);
+                }
+                recordAndPosition.setNext(row);
                 currentNumRead++;
                 return recordAndPosition;
             } catch (IOException e) {

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/TestDataReadWrite.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/TestDataReadWrite.java
@@ -89,7 +89,7 @@ public class TestDataReadWrite {
         return new ArrayList<>(files);
     }
 
-    private RecordWriter createMergeTreeWriter(BinaryRowData partition, int bucket) {
+    public RecordWriter createMergeTreeWriter(BinaryRowData partition, int bucket) {
         MergeTreeOptions options = new MergeTreeOptions(new Configuration());
         return new FileStoreWriteImpl(
                         KEY_TYPE,

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/TestDataReadWrite.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/TestDataReadWrite.java
@@ -34,6 +34,7 @@ import org.apache.flink.table.store.file.operation.FileStoreReadImpl;
 import org.apache.flink.table.store.file.operation.FileStoreWriteImpl;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 import org.apache.flink.table.store.file.utils.RecordWriter;
+import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Preconditions;
@@ -49,10 +50,11 @@ import static java.util.Collections.singletonList;
 public class TestDataReadWrite {
 
     private static final RowType KEY_TYPE =
-            new RowType(singletonList(new RowType.RowField("k", new IntType())));
+            new RowType(singletonList(new RowType.RowField("k", new BigIntType())));
     private static final RowType VALUE_TYPE =
-            new RowType(singletonList(new RowType.RowField("v", new IntType())));
-    private static final Comparator<RowData> COMPARATOR = Comparator.comparingInt(o -> o.getInt(0));
+            new RowType(singletonList(new RowType.RowField("v", new BigIntType())));
+    private static final Comparator<RowData> COMPARATOR =
+            Comparator.comparingLong(o -> o.getLong(0));
 
     private final FileFormat avro;
     private final FileStorePathFactory pathFactory;
@@ -75,12 +77,11 @@ public class TestDataReadWrite {
     }
 
     public List<SstFileMeta> writeFiles(
-            BinaryRowData partition, int bucket, List<Tuple2<Integer, Integer>> kvs)
-            throws Exception {
+            BinaryRowData partition, int bucket, List<Tuple2<Long, Long>> kvs) throws Exception {
         Preconditions.checkNotNull(
                 service, "ExecutorService must be provided if writeFiles is needed");
         RecordWriter writer = createMergeTreeWriter(partition, bucket);
-        for (Tuple2<Integer, Integer> tuple2 : kvs) {
+        for (Tuple2<Long, Long> tuple2 : kvs) {
             writer.write(ValueKind.ADD, GenericRowData.of(tuple2.f0), GenericRowData.of(tuple2.f1));
         }
         List<SstFileMeta> files = writer.prepareCommit().newFiles();

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreRead.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreRead.java
@@ -28,11 +28,14 @@ import java.util.List;
 /** Read operation which provides {@link RecordReader} creation. */
 public interface FileStoreRead {
 
+    /** With drop delete records. */
+    FileStoreRead withDropDelete(boolean dropDelete);
+
     /** With key nested projection. */
-    void withKeyProjection(int[][] projectedFields);
+    FileStoreRead withKeyProjection(int[][] projectedFields);
 
     /** With value nested projection. */
-    void withValueProjection(int[][] projectedFields);
+    FileStoreRead withValueProjection(int[][] projectedFields);
 
     /**
      * Create a {@link RecordReader} from partition and bucket and files.

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreReadTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreReadTest.java
@@ -196,6 +196,7 @@ public class FileStoreReadTest {
         FileStoreRead read = store.newRead();
         if (keyProjection != null) {
             read.withKeyProjection(keyProjection);
+            read.withDropDelete(false);
         }
         if (valueProjection != null) {
             read.withValueProjection(valueProjection);


### PR DESCRIPTION
There is a keyAsRecord in `FileStoreSourceSplitReader`, but this should only be keyAsRecord. When keyAsRecord, it should emit the same number of records as value count.

And, `FileStoreSourceSplitReader` should have the ability to output delete records.