### PR TITLE
[FLINK-26753] PK constraint should include partition keys if table is partitioned

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStore.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStore.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.store.connector;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.Source;
@@ -128,6 +129,12 @@ public class TableStore {
     public List<String> partitionKeys() {
         RowType partitionType = TypeUtils.project(type, partitions);
         return partitionType.getFieldNames();
+    }
+
+    @VisibleForTesting
+    List<String> primaryKeys() {
+        RowType primaryKeyType = TypeUtils.project(type, primaryKeys);
+        return primaryKeyType.getFieldNames();
     }
 
     public Configuration logOptions() {

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStore.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStore.java
@@ -31,7 +31,6 @@ import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.transformations.PartitionTransformation;
-import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.catalog.CatalogLock;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.data.RowData;
@@ -54,16 +53,11 @@ import org.apache.flink.table.store.log.LogSourceProvider;
 import org.apache.flink.table.store.utils.TypeUtils;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -79,42 +73,45 @@ public class TableStore {
     private final Configuration options;
 
     /** commit user, default uuid. */
-    private final String user;
+    private String user = UUID.randomUUID().toString();
 
     /** partition keys, default no partition. */
-    private final int[] partitions;
+    private int[] partitions = new int[0];
 
     /** primary keys, default no key. */
-    private final int[] primaryKeys;
+    private int[] primaryKeys = new int[0];
 
-    /** physical row type. */
-    private final RowType type;
+    private RowType type;
 
-    private final ObjectIdentifier tableIdentifier;
+    private ObjectIdentifier tableIdentifier;
 
-    private TableStore(
-            Configuration options,
-            ObjectIdentifier tableIdentifier,
-            RowType type,
-            int[] partitions,
-            int[] primaryKeys,
-            String user) {
+    public TableStore(Configuration options) {
         this.options = options;
-        this.tableIdentifier = tableIdentifier;
-        this.type = type;
-        this.partitions = partitions;
-        this.primaryKeys = primaryKeys;
-        this.user = user;
     }
 
-    public TableStoreBuilder toBuilder() {
-        return new TableStoreBuilder()
-                .withConfiguration(options)
-                .withTableIdentifier(tableIdentifier)
-                .withSchema(type)
-                .withPrimaryKeys(primaryKeys())
-                .withPartitionKeys(partitionKeys())
-                .withUser(user);
+    public TableStore withUser(String user) {
+        this.user = user;
+        return this;
+    }
+
+    public TableStore withSchema(RowType type) {
+        this.type = type;
+        return this;
+    }
+
+    public TableStore withPartitions(int[] partitions) {
+        this.partitions = partitions;
+        return this;
+    }
+
+    public TableStore withPrimaryKeys(int[] primaryKeys) {
+        this.primaryKeys = primaryKeys;
+        return this;
+    }
+
+    public TableStore withTableIdentifier(ObjectIdentifier tableIdentifier) {
+        this.tableIdentifier = tableIdentifier;
+        return this;
     }
 
     public boolean partitioned() {
@@ -179,83 +176,6 @@ public class TableStore {
         }
         return new FileStoreImpl(
                 tableIdentifier, options, user, partitionType, keyType, valueType, mergeFunction);
-    }
-
-    // --------------------------------------------------------------------------------------------
-
-    /** A builder for constructing a immutable {@link TableStore}. */
-    public static final class TableStoreBuilder {
-
-        private Configuration options;
-        private ObjectIdentifier tableIdentifier;
-        private RowType type;
-
-        private List<String> primaryKeys = new ArrayList<>();
-        private List<String> partitionKeys = new ArrayList<>();
-        private String user = UUID.randomUUID().toString();
-
-        public TableStoreBuilder withConfiguration(Configuration options) {
-            this.options = options;
-            return this;
-        }
-
-        public TableStoreBuilder withTableIdentifier(ObjectIdentifier tableIdentifier) {
-            this.tableIdentifier = tableIdentifier;
-            return this;
-        }
-
-        public TableStoreBuilder withSchema(RowType type) {
-            this.type = type;
-            return this;
-        }
-
-        public TableStoreBuilder withPrimaryKeys(List<String> primaryKeys) {
-            this.primaryKeys = primaryKeys;
-            return this;
-        }
-
-        public TableStoreBuilder withPartitionKeys(List<String> partitionKeys) {
-            this.partitionKeys = partitionKeys;
-            return this;
-        }
-
-        public TableStoreBuilder withUser(String user) {
-            this.user = user;
-            return this;
-        }
-
-        public TableStore build() {
-            List<int[]> indices = adjustAndValidate();
-            return new TableStore(
-                    options, tableIdentifier, type, indices.get(0), indices.get(1), user);
-        }
-
-        private List<int[]> adjustAndValidate() {
-            if (primaryKeys.size() > 0 && partitionKeys.size() > 0) {
-                // primary keys must contain all partition keys if table is partitioned
-                Preconditions.checkState(
-                        new HashSet<>(primaryKeys).containsAll(partitionKeys),
-                        String.format(
-                                "Primary key constraint %s should include all partition fields %s",
-                                primaryKeys, partitionKeys));
-            }
-            Set<String> partFilter = new HashSet<>(partitionKeys);
-            int[] pks =
-                    primaryKeys.stream()
-                            .filter(pk -> !partFilter.contains(pk))
-                            .mapToInt(type.getFieldNames()::indexOf)
-                            .toArray();
-            if (pks.length == 0 && primaryKeys.size() > 0) {
-                throw new TableException(
-                        String.format(
-                                "Primary key constraint %s should not be same with partition fields %s,"
-                                        + " this will result in only one record in a partition",
-                                primaryKeys, partitionKeys));
-            }
-            // adjust index according to physical row type
-            return Arrays.asList(
-                    partitionKeys.stream().mapToInt(type.getFieldNames()::indexOf).toArray(), pks);
-        }
     }
 
     /** Source builder to build a flink {@link Source}. */

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreFactory.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreFactory.java
@@ -28,7 +28,6 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
-import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.factories.DynamicTableSinkFactory;
@@ -51,6 +50,8 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -58,7 +59,6 @@ import java.util.stream.Collectors;
 
 import static org.apache.flink.table.store.connector.TableStoreFactoryOptions.LOG_SYSTEM;
 import static org.apache.flink.table.store.file.FileStoreOptions.BUCKET;
-import static org.apache.flink.table.store.file.FileStoreOptions.FILE_PATH;
 import static org.apache.flink.table.store.file.FileStoreOptions.TABLE_STORE_PREFIX;
 import static org.apache.flink.table.store.log.LogOptions.CHANGELOG_MODE;
 import static org.apache.flink.table.store.log.LogOptions.CONSISTENCY;
@@ -88,7 +88,7 @@ public class TableStoreFactory
     @Override
     public void onCreateTable(Context context, boolean ignoreIfExists) {
         Map<String, String> options = context.getCatalogTable().getOptions();
-        Path path = tablePath(options, context.getObjectIdentifier());
+        Path path = FileStoreOptions.path(options, context.getObjectIdentifier());
         try {
             if (path.getFileSystem().exists(path) && !ignoreIfExists) {
                 throw new TableException(
@@ -125,7 +125,7 @@ public class TableStoreFactory
     @Override
     public void onDropTable(Context context, boolean ignoreIfNotExists) {
         Map<String, String> options = context.getCatalogTable().getOptions();
-        Path path = tablePath(options, context.getObjectIdentifier());
+        Path path = FileStoreOptions.path(options, context.getObjectIdentifier());
         try {
             if (path.getFileSystem().exists(path)) {
                 path.getFileSystem().delete(path, true);
@@ -241,42 +241,38 @@ public class TableStoreFactory
     }
 
     @VisibleForTesting
-    static Path tablePath(Map<String, String> options, ObjectIdentifier identifier) {
-        Preconditions.checkArgument(
-                options.containsKey(FILE_PATH.key()),
-                String.format(
-                        "Failed to create file store path. "
-                                + "Please specify a root dir by setting session level configuration "
-                                + "as `SET 'table-store.%s' = '...'`. "
-                                + "Alternatively, you can use a per-table root dir "
-                                + "as `CREATE TABLE ${table} (...) WITH ('%s' = '...')`",
-                        FILE_PATH.key(), FILE_PATH.key()));
-        return new Path(
-                options.get(FILE_PATH.key()),
-                String.format(
-                        "root/%s.catalog/%s.db/%s",
-                        identifier.getCatalogName(),
-                        identifier.getDatabaseName(),
-                        identifier.getObjectName()));
-    }
-
-    private TableStore buildTableStore(Context context) {
+    TableStore buildTableStore(Context context) {
         ResolvedCatalogTable catalogTable = context.getCatalogTable();
         ResolvedSchema schema = catalogTable.getResolvedSchema();
         RowType rowType = (RowType) schema.toPhysicalRowDataType().getLogicalType();
-        int[] primaryKeys = new int[0];
+        List<String> partitionKeys = catalogTable.getPartitionKeys();
+        int[] pkIndex = new int[0];
         if (schema.getPrimaryKey().isPresent()) {
-            primaryKeys =
+            List<String> pkCols = schema.getPrimaryKey().get().getColumns();
+            Preconditions.checkState(
+                    new HashSet<>(pkCols).containsAll(partitionKeys),
+                    String.format(
+                            "Primary key constraint %s should include partition key %s",
+                            pkCols, partitionKeys));
+            Set<String> partFilter = new HashSet<>(partitionKeys);
+            pkIndex =
                     schema.getPrimaryKey().get().getColumns().stream()
+                            .filter(pk -> !partFilter.contains(pk))
                             .mapToInt(rowType.getFieldNames()::indexOf)
                             .toArray();
+            if (pkIndex.length == 0) {
+                throw new TableException(
+                        String.format(
+                                "Primary key constraint %s should not be same with partition key %s",
+                                pkCols, partitionKeys));
+            }
         }
         return new TableStore(Configuration.fromMap(catalogTable.getOptions()))
                 .withTableIdentifier(context.getObjectIdentifier())
                 .withSchema(rowType)
-                .withPrimaryKeys(primaryKeys)
+                .withPrimaryKeys(pkIndex)
                 .withPartitions(
-                        catalogTable.getPartitionKeys().stream()
+                        partitionKeys.stream()
                                 .mapToInt(rowType.getFieldNames()::indexOf)
                                 .toArray());
     }

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreFactory.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreFactory.java
@@ -44,13 +44,12 @@ import org.apache.flink.table.store.log.LogOptions.LogConsistency;
 import org.apache.flink.table.store.log.LogOptions.LogStartupMode;
 import org.apache.flink.table.store.log.LogStoreTableFactory;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -244,36 +243,14 @@ public class TableStoreFactory
     TableStore buildTableStore(Context context) {
         ResolvedCatalogTable catalogTable = context.getCatalogTable();
         ResolvedSchema schema = catalogTable.getResolvedSchema();
-        RowType rowType = (RowType) schema.toPhysicalRowDataType().getLogicalType();
-        List<String> partitionKeys = catalogTable.getPartitionKeys();
-        int[] pkIndex = new int[0];
-        if (schema.getPrimaryKey().isPresent()) {
-            List<String> pkCols = schema.getPrimaryKey().get().getColumns();
-            Preconditions.checkState(
-                    new HashSet<>(pkCols).containsAll(partitionKeys),
-                    String.format(
-                            "Primary key constraint %s should include partition key %s",
-                            pkCols, partitionKeys));
-            Set<String> partFilter = new HashSet<>(partitionKeys);
-            pkIndex =
-                    schema.getPrimaryKey().get().getColumns().stream()
-                            .filter(pk -> !partFilter.contains(pk))
-                            .mapToInt(rowType.getFieldNames()::indexOf)
-                            .toArray();
-            if (pkIndex.length == 0) {
-                throw new TableException(
-                        String.format(
-                                "Primary key constraint %s should not be same with partition key %s",
-                                pkCols, partitionKeys));
-            }
-        }
-        return new TableStore(Configuration.fromMap(catalogTable.getOptions()))
+        List<String> primaryKeys = new ArrayList<>();
+        schema.getPrimaryKey().ifPresent((pk) -> primaryKeys.addAll(pk.getColumns()));
+        return new TableStore.TableStoreBuilder()
+                .withConfiguration(Configuration.fromMap(catalogTable.getOptions()))
                 .withTableIdentifier(context.getObjectIdentifier())
-                .withSchema(rowType)
-                .withPrimaryKeys(pkIndex)
-                .withPartitions(
-                        partitionKeys.stream()
-                                .mapToInt(rowType.getFieldNames()::indexOf)
-                                .toArray());
+                .withSchema((RowType) schema.toSourceRowDataType().getLogicalType())
+                .withPrimaryKeys(primaryKeys)
+                .withPartitionKeys(catalogTable.getPartitionKeys())
+                .build();
     }
 }

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreFactory.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreFactory.java
@@ -44,13 +44,11 @@ import org.apache.flink.table.store.log.LogOptions.LogConsistency;
 import org.apache.flink.table.store.log.LogOptions.LogStartupMode;
 import org.apache.flink.table.store.log.LogStoreTableFactory;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -248,24 +246,10 @@ public class TableStoreFactory
         List<String> partitionKeys = catalogTable.getPartitionKeys();
         int[] pkIndex = new int[0];
         if (schema.getPrimaryKey().isPresent()) {
-            List<String> pkCols = schema.getPrimaryKey().get().getColumns();
-            Preconditions.checkState(
-                    new HashSet<>(pkCols).containsAll(partitionKeys),
-                    String.format(
-                            "Primary key constraint %s should include partition key %s",
-                            pkCols, partitionKeys));
-            Set<String> partFilter = new HashSet<>(partitionKeys);
             pkIndex =
                     schema.getPrimaryKey().get().getColumns().stream()
-                            .filter(pk -> !partFilter.contains(pk))
                             .mapToInt(rowType.getFieldNames()::indexOf)
                             .toArray();
-            if (pkIndex.length == 0) {
-                throw new TableException(
-                        String.format(
-                                "Primary key constraint %s should not be same with partition key %s",
-                                pkCols, partitionKeys));
-            }
         }
         return new TableStore(Configuration.fromMap(catalogTable.getOptions()))
                 .withTableIdentifier(context.getObjectIdentifier())

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/CreateTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/CreateTableITCase.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
+import org.apache.flink.table.store.file.FileStoreOptions;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
@@ -78,7 +79,9 @@ public class CreateTableITCase extends TableStoreTestBase {
             assertThat(((TableEnvironmentImpl) tEnv).getCatalogManager().getTable(tableIdentifier))
                     .isPresent();
             // check table store
-            assertThat(Paths.get(rootPath, getRelativeFileStoreTablePath(tableIdentifier)).toFile())
+            assertThat(
+                            Paths.get(rootPath, FileStoreOptions.relativeTablePath(tableIdentifier))
+                                    .toFile())
                     .exists();
             // check log store
             assertThat(topicExists(tableIdentifier.asSummaryString())).isEqualTo(enableLogStore);
@@ -128,7 +131,9 @@ public class CreateTableITCase extends TableStoreTestBase {
             }
         } else if (expectedResult.expectedMessage.startsWith("Failed to create file store path.")) {
             // failed when creating file store
-            Paths.get(rootPath, getRelativeFileStoreTablePath(tableIdentifier)).toFile().mkdirs();
+            Paths.get(rootPath, FileStoreOptions.relativeTablePath(tableIdentifier))
+                    .toFile()
+                    .mkdirs();
         } else if (expectedResult.expectedMessage.startsWith("Failed to create kafka topic.")) {
             // failed when creating log store
             createTopicIfNotExists(tableIdentifier.asSummaryString(), BUCKET.defaultValue());

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/DropTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/DropTableITCase.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.api.internal.TableEnvironmentImpl;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
+import org.apache.flink.table.store.file.FileStoreOptions;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
@@ -79,7 +80,9 @@ public class DropTableITCase extends TableStoreTestBase {
             assertThat(((TableEnvironmentImpl) tEnv).getCatalogManager().getTable(tableIdentifier))
                     .isNotPresent();
             // check table store
-            assertThat(Paths.get(rootPath, getRelativeFileStoreTablePath(tableIdentifier)).toFile())
+            assertThat(
+                            Paths.get(rootPath, FileStoreOptions.relativeTablePath(tableIdentifier))
+                                    .toFile())
                     .doesNotExist();
             // check log store
             assertThat(topicExists(tableIdentifier.asSummaryString())).isFalse();

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileStoreITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileStoreITCase.java
@@ -98,7 +98,7 @@ public class FileStoreITCase extends AbstractTestBase {
 
     private final StreamExecutionEnvironment env;
 
-    private TableStore store;
+    private final TableStore store;
 
     public FileStoreITCase(boolean isBatch) throws IOException {
         this.isBatch = isBatch;
@@ -117,11 +117,7 @@ public class FileStoreITCase extends AbstractTestBase {
 
     @Test
     public void testPartitioned() throws Exception {
-        store =
-                store.toBuilder()
-                        .withPartitionKeys(Collections.singletonList("p"))
-                        .withPrimaryKeys(Arrays.asList("p", "_k"))
-                        .build();
+        store.withPartitions(new int[] {1});
 
         // write
         store.sinkBuilder().withInput(buildTestSource(env, isBatch)).build();
@@ -140,11 +136,7 @@ public class FileStoreITCase extends AbstractTestBase {
 
     @Test
     public void testNonPartitioned() throws Exception {
-        store =
-                store.toBuilder()
-                        .withPartitionKeys(Collections.emptyList())
-                        .withPrimaryKeys(Collections.singletonList("_k"))
-                        .build();
+        store.withPartitions(new int[0]);
 
         // write
         store.sinkBuilder().withInput(buildTestSource(env, isBatch)).build();
@@ -161,11 +153,7 @@ public class FileStoreITCase extends AbstractTestBase {
     @Test
     public void testOverwrite() throws Exception {
         Assume.assumeTrue(isBatch);
-        store =
-                store.toBuilder()
-                        .withPartitionKeys(Collections.singletonList("p"))
-                        .withPrimaryKeys(Arrays.asList("p", "_k"))
-                        .build();
+        store.withPartitions(new int[] {1});
 
         // write
         store.sinkBuilder().withInput(buildTestSource(env, isBatch)).build();
@@ -205,11 +193,7 @@ public class FileStoreITCase extends AbstractTestBase {
 
     @Test
     public void testPartitionedNonKey() throws Exception {
-        store =
-                store.toBuilder()
-                        .withPartitionKeys(Collections.singletonList("p"))
-                        .withPrimaryKeys(Collections.emptyList())
-                        .build();
+        store.withPartitions(new int[] {1}).withPrimaryKeys(new int[0]);
 
         // write
         store.sinkBuilder().withInput(buildTestSource(env, isBatch)).build();
@@ -230,13 +214,13 @@ public class FileStoreITCase extends AbstractTestBase {
 
     @Test
     public void testContinuous() throws Exception {
-        store = store.toBuilder().withPrimaryKeys(Collections.singletonList("_k")).build();
+        store.withPrimaryKeys(new int[] {2});
         innerTestContinuous();
     }
 
     @Test
     public void testContinuousWithoutPK() throws Exception {
-        store = store.toBuilder().withPrimaryKeys(Collections.emptyList()).build();
+        store.withPrimaryKeys(new int[0]);
         innerTestContinuous();
     }
 
@@ -317,12 +301,10 @@ public class FileStoreITCase extends AbstractTestBase {
 
     public static TableStore buildTableStore(boolean noFail, TemporaryFolder temporaryFolder)
             throws IOException {
-        return new TableStore.TableStoreBuilder()
-                .withConfiguration(buildConfiguration(noFail, temporaryFolder.newFolder()))
+        return new TableStore(buildConfiguration(noFail, temporaryFolder.newFolder()))
                 .withSchema(TABLE_TYPE)
-                .withPrimaryKeys(Collections.singletonList("_k"))
-                .withTableIdentifier(ObjectIdentifier.of("catalog", "db", "t"))
-                .build();
+                .withPrimaryKeys(new int[] {2})
+                .withTableIdentifier(ObjectIdentifier.of("catalog", "db", "t"));
     }
 
     public static Configuration buildConfiguration(boolean noFail, File folder) {

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileStoreITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileStoreITCase.java
@@ -117,7 +117,7 @@ public class FileStoreITCase extends AbstractTestBase {
 
     @Test
     public void testPartitioned() throws Exception {
-        store.withPartitions(new int[] {1});
+        store.withPrimaryKeys(new int[] {1, 2}).withPartitions(new int[] {1});
 
         // write
         store.sinkBuilder().withInput(buildTestSource(env, isBatch)).build();
@@ -153,7 +153,7 @@ public class FileStoreITCase extends AbstractTestBase {
     @Test
     public void testOverwrite() throws Exception {
         Assume.assumeTrue(isBatch);
-        store.withPartitions(new int[] {1});
+        store.withPrimaryKeys(new int[] {1, 2}).withPartitions(new int[] {1});
 
         // write
         store.sinkBuilder().withInput(buildTestSource(env, isBatch)).build();
@@ -193,7 +193,7 @@ public class FileStoreITCase extends AbstractTestBase {
 
     @Test
     public void testPartitionedNonKey() throws Exception {
-        store.withPartitions(new int[] {1}).withPrimaryKeys(new int[0]);
+        store.withPrimaryKeys(new int[0]).withPartitions(new int[] {1});
 
         // write
         store.sinkBuilder().withInput(buildTestSource(env, isBatch)).build();

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ReadWriteTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ReadWriteTableITCase.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.store.connector;
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.planner.runtime.utils.TestData;
+import org.apache.flink.table.store.file.FileStoreOptions;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 
@@ -86,7 +87,7 @@ public class ReadWriteTableITCase extends TableStoreTestBase {
                 }
             }
             assertThat(actual).containsExactlyInAnyOrderElementsOf(expectedResult.expectedRecords);
-            String relativeFilePath = getRelativeFileStoreTablePath(tableIdentifier);
+            String relativeFilePath = FileStoreOptions.relativeTablePath(tableIdentifier);
             // check snapshot file path
             assertThat(Paths.get(rootPath, relativeFilePath, "snapshot")).exists();
             // check manifest file path

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreFactoryTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreFactoryTest.java
@@ -291,7 +291,7 @@ public class TableStoreFactoryTest {
                                 .success(false)
                                 .expectedType(IllegalStateException.class)
                                 .expectedMessage(
-                                        "Primary key constraint [shopId] should include all partition fields [dt, hr]"));
+                                        "Primary key constraint [shopId] should include partition key [dt, hr]"));
 
         // failed case: pk is same as partition key
         Arguments arg2 =
@@ -303,8 +303,7 @@ public class TableStoreFactoryTest {
                                 .success(false)
                                 .expectedType(TableException.class)
                                 .expectedMessage(
-                                        "Primary key constraint [dt, hr, shopId] should not be same with partition fields [dt, hr, shopId],"
-                                                + " this will result in only one record in a partition"));
+                                        "Primary key constraint [dt, hr, shopId] should not be same with partition key [dt, hr, shopId]"));
 
         return Stream.of(arg0, arg1, arg2);
     }

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreFactoryTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreFactoryTest.java
@@ -291,7 +291,7 @@ public class TableStoreFactoryTest {
                                 .success(false)
                                 .expectedType(IllegalStateException.class)
                                 .expectedMessage(
-                                        "Primary key constraint [shopId] should include partition key [dt, hr]"));
+                                        "Primary key constraint [shopId] should include all partition fields [dt, hr]"));
 
         // failed case: pk is same as partition key
         Arguments arg2 =
@@ -301,9 +301,10 @@ public class TableStoreFactoryTest {
                         new int[] {0, 1, 2}, // pk is [dt, hr, shopId]
                         new TableStoreTestBase.ExpectedResult()
                                 .success(false)
-                                .expectedType(TableException.class)
+                                .expectedType(IllegalStateException.class)
                                 .expectedMessage(
-                                        "Primary key constraint [dt, hr, shopId] should not be same with partition key [dt, hr, shopId]"));
+                                        "Primary key constraint [dt, hr, shopId] should not be same with partition fields [dt, hr, shopId],"
+                                                + " this will result in only one record in a partition"));
 
         return Stream.of(arg0, arg1, arg2);
     }

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreFactoryTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreFactoryTest.java
@@ -27,8 +27,9 @@ import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.factories.DynamicTableFactory;
 import org.apache.flink.table.factories.FactoryUtil;
-import org.apache.flink.table.factories.ManagedTableFactory;
+import org.apache.flink.table.store.file.TestKeyValueGenerator;
 import org.apache.flink.table.store.log.LogOptions;
+import org.apache.flink.table.types.logical.RowType;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -39,15 +40,19 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import static org.apache.flink.table.store.connector.TableStoreTestBase.createResolvedTable;
 import static org.apache.flink.table.store.file.FileStoreOptions.BUCKET;
 import static org.apache.flink.table.store.file.FileStoreOptions.FILE_PATH;
 import static org.apache.flink.table.store.file.FileStoreOptions.TABLE_STORE_PREFIX;
+import static org.apache.flink.table.store.file.FileStoreOptions.relativeTablePath;
 import static org.apache.flink.table.store.kafka.KafkaLogOptions.BOOTSTRAP_SERVERS;
 import static org.apache.flink.table.store.log.LogOptions.CONSISTENCY;
 import static org.apache.flink.table.store.log.LogOptions.LOG_PREFIX;
@@ -60,7 +65,7 @@ public class TableStoreFactoryTest {
     private static final ObjectIdentifier TABLE_IDENTIFIER =
             ObjectIdentifier.of("catalog", "database", "table");
 
-    private final ManagedTableFactory tableStoreFactory = new TableStoreFactory();
+    private final TableStoreFactory tableStoreFactory = new TableStoreFactory();
 
     @TempDir private static java.nio.file.Path sharedTempDir;
     private DynamicTableFactory.Context context;
@@ -84,11 +89,7 @@ public class TableStoreFactoryTest {
         Path expectedPath =
                 Paths.get(
                         sharedTempDir.toAbsolutePath().toString(),
-                        String.format(
-                                "root/%s.catalog/%s.db/%s",
-                                TABLE_IDENTIFIER.getCatalogName(),
-                                TABLE_IDENTIFIER.getDatabaseName(),
-                                TABLE_IDENTIFIER.getObjectName()));
+                        relativeTablePath(TABLE_IDENTIFIER));
         boolean exist = expectedPath.toFile().exists();
         if (ignoreIfExists || !exist) {
             tableStoreFactory.onCreateTable(context, ignoreIfExists);
@@ -119,11 +120,7 @@ public class TableStoreFactoryTest {
         Path expectedPath =
                 Paths.get(
                         sharedTempDir.toAbsolutePath().toString(),
-                        String.format(
-                                "root/%s.catalog/%s.db/%s",
-                                TABLE_IDENTIFIER.getCatalogName(),
-                                TABLE_IDENTIFIER.getDatabaseName(),
-                                TABLE_IDENTIFIER.getObjectName()));
+                        relativeTablePath(TABLE_IDENTIFIER));
         boolean exist = expectedPath.toFile().exists();
         if (exist || ignoreIfNotExists) {
             tableStoreFactory.onDropTable(context, ignoreIfNotExists);
@@ -161,23 +158,41 @@ public class TableStoreFactoryTest {
                 .containsExactlyInAnyOrderEntriesOf(expectedLogOptions);
     }
 
-    @Test
-    public void testTablePath() {
-        Map<String, String> options = of(FILE_PATH.key(), "dummy:/foo/bar");
-        assertThat(TableStoreFactory.tablePath(options, TABLE_IDENTIFIER))
-                .isEqualTo(
-                        new org.apache.flink.core.fs.Path(
-                                "dummy:/foo/bar/root/catalog.catalog/database.db/table"));
+    @ParameterizedTest
+    @MethodSource("providingResolvedTable")
+    public void testBuildTableStore(
+            RowType rowType,
+            List<String> partitions,
+            int[] pkIndex,
+            TableStoreTestBase.ExpectedResult expectedResult) {
+        ResolvedCatalogTable catalogTable =
+                createResolvedTable(Collections.emptyMap(), rowType, partitions, pkIndex);
+        context =
+                new FactoryUtil.DefaultDynamicTableContext(
+                        TABLE_IDENTIFIER,
+                        catalogTable,
+                        Collections.emptyMap(),
+                        Configuration.fromMap(Collections.emptyMap()),
+                        Thread.currentThread().getContextClassLoader(),
+                        false);
+        if (expectedResult.success) {
+            TableStore tableStore = tableStoreFactory.buildTableStore(context);
+            assertThat(tableStore.partitioned()).isEqualTo(catalogTable.isPartitioned());
+            assertThat(tableStore.valueCountMode())
+                    .isEqualTo(catalogTable.getResolvedSchema().getPrimaryKeyIndexes().length == 0);
 
-        assertThatThrownBy(
-                        () -> TableStoreFactory.tablePath(Collections.emptyMap(), TABLE_IDENTIFIER))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining(
-                        "Failed to create file store path. "
-                                + "Please specify a root dir by setting session level configuration "
-                                + "as `SET 'table-store.file.path' = '...'`. "
-                                + "Alternatively, you can use a per-table root dir "
-                                + "as `CREATE TABLE ${table} (...) WITH ('file.path' = '...')`");
+            // check primary key doesn't contain partition
+            if (tableStore.partitioned() && !tableStore.valueCountMode()) {
+                assertThat(
+                                tableStore.primaryKeys().stream()
+                                        .noneMatch(pk -> tableStore.partitionKeys().contains(pk)))
+                        .isTrue();
+            }
+        } else {
+            assertThatThrownBy(() -> tableStoreFactory.buildTableStore(context))
+                    .isInstanceOf(expectedResult.expectedType)
+                    .hasMessageContaining(expectedResult.expectedMessage);
+        }
     }
 
     // ~ Tools ------------------------------------------------------------------
@@ -254,6 +269,43 @@ public class TableStoreFactoryTest {
                 Arguments.of(enrichedOptions, false),
                 Arguments.of(enrichedOptions, true),
                 Arguments.of(enrichedOptions, false));
+    }
+
+    private static Stream<Arguments> providingResolvedTable() {
+        RowType rowType = TestKeyValueGenerator.ROW_TYPE;
+        // success case
+        Arguments arg0 =
+                Arguments.of(
+                        rowType,
+                        Arrays.asList("dt", "hr"),
+                        new int[] {0, 1, 2}, // pk is [dt, hr, shopId]
+                        new TableStoreTestBase.ExpectedResult().success(true));
+
+        // failed case: pk doesn't contain partition key
+        Arguments arg1 =
+                Arguments.of(
+                        rowType,
+                        Arrays.asList("dt", "hr"),
+                        new int[] {2}, // pk is [shopId]
+                        new TableStoreTestBase.ExpectedResult()
+                                .success(false)
+                                .expectedType(IllegalStateException.class)
+                                .expectedMessage(
+                                        "Primary key constraint [shopId] should include partition key [dt, hr]"));
+
+        // failed case: pk is same as partition key
+        Arguments arg2 =
+                Arguments.of(
+                        rowType,
+                        Arrays.asList("dt", "hr", "shopId"),
+                        new int[] {0, 1, 2}, // pk is [dt, hr, shopId]
+                        new TableStoreTestBase.ExpectedResult()
+                                .success(false)
+                                .expectedType(TableException.class)
+                                .expectedMessage(
+                                        "Primary key constraint [dt, hr, shopId] should not be same with partition key [dt, hr, shopId]"));
+
+        return Stream.of(arg0, arg1, arg2);
     }
 
     private static Map<String, String> addPrefix(

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreFactoryTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreFactoryTest.java
@@ -291,7 +291,7 @@ public class TableStoreFactoryTest {
                                 .success(false)
                                 .expectedType(IllegalStateException.class)
                                 .expectedMessage(
-                                        "Primary key constraint [shopId] should include partition key [dt, hr]"));
+                                        "Primary key constraint [shopId] should include all partition fields [dt, hr]"));
 
         // failed case: pk is same as partition key
         Arguments arg2 =
@@ -303,7 +303,8 @@ public class TableStoreFactoryTest {
                                 .success(false)
                                 .expectedType(TableException.class)
                                 .expectedMessage(
-                                        "Primary key constraint [dt, hr, shopId] should not be same with partition key [dt, hr, shopId]"));
+                                        "Primary key constraint [dt, hr, shopId] should not be same with partition fields [dt, hr, shopId],"
+                                                + " this will result in only one record in a partition"));
 
         return Stream.of(arg0, arg1, arg2);
     }

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreTestBase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreTestBase.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.UniqueConstraint;
+import org.apache.flink.table.store.file.FileStoreOptions;
 import org.apache.flink.table.store.kafka.KafkaTableTestBase;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
@@ -146,15 +147,7 @@ public abstract class TableStoreTestBase extends KafkaTableTestBase {
 
     protected void deleteTablePath() {
         FileUtils.deleteQuietly(
-                Paths.get(rootPath, getRelativeFileStoreTablePath(tableIdentifier)).toFile());
-    }
-
-    protected static String getRelativeFileStoreTablePath(ObjectIdentifier tableIdentifier) {
-        return String.format(
-                "root/%s.catalog/%s.db/%s",
-                tableIdentifier.getCatalogName(),
-                tableIdentifier.getDatabaseName(),
-                tableIdentifier.getObjectName());
+                Paths.get(rootPath, FileStoreOptions.relativeTablePath(tableIdentifier)).toFile());
     }
 
     /** Expected result wrapper. */

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/LogStoreSinkITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/LogStoreSinkITCase.java
@@ -33,7 +33,6 @@ import org.apache.flink.types.Row;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -93,11 +92,11 @@ public class LogStoreSinkITCase extends KafkaTableTestBase {
         // in eventual mode, failure will result in duplicate data
         TableStore store = buildTableStore(isBatch || !transaction, TEMPORARY_FOLDER);
         if (partitioned) {
-            store = store.toBuilder().withPartitionKeys(Collections.singletonList("p")).build();
+            store.withPartitions(new int[] {1});
         }
 
         if (!keyed) {
-            store = store.toBuilder().withPrimaryKeys(Collections.singletonList("v")).build();
+            store.withPrimaryKeys(new int[0]);
         }
 
         // prepare log

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/LogStoreSinkITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/LogStoreSinkITCase.java
@@ -33,6 +33,7 @@ import org.apache.flink.types.Row;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -92,11 +93,11 @@ public class LogStoreSinkITCase extends KafkaTableTestBase {
         // in eventual mode, failure will result in duplicate data
         TableStore store = buildTableStore(isBatch || !transaction, TEMPORARY_FOLDER);
         if (partitioned) {
-            store.withPartitions(new int[] {1});
+            store = store.toBuilder().withPartitionKeys(Collections.singletonList("p")).build();
         }
 
         if (!keyed) {
-            store.withPrimaryKeys(new int[0]);
+            store = store.toBuilder().withPrimaryKeys(Collections.singletonList("v")).build();
         }
 
         // prepare log


### PR DESCRIPTION
* Add check on pk and partition key, and filter partition keys when computing pk index
* Redefine table path as '${file.path}/${cat}.catalog/${db}.db/${table}'