### PR TITLE
[hotfix] Rename ambiguous key to primary key

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/BucketStreamPartitioner.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/BucketStreamPartitioner.java
@@ -54,7 +54,7 @@ public class BucketStreamPartitioner extends StreamPartitioner<RowData> {
     @Override
     public int selectChannel(SerializationDelegate<StreamRecord<RowData>> record) {
         RowData row = record.getInstance().getValue();
-        int bucket = recordConverter.bucket(row, recordConverter.key(row));
+        int bucket = recordConverter.bucket(row, recordConverter.primaryKey(row));
         return bucket % numberOfChannels;
     }
 

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSinkWriter.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSinkWriter.java
@@ -115,18 +115,18 @@ public class StoreSinkWriter<WriterStateT>
         switch (record.row().getRowKind()) {
             case INSERT:
             case UPDATE_AFTER:
-                if (record.key().getArity() == 0) {
+                if (record.primaryKey().getArity() == 0) {
                     writer.write(ValueKind.ADD, record.row(), GenericRowData.of(1L));
                 } else {
-                    writer.write(ValueKind.ADD, record.key(), record.row());
+                    writer.write(ValueKind.ADD, record.primaryKey(), record.row());
                 }
                 break;
             case UPDATE_BEFORE:
             case DELETE:
-                if (record.key().getArity() == 0) {
+                if (record.primaryKey().getArity() == 0) {
                     writer.write(ValueKind.ADD, record.row(), GenericRowData.of(-1L));
                 } else {
-                    writer.write(ValueKind.DELETE, record.key(), record.row());
+                    writer.write(ValueKind.DELETE, record.primaryKey(), record.row());
                 }
                 break;
         }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/sink/SinkRecord.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/sink/SinkRecord.java
@@ -31,16 +31,16 @@ public class SinkRecord {
 
     private final int bucket;
 
-    private final BinaryRowData key;
+    private final BinaryRowData primaryKey;
 
     private final RowData row;
 
-    public SinkRecord(BinaryRowData partition, int bucket, BinaryRowData key, RowData row) {
+    public SinkRecord(BinaryRowData partition, int bucket, BinaryRowData primaryKey, RowData row) {
         checkArgument(partition.getRowKind() == RowKind.INSERT);
-        checkArgument(key.getRowKind() == RowKind.INSERT);
+        checkArgument(primaryKey.getRowKind() == RowKind.INSERT);
         this.partition = partition;
         this.bucket = bucket;
-        this.key = key;
+        this.primaryKey = primaryKey;
         this.row = row;
     }
 
@@ -52,8 +52,8 @@ public class SinkRecord {
         return bucket;
     }
 
-    public BinaryRowData key() {
-        return key;
+    public BinaryRowData primaryKey() {
+        return primaryKey;
     }
 
     public RowData row() {

--- a/flink-table-store-kafka/src/test/java/org/apache/flink/table/store/kafka/KafkaLogTestUtils.java
+++ b/flink-table-store-kafka/src/test/java/org/apache/flink/table/store/kafka/KafkaLogTestUtils.java
@@ -192,11 +192,11 @@ public class KafkaLogTestUtils {
         return createContext(name, type, keys, options);
     }
 
-    static SinkRecord testRecord(boolean keyed, int bucket, int key, int value, RowKind rowKind) {
+    static SinkRecord testRecord(boolean hasPk, int bucket, int pk, int value, RowKind rowKind) {
         return new SinkRecord(
                 EMPTY_ROW,
                 bucket,
-                keyed ? row(key) : EMPTY_ROW,
-                GenericRowData.ofKind(rowKind, key, value));
+                hasPk ? row(pk) : EMPTY_ROW,
+                GenericRowData.ofKind(rowKind, pk, value));
     }
 }


### PR DESCRIPTION
`record.key().getArity() == 0` is ambiguous, it should be `record.primaryKey().getArity() == 0`