### PR TITLE
[hotfix] Fix junit4 dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@ under the License.
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>${junit.version}</version>
+                <version>${junit4.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
`junit.version` in pom.xml is not defined. Use `junit4.version` instead.