### PR TITLE
[FLINK-27135] Rename 'file.path' table option in table store to 'path'

### DIFF
--- a/docs/content/docs/development/create-table.md
+++ b/docs/content/docs/development/create-table.md
@@ -106,7 +106,7 @@ Important options include the following:
     </thead>
     <tbody>
     <tr>
-      <td><h5>file.path</h5></td>
+      <td><h5>path</h5></td>
       <td>Yes</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
@@ -147,7 +147,7 @@ Important options include the following:
 
 Creating a table will create the corresponding physical storage:
 - The table's FileStore directory will be created under:
-  `${file.path}/${catalog_name}.catalog/${database_name}.db/${table_name}`
+  `${path}/${catalog_name}.catalog/${database_name}.db/${table_name}`
 - If `log.system` is configured as Kafka, a Topic named
   "${catalog_name}.${database_name}.${table_name}" will be created
   automatically when the table is created.

--- a/docs/content/docs/try-table-store/quick-start.md
+++ b/docs/content/docs/try-table-store/quick-start.md
@@ -112,7 +112,7 @@ Start the SQL Client CLI:
 
 ```sql
 -- set root path to session config
-SET 'table-store.file.path' = '/tmp/table_store';
+SET 'table-store.path' = '/tmp/table_store';
 
 -- create a word count dynamic table without 'connector' option
 CREATE TABLE word_count (

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ContinuousFileStoreITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ContinuousFileStoreITCase.java
@@ -35,7 +35,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import static org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL;
-import static org.apache.flink.table.store.file.FileStoreOptions.FILE_PATH;
+import static org.apache.flink.table.store.file.FileStoreOptions.PATH;
 import static org.apache.flink.table.store.file.FileStoreOptions.TABLE_STORE_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -59,7 +59,7 @@ public class ContinuousFileStoreITCase extends AbstractTestBase {
     private void prepareEnv(TableEnvironment env, String path) {
         Configuration config = env.getConfig().getConfiguration();
         config.set(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 2);
-        config.setString(TABLE_STORE_PREFIX + FILE_PATH.key(), path);
+        config.setString(TABLE_STORE_PREFIX + PATH.key(), path);
         env.executeSql("CREATE TABLE IF NOT EXISTS T1 (a STRING, b STRING, c STRING)");
         env.executeSql(
                 "CREATE TABLE IF NOT EXISTS T2 (a STRING, b STRING, c STRING, PRIMARY KEY (a) NOT ENFORCED)");

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileStoreITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileStoreITCase.java
@@ -63,7 +63,7 @@ import java.util.stream.Stream;
 
 import static org.apache.flink.table.store.file.FileStoreOptions.BUCKET;
 import static org.apache.flink.table.store.file.FileStoreOptions.FILE_FORMAT;
-import static org.apache.flink.table.store.file.FileStoreOptions.FILE_PATH;
+import static org.apache.flink.table.store.file.FileStoreOptions.PATH;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** ITCase for {@link FileStoreSource} and {@link StoreSink}. */
@@ -347,10 +347,10 @@ public class FileStoreITCase extends AbstractTestBase {
         Configuration options = new Configuration();
         options.set(BUCKET, NUM_BUCKET);
         if (noFail) {
-            options.set(FILE_PATH, folder.toURI().toString());
+            options.set(PATH, folder.toURI().toString());
         } else {
             FailingAtomicRenameFileSystem.get().reset(3, 100);
-            options.set(FILE_PATH, FailingAtomicRenameFileSystem.getFailingPath(folder.getPath()));
+            options.set(PATH, FailingAtomicRenameFileSystem.getFailingPath(folder.getPath()));
         }
         options.set(FILE_FORMAT, "avro");
         return options;

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ReadWriteTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ReadWriteTableITCase.java
@@ -1214,7 +1214,7 @@ public class ReadWriteTableITCase extends ReadWriteTableTestBase {
                         id));
         tEnv.executeSql(
                 String.format(
-                        "create table managed_table with ('file.path' = '%s') "
+                        "create table managed_table with ('path' = '%s') "
                                 + "like dummy_source (excluding options)",
                         rootPath));
         tEnv.executeSql("insert into managed_table select * from dummy_source").await();

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ReadWriteTableTestBase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ReadWriteTableTestBase.java
@@ -288,7 +288,7 @@ public class ReadWriteTableTestBase extends KafkaTableTestBase {
             throws Exception {
         Map<String, String> tableOptions = new HashMap<>();
         rootPath = TEMPORARY_FOLDER.newFolder().getPath();
-        tableOptions.put(FileStoreOptions.FILE_PATH.key(), rootPath);
+        tableOptions.put(FileStoreOptions.PATH.key(), rootPath);
         if (enableLogStore) {
             tableOptions.put(LOG_SYSTEM.key(), "kafka");
             tableOptions.put(LOG_PREFIX + BOOTSTRAP_SERVERS.key(), getBootstrapServers());

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreFactoryTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreFactoryTest.java
@@ -50,7 +50,7 @@ import java.util.stream.Stream;
 
 import static org.apache.flink.table.store.connector.TableStoreTestBase.createResolvedTable;
 import static org.apache.flink.table.store.file.FileStoreOptions.BUCKET;
-import static org.apache.flink.table.store.file.FileStoreOptions.FILE_PATH;
+import static org.apache.flink.table.store.file.FileStoreOptions.PATH;
 import static org.apache.flink.table.store.file.FileStoreOptions.TABLE_STORE_PREFIX;
 import static org.apache.flink.table.store.file.FileStoreOptions.relativeTablePath;
 import static org.apache.flink.table.store.kafka.KafkaLogOptions.BOOTSTRAP_SERVERS;
@@ -202,7 +202,7 @@ public class TableStoreFactoryTest {
                 of(
                         BUCKET.key(),
                         BUCKET.defaultValue().toString(),
-                        FILE_PATH.key(),
+                        PATH.key(),
                         sharedTempDir.toString(),
                         LOG_PREFIX + BOOTSTRAP_SERVERS.key(),
                         "localhost:9092",
@@ -226,7 +226,7 @@ public class TableStoreFactoryTest {
 
         // set both session and table level configuration to test options combination
         Map<String, String> tableOptions = new HashMap<>(enrichedOptions);
-        tableOptions.remove(FILE_PATH.key());
+        tableOptions.remove(PATH.key());
         tableOptions.remove(CONSISTENCY.key());
         Arguments arg3 =
                 Arguments.of(
@@ -247,7 +247,7 @@ public class TableStoreFactoryTest {
 
     private static Stream<Arguments> providingEnrichedOptionsForCreation() {
         Map<String, String> enrichedOptions = new HashMap<>();
-        enrichedOptions.put(FILE_PATH.key(), sharedTempDir.toAbsolutePath().toString());
+        enrichedOptions.put(PATH.key(), sharedTempDir.toAbsolutePath().toString());
         return Stream.of(
                 Arguments.of(enrichedOptions, false),
                 Arguments.of(enrichedOptions, true),
@@ -264,7 +264,7 @@ public class TableStoreFactoryTest {
             tablePath.mkdirs();
         }
         Map<String, String> enrichedOptions = new HashMap<>();
-        enrichedOptions.put(FILE_PATH.key(), sharedTempDir.toAbsolutePath().toString());
+        enrichedOptions.put(PATH.key(), sharedTempDir.toAbsolutePath().toString());
         return Stream.of(
                 Arguments.of(enrichedOptions, false),
                 Arguments.of(enrichedOptions, true),

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreTestBase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreTestBase.java
@@ -51,7 +51,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.apache.flink.table.store.connector.TableStoreFactoryOptions.LOG_SYSTEM;
-import static org.apache.flink.table.store.file.FileStoreOptions.FILE_PATH;
+import static org.apache.flink.table.store.file.FileStoreOptions.PATH;
 import static org.apache.flink.table.store.file.FileStoreOptions.TABLE_STORE_PREFIX;
 import static org.apache.flink.table.store.kafka.KafkaLogOptions.BOOTSTRAP_SERVERS;
 import static org.apache.flink.table.store.log.LogOptions.LOG_PREFIX;
@@ -109,7 +109,7 @@ public abstract class TableStoreTestBase extends KafkaTableTestBase {
 
     protected void prepareSessionContext() {
         Configuration configuration = tEnv.getConfig().getConfiguration();
-        configuration.setString(TABLE_STORE_PREFIX + FILE_PATH.key(), rootPath);
+        configuration.setString(TABLE_STORE_PREFIX + PATH.key(), rootPath);
         configuration.setString(
                 TABLE_STORE_PREFIX + LOG_PREFIX + BOOTSTRAP_SERVERS.key(), getBootstrapServers());
         if (enableLogStore) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreOptions.java
@@ -47,8 +47,8 @@ public class FileStoreOptions implements Serializable {
                     .defaultValue(1)
                     .withDescription("Bucket number for file store.");
 
-    public static final ConfigOption<String> FILE_PATH =
-            ConfigOptions.key("file.path")
+    public static final ConfigOption<String> PATH =
+            ConfigOptions.key("path")
                     .stringType()
                     .noDefaultValue()
                     .withDescription("The root file path of the table store in the filesystem.");
@@ -116,7 +116,7 @@ public class FileStoreOptions implements Serializable {
     public static Set<ConfigOption<?>> allOptions() {
         Set<ConfigOption<?>> allOptions = new HashSet<>();
         allOptions.add(BUCKET);
-        allOptions.add(FILE_PATH);
+        allOptions.add(PATH);
         allOptions.add(FILE_FORMAT);
         allOptions.add(MANIFEST_FORMAT);
         allOptions.add(MANIFEST_TARGET_FILE_SIZE);
@@ -151,15 +151,15 @@ public class FileStoreOptions implements Serializable {
 
     public static Path path(Map<String, String> options, ObjectIdentifier tableIdentifier) {
         Preconditions.checkArgument(
-                options.containsKey(FILE_PATH.key()),
+                options.containsKey(PATH.key()),
                 String.format(
                         "Failed to create file store path. "
                                 + "Please specify a root dir by setting session level configuration "
                                 + "as `SET 'table-store.%s' = '...'`. "
                                 + "Alternatively, you can use a per-table root dir "
                                 + "as `CREATE TABLE ${table} (...) WITH ('%s' = '...')`",
-                        FILE_PATH.key(), FILE_PATH.key()));
-        return new Path(options.get(FILE_PATH.key()), relativeTablePath(tableIdentifier));
+                        PATH.key(), PATH.key()));
+        return new Path(options.get(PATH.key()), relativeTablePath(tableIdentifier));
     }
 
     public static String relativeTablePath(ObjectIdentifier tableIdentifier) {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -97,7 +97,7 @@ public class TestFileStore extends FileStoreImpl {
 
         conf.set(FileStoreOptions.FILE_FORMAT, format);
         conf.set(FileStoreOptions.MANIFEST_FORMAT, format);
-        conf.set(FileStoreOptions.FILE_PATH, root);
+        conf.set(FileStoreOptions.PATH, root);
         conf.set(FileStoreOptions.BUCKET, numBuckets);
 
         return new TestFileStore(conf, partitionType, keyType, valueType, mergeFunction);
@@ -117,7 +117,7 @@ public class TestFileStore extends FileStoreImpl {
                 keyType,
                 valueType,
                 mergeFunction);
-        this.root = conf.getString(FileStoreOptions.FILE_PATH);
+        this.root = conf.getString(FileStoreOptions.PATH);
         this.keySerializer = new RowDataSerializer(keyType);
         this.valueSerializer = new RowDataSerializer(valueType);
     }


### PR DESCRIPTION
The original `file.path` indicates the root path of table store. However other options starting with `file.` (for example `file.format`) only affects sst files and have nothing to do with manifests or snapshots. We should change `file.path` to `path` to indicate that this config option affects the whole table store, not only the sst files.