### PR TITLE
[FLINK-26677] Make flink-connector-base dependency consistent

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStore.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStore.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.connector.base.source.hybrid.HybridSource;
+import org.apache.flink.connector.files.shaded.org.apache.flink.connector.base.source.hybrid.HybridSource;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceReader.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceReader.java
@@ -20,8 +20,8 @@ package org.apache.flink.table.store.connector.source;
 
 import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.SourceReaderContext;
-import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSourceReaderBase;
 import org.apache.flink.connector.file.src.util.RecordAndPosition;
+import org.apache.flink.connector.files.shaded.org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSourceReaderBase;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.file.operation.FileStoreRead;
 

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitReader.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitReader.java
@@ -18,15 +18,15 @@
 
 package org.apache.flink.table.store.connector.source;
 
-import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
-import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
-import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
-import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
 import org.apache.flink.connector.file.src.impl.FileRecords;
 import org.apache.flink.connector.file.src.reader.BulkFormat;
 import org.apache.flink.connector.file.src.util.MutableRecordAndPosition;
 import org.apache.flink.connector.file.src.util.Pool;
 import org.apache.flink.connector.file.src.util.RecordAndPosition;
+import org.apache.flink.connector.files.shaded.org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.files.shaded.org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.files.shaded.org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
+import org.apache.flink.connector.files.shaded.org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.file.KeyValue;
 import org.apache.flink.table.store.file.ValueKind;

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/LogHybridSourceFactory.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/LogHybridSourceFactory.java
@@ -19,17 +19,17 @@
 package org.apache.flink.table.store.connector.source;
 
 import org.apache.flink.api.connector.source.Source;
-import org.apache.flink.connector.base.source.hybrid.HybridSource;
-import org.apache.flink.connector.base.source.hybrid.HybridSource.SourceFactory;
+import org.apache.flink.connector.files.shaded.org.apache.flink.connector.base.source.hybrid.HybridSource;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.file.Snapshot;
 import org.apache.flink.table.store.log.LogSourceProvider;
 
 import java.util.Map;
 
-/** Log {@link SourceFactory} from {@link StaticFileStoreSplitEnumerator}. */
+/** Log {@link HybridSource.SourceFactory} from {@link StaticFileStoreSplitEnumerator}. */
 public class LogHybridSourceFactory
-        implements SourceFactory<RowData, Source<RowData, ?, ?>, StaticFileStoreSplitEnumerator> {
+        implements HybridSource.SourceFactory<
+                RowData, Source<RowData, ?, ?>, StaticFileStoreSplitEnumerator> {
 
     private final LogSourceProvider provider;
 

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitReaderTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitReaderTest.java
@@ -19,10 +19,10 @@
 package org.apache.flink.table.store.connector.source;
 
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
-import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
-import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
 import org.apache.flink.connector.file.src.util.RecordAndPosition;
+import org.apache.flink.connector.files.shaded.org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.files.shaded.org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
+import org.apache.flink.connector.files.shaded.org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.file.ValueKind;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/FileUtils.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/FileUtils.java
@@ -19,10 +19,10 @@
 package org.apache.flink.table.store.file.utils;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.connector.base.source.reader.SourceReaderOptions;
 import org.apache.flink.connector.file.src.FileSourceSplit;
 import org.apache.flink.connector.file.src.reader.BulkFormat;
 import org.apache.flink.connector.file.src.util.Utils;
+import org.apache.flink.connector.files.shaded.org.apache.flink.connector.base.source.reader.SourceReaderOptions;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileSystem;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/log/LogSourceProvider.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/log/LogSourceProvider.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.store.log;
 
 import org.apache.flink.api.connector.source.Source;
-import org.apache.flink.connector.base.source.hybrid.HybridSource;
+import org.apache.flink.connector.files.shaded.org.apache.flink.connector.base.source.hybrid.HybridSource;
 import org.apache.flink.table.data.RowData;
 
 import javax.annotation.Nullable;

--- a/flink-table-store-kafka/src/main/java/org/apache/flink/table/store/kafka/KafkaLogSinkProvider.java
+++ b/flink-table-store-kafka/src/main/java/org/apache/flink/table/store/kafka/KafkaLogSinkProvider.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.store.kafka;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.serialization.SerializationSchema;
-import org.apache.flink.connector.base.DeliveryGuarantee;
+import org.apache.flink.connector.kafka.shaded.org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.connector.kafka.sink.KafkaSink;
 import org.apache.flink.connector.kafka.sink.KafkaSinkBuilder;
 import org.apache.flink.table.data.RowData;


### PR DESCRIPTION
as https://issues.apache.org/jira/browse/FLINK-25927 has been merged into flink master branch and 1.15 branch, the flink-connector-base modules has been shaded into many connectors modules.
now the building of table-store project has been failed caused by above.