### PR TITLE
[hotfix] Shade kafka dependencies

### DIFF
--- a/flink-table-store-dist/pom.xml
+++ b/flink-table-store-dist/pom.xml
@@ -208,6 +208,14 @@ under the License.
                                     <pattern>com.google.protobuf</pattern>
                                     <shadedPattern>org.apache.flink.table.store.shaded.com.google.protobuf</shadedPattern>
                                 </relocation>
+                                <!--
+                                flink-sql-connector-kafka contains shaded kafka classes.
+                                As we've shaded kafka connector we also need to shade kafka dependencies.
+                                -->
+                                <relocation>
+                                    <pattern>org.apache.kafka</pattern>
+                                    <shadedPattern>org.apache.flink.table.store.shaded.org.apache.flink.kafka.shaded.org.apache.kafka</shadedPattern>
+                                </relocation>
                             </relocations>
                         </configuration>
                     </execution>


### PR DESCRIPTION
`flink-sql-connector-kafka` contains shaded kafka classes. As we rely directly on kafka classes we need to use these shaded classes, so we also need to shade kafka dependencies.