### PR TITLE
[FLINK-27136] Disable rolling file when writing level 0 sst files

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/sst/SstFileWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/sst/SstFileWriter.java
@@ -134,6 +134,9 @@ public class SstFileWriter {
         private long maxSequenceNumber;
 
         private SstRollingFile(int level) {
+            // each level 0 sst file is a sorted run,
+            // we must not write rolling files for level 0 ssts
+            // otherwise we cannot reduce the number of sorted runs when compacting
             super(level == 0 ? Long.MAX_VALUE : suggestedFileSize);
             this.level = level;
             this.serializer = new KeyValueSerializer(keyType, valueType);

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/sst/SstFileWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/sst/SstFileWriter.java
@@ -134,7 +134,7 @@ public class SstFileWriter {
         private long maxSequenceNumber;
 
         private SstRollingFile(int level) {
-            super(suggestedFileSize);
+            super(level == 0 ? Long.MAX_VALUE : suggestedFileSize);
             this.level = level;
             this.serializer = new KeyValueSerializer(keyType, valueType);
             this.keySerializer = new RowDataSerializer(keyType);


### PR DESCRIPTION
Each level 0 sst file is a sorted run. If we write rolling files then we cannot decrease number of sorted runs.