### PR TITLE
[FLINK-26711] Remove change tracking in TableStore

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreFactoryOptions.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreFactoryOptions.java
@@ -24,14 +24,6 @@ import org.apache.flink.configuration.ConfigOptions;
 /** Options for {@link TableStoreFactory}. */
 public class TableStoreFactoryOptions {
 
-    // TODO remove CHANGE_TRACKING, just ignore changes for overwrite
-    public static final ConfigOption<Boolean> CHANGE_TRACKING =
-            ConfigOptions.key("change-tracking")
-                    .booleanType()
-                    .defaultValue(true)
-                    .withDescription(
-                            "Whether to enable change tracking. The default value is true, which means consuming changes from the table.");
-
     public static final ConfigOption<String> LOG_SYSTEM =
             ConfigOptions.key("log.system")
                     .stringType()

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/TableStoreSink.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/TableStoreSink.java
@@ -112,7 +112,8 @@ public class TableStoreSink
                                 }
                             });
         }
-        final LogSinkProvider finalLogSinkProvider = logSinkProvider;
+        // Do not sink to log store when overwrite mode
+        final LogSinkProvider finalLogSinkProvider = overwrite ? null : logSinkProvider;
         return (DataStreamSinkProvider)
                 (providerContext, dataStream) ->
                         tableStore

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/ContinuousFileSplitEnumerator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/ContinuousFileSplitEnumerator.java
@@ -202,8 +202,7 @@ public class ContinuousFileSplitEnumerator
                 Snapshot snapshot = scan.snapshot(nextSnapshotId);
                 if (snapshot.commitKind() != Snapshot.CommitKind.APPEND) {
                     if (snapshot.commitKind() == Snapshot.CommitKind.OVERWRITE) {
-                        throw new UnsupportedOperationException(
-                                "Invalid overwrite snapshot id: " + nextSnapshotId);
+                        LOG.warn("Ignore overwrite snapshot id {}.", nextSnapshotId);
                     }
 
                     nextSnapshotId++;

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/CreateTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/CreateTableITCase.java
@@ -60,10 +60,10 @@ public class CreateTableITCase extends TableStoreTestBase {
     public CreateTableITCase(
             RuntimeExecutionMode executionMode,
             String tableName,
-            boolean enableChangeTracking,
+            boolean enableLogStore,
             boolean ignoreException,
             ExpectedResult expectedResult) {
-        super(executionMode, tableName, enableChangeTracking, expectedResult);
+        super(executionMode, tableName, enableLogStore, expectedResult);
         this.ignoreException = ignoreException;
     }
 
@@ -81,8 +81,7 @@ public class CreateTableITCase extends TableStoreTestBase {
             assertThat(Paths.get(rootPath, getRelativeFileStoreTablePath(tableIdentifier)).toFile())
                     .exists();
             // check log store
-            assertThat(topicExists(tableIdentifier.asSummaryString()))
-                    .isEqualTo(enableChangeTracking);
+            assertThat(topicExists(tableIdentifier.asSummaryString())).isEqualTo(enableLogStore);
         } else {
             // check inconsistency between catalog/file store/log store
             assertThat(ignoreException).isFalse();
@@ -124,7 +123,7 @@ public class CreateTableITCase extends TableStoreTestBase {
                                 }
                             });
             // ensure log store doesn't exist the topic
-            if (enableChangeTracking && !ignoreException) {
+            if (enableLogStore && !ignoreException) {
                 deleteTopicIfExists(tableIdentifier.asSummaryString());
             }
         } else if (expectedResult.expectedMessage.startsWith("Failed to create file store path.")) {
@@ -151,7 +150,7 @@ public class CreateTableITCase extends TableStoreTestBase {
 
     @Parameterized.Parameters(
             name =
-                    "executionMode-{0}, tableName-{1}, enableChangeTracking-{2}, ignoreException-{3}, expectedResult-{4}")
+                    "executionMode-{0}, tableName-{1}, enableLogStore-{2}, ignoreException-{3}, expectedResult-{4}")
     public static List<Object[]> data() {
         List<Object[]> specs = new ArrayList<>();
         // successful case specs

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/DropTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/DropTableITCase.java
@@ -58,10 +58,10 @@ public class DropTableITCase extends TableStoreTestBase {
     public DropTableITCase(
             RuntimeExecutionMode executionMode,
             String tableName,
-            boolean enableChangeTracking,
+            boolean enableLogStore,
             boolean ignoreException,
             ExpectedResult expectedResult) {
-        super(executionMode, tableName, enableChangeTracking, expectedResult);
+        super(executionMode, tableName, enableLogStore, expectedResult);
         this.ignoreException = ignoreException;
     }
 
@@ -132,7 +132,7 @@ public class DropTableITCase extends TableStoreTestBase {
                 // delete file store path does not affect dropping the table
                 deleteTablePath();
                 // delete log store topic does not affect dropping the table
-                if (enableChangeTracking) {
+                if (enableLogStore) {
                     deleteTopicIfExists(tableIdentifier.asSummaryString());
                 }
             }
@@ -158,7 +158,7 @@ public class DropTableITCase extends TableStoreTestBase {
 
     @Parameterized.Parameters(
             name =
-                    "executionMode-{0}, tableName-{1}, enableChangeTracking-{2}, ignoreException-{3}, expectedResult-{4}")
+                    "executionMode-{0}, tableName-{1}, enableLogStore-{2}, ignoreException-{3}, expectedResult-{4}")
     public static List<Object[]> data() {
         List<Object[]> specs = new ArrayList<>();
         // successful case specs

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ReadWriteTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ReadWriteTableITCase.java
@@ -56,11 +56,11 @@ public class ReadWriteTableITCase extends TableStoreTestBase {
     public ReadWriteTableITCase(
             RuntimeExecutionMode executionMode,
             String tableName,
-            boolean enableChangeTracking,
+            boolean enableLogStore,
             boolean hasPk,
             @Nullable Boolean duplicate,
             ExpectedResult expectedResult) {
-        super(executionMode, tableName, enableChangeTracking, expectedResult);
+        super(executionMode, tableName, enableLogStore, expectedResult);
         this.hasPk = hasPk;
         this.duplicate = duplicate;
     }
@@ -92,7 +92,7 @@ public class ReadWriteTableITCase extends TableStoreTestBase {
             // check manifest file path
             assertThat(Paths.get(rootPath, relativeFilePath, "manifest")).exists();
 
-            if (enableChangeTracking) {
+            if (enableLogStore) {
                 assertThat(topicExists(tableIdentifier.asSummaryString())).isTrue();
             }
         } else {
@@ -110,7 +110,7 @@ public class ReadWriteTableITCase extends TableStoreTestBase {
     @Parameterized.Parameters(
             name =
                     "executionMode-{0}, tableName-{1}, "
-                            + "enableChangeTracking-{2}, hasPk-{3},"
+                            + "enableLogStore-{2}, hasPk-{3},"
                             + " duplicate-{4}, expectedResult-{5}")
     public static List<Object[]> data() {
         List<Object[]> specs = new ArrayList<>();
@@ -119,8 +119,8 @@ public class ReadWriteTableITCase extends TableStoreTestBase {
                 new Object[] {
                     RuntimeExecutionMode.BATCH,
                     "table_" + UUID.randomUUID(),
-                    false, // enable change-tracking
-                    false, // has pk
+                    false, // disable log store
+                    false, // no pk
                     false, // without duplicate
                     new ExpectedResult().success(true).expectedRecords(insertOnlyCities(false))
                 });
@@ -128,8 +128,8 @@ public class ReadWriteTableITCase extends TableStoreTestBase {
                 new Object[] {
                     RuntimeExecutionMode.BATCH,
                     "table_" + UUID.randomUUID(),
-                    false, // enable change-tracking
-                    false, // has pk
+                    false, // disable log store
+                    false, // no pk
                     true, //  with duplicate
                     new ExpectedResult().success(true).expectedRecords(insertOnlyCities(true))
                 });
@@ -139,14 +139,12 @@ public class ReadWriteTableITCase extends TableStoreTestBase {
                 new Object[] {
                     RuntimeExecutionMode.BATCH,
                     "table_" + UUID.randomUUID(),
-                    false, // enable change-tracking
+                    false, // disable log store
                     true, // has pk
-                    null, // without delete
+                    null, // without duplicate
                     new ExpectedResult().success(true).expectedRecords(expected)
                 });
-        // TODO: streaming with change-tracking
-
-        // TODO: streaming without log system
+        // TODO: streaming with log system
 
         // TODO: add overwrite case
 

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreFactoryTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreFactoryTest.java
@@ -45,7 +45,6 @@ import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import static org.apache.flink.table.store.connector.TableStoreFactoryOptions.CHANGE_TRACKING;
 import static org.apache.flink.table.store.file.FileStoreOptions.BUCKET;
 import static org.apache.flink.table.store.file.FileStoreOptions.FILE_PATH;
 import static org.apache.flink.table.store.file.FileStoreOptions.TABLE_STORE_PREFIX;
@@ -181,12 +180,6 @@ public class TableStoreFactoryTest {
                                 + "as `CREATE TABLE ${table} (...) WITH ('file.path' = '...')`");
     }
 
-    @ParameterizedTest
-    @MethodSource("providingEnrichedOptionsForChangeTracking")
-    public void testEnableChangeTracking(Map<String, String> options, boolean expected) {
-        assertThat(TableStoreFactory.enableChangeTracking(options)).isEqualTo(expected);
-    }
-
     // ~ Tools ------------------------------------------------------------------
 
     private static Stream<Arguments> providingOptions() {
@@ -240,7 +233,6 @@ public class TableStoreFactoryTest {
     private static Stream<Arguments> providingEnrichedOptionsForCreation() {
         Map<String, String> enrichedOptions = new HashMap<>();
         enrichedOptions.put(FILE_PATH.key(), sharedTempDir.toAbsolutePath().toString());
-        enrichedOptions.put(CHANGE_TRACKING.key(), String.valueOf(false));
         return Stream.of(
                 Arguments.of(enrichedOptions, false),
                 Arguments.of(enrichedOptions, true),
@@ -258,19 +250,10 @@ public class TableStoreFactoryTest {
         }
         Map<String, String> enrichedOptions = new HashMap<>();
         enrichedOptions.put(FILE_PATH.key(), sharedTempDir.toAbsolutePath().toString());
-        enrichedOptions.put(CHANGE_TRACKING.key(), String.valueOf(false));
         return Stream.of(
                 Arguments.of(enrichedOptions, false),
                 Arguments.of(enrichedOptions, true),
                 Arguments.of(enrichedOptions, false));
-    }
-
-    private static Stream<Arguments> providingEnrichedOptionsForChangeTracking() {
-        return Stream.of(
-                Arguments.of(Collections.emptyMap(), true),
-                Arguments.of(of(CHANGE_TRACKING.key(), "true"), true),
-                Arguments.of(of(CHANGE_TRACKING.key(), "false"), false),
-                Arguments.of(of(TABLE_STORE_PREFIX + CHANGE_TRACKING.key(), "false"), true));
     }
 
     private static Map<String, String> addPrefix(

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreTestBase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreTestBase.java
@@ -50,7 +50,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.apache.flink.table.store.connector.TableStoreFactoryOptions.CHANGE_TRACKING;
 import static org.apache.flink.table.store.connector.TableStoreFactoryOptions.LOG_SYSTEM;
 import static org.apache.flink.table.store.file.FileStoreOptions.FILE_PATH;
 import static org.apache.flink.table.store.file.FileStoreOptions.TABLE_STORE_PREFIX;
@@ -65,7 +64,7 @@ public abstract class TableStoreTestBase extends KafkaTableTestBase {
 
     protected final RuntimeExecutionMode executionMode;
     protected final ObjectIdentifier tableIdentifier;
-    protected final boolean enableChangeTracking;
+    protected final boolean enableLogStore;
     protected final ExpectedResult expectedResult;
 
     protected String rootPath;
@@ -73,11 +72,11 @@ public abstract class TableStoreTestBase extends KafkaTableTestBase {
     public TableStoreTestBase(
             RuntimeExecutionMode executionMode,
             String tableName,
-            boolean enableChangeTracking,
+            boolean enableLogStore,
             ExpectedResult expectedResult) {
         this.executionMode = executionMode;
         this.tableIdentifier = ObjectIdentifier.of(CURRENT_CATALOG, CURRENT_DATABASE, tableName);
-        this.enableChangeTracking = enableChangeTracking;
+        this.enableLogStore = enableLogStore;
         this.expectedResult = expectedResult;
     }
 
@@ -113,8 +112,9 @@ public abstract class TableStoreTestBase extends KafkaTableTestBase {
         configuration.setString(TABLE_STORE_PREFIX + FILE_PATH.key(), rootPath);
         configuration.setString(
                 TABLE_STORE_PREFIX + LOG_PREFIX + BOOTSTRAP_SERVERS.key(), getBootstrapServers());
-        configuration.setBoolean(TABLE_STORE_PREFIX + CHANGE_TRACKING.key(), enableChangeTracking);
-        configuration.setString(TABLE_STORE_PREFIX + LOG_SYSTEM.key(), "kafka");
+        if (enableLogStore) {
+            configuration.setString(TABLE_STORE_PREFIX + LOG_SYSTEM.key(), "kafka");
+        }
     }
 
     protected static ResolvedCatalogTable createResolvedTable(


### PR DESCRIPTION
Remove CHANGE_TRACKING, the default overwrite does not generate changes to the log system.
Add hint CHANGE_TRACKING=false is an unfriendly way to  to support overwrite, and by default overwrite does not generate changes, so users have to turn it off.
Later we have the ability to generate changes for overwrite, and then add an overwrite.change-tracking.mode to configure it.

