### PR TITLE
[FLINK-27139] FileStoreCommitImpl#filterCommitted should exit when faced with expired files

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
@@ -118,6 +118,11 @@ public class FileStoreCommitImpl implements FileStoreCommit {
 
     @Override
     public List<ManifestCommittable> filterCommitted(List<ManifestCommittable> committableList) {
+        // nothing to filter, fast exit
+        if (committableList.isEmpty()) {
+            return committableList;
+        }
+
         // if there is no previous snapshots then nothing should be filtered
         Long latestSnapshotId = pathFactory.latestSnapshotId();
         if (latestSnapshotId == null) {
@@ -130,9 +135,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             identifiers.put(committable.identifier(), committable);
         }
 
-        for (long id = latestSnapshotId;
-                id >= Snapshot.FIRST_SNAPSHOT_ID && !identifiers.isEmpty();
-                id--) {
+        for (long id = latestSnapshotId; id >= Snapshot.FIRST_SNAPSHOT_ID; id--) {
             Path snapshotPath = pathFactory.toSnapshotPath(id);
             try {
                 if (!snapshotPath.getFileSystem().exists(snapshotPath)) {


### PR DESCRIPTION
Currently it is possible for `FileStoreCommitImpl#filterCommitted` to check an expired snapshot, which throws `FileNotExists` exception. When faced with an expired file `FileStoreCommitImpl#filterCommitted` should exit.