### PR TITLE
[FLINK-26860] FileStore continuous bug for delete row kind records

### DIFF
--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ReadWriteTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ReadWriteTableITCase.java
@@ -111,16 +111,6 @@ public class ReadWriteTableITCase extends KafkaTableTestBase {
         collectAndCheck(tEnv, managedTable, Collections.emptyMap(), expectedRecords).close();
         checkFileStorePath(tEnv, managedTable);
 
-        // test batch read with latest-scan
-        collectAndCheck(
-                        tEnv,
-                        managedTable,
-                        Collections.singletonMap(
-                                LogOptions.SCAN.key(),
-                                LogOptions.LogStartupMode.LATEST.name().toLowerCase()),
-                        Collections.emptyList())
-                .close();
-
         // overwrite dynamic partition
         prepareEnvAndOverwrite(
                 managedTable,
@@ -375,7 +365,8 @@ public class ReadWriteTableITCase extends KafkaTableTestBase {
         List<Row> expectedRecords = Collections.emptyList();
         try {
             // set expectation size to 1 to let time pass by until timeout
-            expectedRecords = iterator.collect(1, 1L, TimeUnit.MINUTES);
+            // just wait 5s to avoid too long time
+            expectedRecords = iterator.collect(1, 5L, TimeUnit.SECONDS);
             iterator.close();
         } catch (Exception ignored) {
             // don't throw exception

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ReadWriteTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ReadWriteTableITCase.java
@@ -221,20 +221,9 @@ public class ReadWriteTableITCase extends KafkaTableTestBase {
         assertNoMoreRecords(streamIter);
     }
 
-    @Ignore("file store continuous read is failed, actual has size 1")
     @Test
     public void testDisableLogAndStreamingReadWritePartitionedRecordsWithPk() throws Exception {
         String managedTable = prepareEnvAndWrite(true, false, true, true);
-
-        // disable log store and read from latest
-        collectAndCheck(
-                        tEnv,
-                        managedTable,
-                        Collections.singletonMap(
-                                LogOptions.SCAN.key(),
-                                LogOptions.LogStartupMode.LATEST.name().toLowerCase()),
-                        Collections.emptyList())
-                .close();
 
         // input is dailyRatesChangelogWithoutUB()
         // file store continuous read

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ReadWriteTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ReadWriteTableITCase.java
@@ -29,7 +29,6 @@ import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.store.file.FileStoreOptions;
 import org.apache.flink.table.store.file.utils.BlockingIterator;
 import org.apache.flink.table.store.kafka.KafkaTableTestBase;
-import org.apache.flink.table.store.log.LogOptions;
 import org.apache.flink.types.Row;
 
 import org.junit.Ignore;

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/BlockingIterator.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/BlockingIterator.java
@@ -88,7 +88,7 @@ public class BlockingIterator<IN, OUT> implements AutoCloseable {
 
     private List<OUT> doCollect(int limit) {
         if (limit == 0) {
-            return Collections.emptyList();
+            throw new RuntimeException("Collect zero record is meaningless.");
         }
 
         List<OUT> result = new ArrayList<>();

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/BlockingIterator.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/BlockingIterator.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.store.file.utils;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ExecutionException;


### PR DESCRIPTION
Bug in FileStoreSourceSplitReader, the row is reused, we can not just modify the row kind. We should set back to insert kind before next keyvalue.

