### PR TITLE
[FLINK-27085] Introduce snapshot.num-retained.min option

### DIFF
--- a/docs/content/docs/development/write-table.md
+++ b/docs/content/docs/development/write-table.md
@@ -142,7 +142,14 @@ to eliminate expired snapshots:
       <td>The maximum time of completed snapshots to retain.</td>
     </tr>
     <tr>
-      <td><h5>snapshot.num-retained</h5></td>
+      <td><h5>snapshot.num-retained.min</h5></td>
+      <td>No</td>
+      <td style="word-wrap: break-word;">10</td>
+      <td>Integer</td>
+      <td>The minimum number of completed snapshots to retain.</td>
+    </tr>
+    <tr>
+      <td><h5>snapshot.num-retained.max</h5></td>
       <td>No</td>
       <td style="word-wrap: break-word;">Integer.MAX_VALUE</td>
       <td>Integer</td>

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreImpl.java
@@ -135,7 +135,8 @@ public class FileStoreImpl implements FileStore {
     @Override
     public FileStoreExpireImpl newExpire() {
         return new FileStoreExpireImpl(
-                options.snapshotNumRetain(),
+                options.snapshotNumRetainMin(),
+                options.snapshotNumRetainMax(),
                 options.snapshotTimeRetain().toMillis(),
                 pathFactory(),
                 manifestFileFactory(),

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -122,9 +122,11 @@ public class TestFileStore extends FileStoreImpl {
         this.valueSerializer = new RowDataSerializer(valueType);
     }
 
-    public FileStoreExpireImpl newExpire(int numRetained, long millisRetained) {
+    public FileStoreExpireImpl newExpire(
+            int numRetainedMin, int numRetainedMax, long millisRetained) {
         return new FileStoreExpireImpl(
-                numRetained,
+                numRetainedMin,
+                numRetainedMax,
                 millisRetained,
                 pathFactory(),
                 manifestFileFactory(),


### PR DESCRIPTION
Currently we retain at least 1 snapshot when expiring. However consider the following scenario:

A user writes a snapshot one day ago. Today he is reading this snapshot and meanwhile writing more records. If a new snapshot is created and the reading is not finished, the old snapshot created one day ago will be removed as it exceeds maximum retaining time. This will cause the reading to fail.

We should introduce `snapshot.num-retained.min` to at least retain a minimum number of snapshots to avoid this problem.