### PR TITLE
[FLINK-27004] Use '<format>.<option>' instead of 'file.<format>.<option>' in table properties of managed table

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/format/FileFormat.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/format/FileFormat.java
@@ -33,7 +33,6 @@ import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.expressions.ResolvedExpression;
-import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.store.file.stats.FileStatsExtractor;
 import org.apache.flink.table.types.DataType;
@@ -105,8 +104,8 @@ public abstract class FileFormat {
             Configuration tableOptions,
             ConfigOption<String> formatOption) {
         String formatIdentifier = tableOptions.get(formatOption);
-        String formatPrefix = FactoryUtil.getFormatPrefix(formatOption, formatIdentifier);
-        ReadableConfig formatOptions = new DelegatingConfiguration(tableOptions, formatPrefix);
+        ReadableConfig formatOptions =
+                new DelegatingConfiguration(tableOptions, formatIdentifier + ".");
         return fromIdentifier(classLoader, formatIdentifier, formatOptions);
     }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/FileFormatTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/FileFormatTest.java
@@ -42,7 +42,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.flink.table.factories.FactoryUtil.FORMAT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link FileFormatImpl}. */
@@ -100,8 +99,9 @@ public class FileFormatTest {
 
     public FileFormat createFileFormat(String codec) {
         Configuration tableOptions = new Configuration();
-        tableOptions.set(FORMAT, "avro");
+        tableOptions.set(FileStoreOptions.FILE_FORMAT, "avro");
         tableOptions.setString("avro.codec", codec);
-        return FileFormat.fromTableOptions(this.getClass().getClassLoader(), tableOptions, FORMAT);
+        return FileFormat.fromTableOptions(
+                this.getClass().getClassLoader(), tableOptions, FileStoreOptions.FILE_FORMAT);
     }
 }


### PR DESCRIPTION
Currently if we want to set compression method of file store we need to use 'file.orc.compress'. It would be better to use 'orc.compress' directly, just like what we do for filesystem connectors.