### PR TITLE
[FLINK-26867] Hybrid reading wrong because of disordered commits

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/global/AbstractCommitterOperator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/global/AbstractCommitterOperator.java
@@ -111,9 +111,9 @@ public abstract class AbstractCommitterOperator<IN, CommT>
     @Override
     public void endInput() throws Exception {
         // Suppose the last checkpoint before endInput is 5. Flink Streaming Job calling order:
-        // 1. Accept elements from upstream prepareSnapshotPreBarrier(5)
+        // 1. Receives elements from upstream prepareSnapshotPreBarrier(5)
         // 2. this.snapshotState(5)
-        // 3. Accept elements from upstream endInput
+        // 3. Receives elements from upstream endInput
         // 4. this.endInput
         // 5. this.notifyCheckpointComplete(5)
         // So we should submit all the data in the endInput in order to avoid disordered commits.

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/LogHybridSourceFactory.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/LogHybridSourceFactory.java
@@ -44,8 +44,7 @@ public class LogHybridSourceFactory
         Snapshot snapshot = enumerator.snapshot();
         Map<Integer, Long> logOffsets = null;
         if (snapshot != null) {
-            // TODO
-            // logOffsets = snapshot.getLogOffsets();
+            logOffsets = snapshot.getLogOffsets();
         }
         return provider.createSource(logOffsets);
     }

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ReadWriteTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ReadWriteTableITCase.java
@@ -31,7 +31,6 @@ import org.apache.flink.table.store.file.utils.BlockingIterator;
 import org.apache.flink.table.store.kafka.KafkaTableTestBase;
 import org.apache.flink.types.Row;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.nio.file.Paths;
@@ -168,7 +167,6 @@ public class ReadWriteTableITCase extends KafkaTableTestBase {
         checkFileStorePath(tEnv, managedTable);
     }
 
-    @Ignore("changelog case is failed")
     @Test
     public void testEnableLogAndStreamingReadWritePartitionedRecordsWithPk() throws Exception {
         String managedTable = prepareEnvAndWrite(true, true, true, true);

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/log/LogWriteCallback.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/log/LogWriteCallback.java
@@ -38,7 +38,8 @@ public class LogWriteCallback implements WriteCallback {
             acc = offsetMap.computeIfAbsent(bucket, k -> new LongAccumulator(Long::max, 0));
         } // else lock free
 
-        // Save the next offset
+        // Save the next offset, what we need to provide to the hybrid reading is the starting
+        // offset of the next transaction
         acc.accumulate(offset + 1);
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/log/LogWriteCallback.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/log/LogWriteCallback.java
@@ -37,7 +37,9 @@ public class LogWriteCallback implements WriteCallback {
             // computeIfAbsent will lock on the key
             acc = offsetMap.computeIfAbsent(bucket, k -> new LongAccumulator(Long::max, 0));
         } // else lock free
-        acc.accumulate(offset);
+
+        // Save the next offset
+        acc.accumulate(offset + 1);
     }
 
     public Map<Integer, Long> offsets() {


### PR DESCRIPTION
In AbstractCommitterOperator.endInput:

Suppose the last checkpoint before endInput is 5. Flink Streaming Job calling order:
1. Accept elements from upstream prepareSnapshotPreBarrier(5)
2. this.snapshotState(5)
3. Accept elements from upstream endInput
4. this.endInput
5. this.notifyCheckpointComplete(5)
So we should submit all the data in the endInput in order to avoid disordered commits.