### PR TITLE
[FLINK-27158] Adjust default value of compaction and compress

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/format/FileFormat.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/format/FileFormat.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DelegatingConfiguration;
-import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.file.src.FileSourceSplit;
 import org.apache.flink.connector.file.src.reader.BulkFormat;
 import org.apache.flink.connector.file.table.format.BulkDecodingFormat;
@@ -108,14 +107,14 @@ public abstract class FileFormat {
             Configuration tableOptions,
             ConfigOption<String> formatOption) {
         String formatIdentifier = tableOptions.get(formatOption);
-        ReadableConfig formatOptions =
+        DelegatingConfiguration formatOptions =
                 new DelegatingConfiguration(tableOptions, formatIdentifier + ".");
         return fromIdentifier(classLoader, formatIdentifier, formatOptions);
     }
 
     /** Create a {@link FileFormatImpl} from format identifier and format options. */
     public static FileFormat fromIdentifier(
-            ClassLoader classLoader, String formatIdentifier, ReadableConfig formatOptions) {
+            ClassLoader classLoader, String formatIdentifier, Configuration formatOptions) {
         ServiceLoader<FileFormatFactory> serviceLoader =
                 ServiceLoader.load(FileFormatFactory.class);
         for (FileFormatFactory factory : serviceLoader) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/format/FileFormatFactory.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/format/FileFormatFactory.java
@@ -18,12 +18,12 @@
 
 package org.apache.flink.table.store.file.format;
 
-import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.configuration.Configuration;
 
 /** Factory to create {@link FileFormat}. */
 public interface FileFormatFactory {
 
     String identifier();
 
-    FileFormat create(ReadableConfig formatOptions);
+    FileFormat create(Configuration formatOptions);
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeOptions.java
@@ -59,7 +59,7 @@ public class MergeTreeOptions {
     public static final ConfigOption<Integer> NUM_LEVELS =
             ConfigOptions.key("num-levels")
                     .intType()
-                    .defaultValue(4)
+                    .noDefaultValue()
                     .withDescription(
                             "Total level number, for example, there are 3 levels, including 0,1,2 levels.");
 
@@ -107,7 +107,7 @@ public class MergeTreeOptions {
             long pageSize,
             long targetFileSize,
             int numSortedRunMax,
-            int numLevels,
+            Integer numLevels,
             boolean commitForceCompact,
             int maxSizeAmplificationPercent,
             int sizeRatio) {
@@ -115,7 +115,9 @@ public class MergeTreeOptions {
         this.pageSize = pageSize;
         this.targetFileSize = targetFileSize;
         this.numSortedRunMax = numSortedRunMax;
-        this.numLevels = numLevels;
+        // By default, this ensures that the compaction does not fall to level 0, but at least to
+        // level 1
+        this.numLevels = numLevels == null ? numSortedRunMax + 1 : numLevels;
         this.commitForceCompact = commitForceCompact;
         this.maxSizeAmplificationPercent = maxSizeAmplificationPercent;
         this.sizeRatio = sizeRatio;

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/format/FileStatsExtractingAvroFormatFactory.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/format/FileStatsExtractingAvroFormatFactory.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.store.file.format;
 
-import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.configuration.Configuration;
 
 /** Factory to create {@link FileStatsExtractingAvroFormat}. */
 public class FileStatsExtractingAvroFormatFactory implements FileFormatFactory {
@@ -29,7 +29,7 @@ public class FileStatsExtractingAvroFormatFactory implements FileFormatFactory {
     }
 
     @Override
-    public FileFormat create(ReadableConfig formatOptions) {
+    public FileFormat create(Configuration formatOptions) {
         return new FileStatsExtractingAvroFormat();
     }
 }

--- a/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/avro/AvroFileFormatFactory.java
+++ b/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/avro/AvroFileFormatFactory.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.store.format.avro;
 
-import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.store.file.format.FileFormat;
 import org.apache.flink.table.store.file.format.FileFormatFactory;
 
@@ -31,7 +31,7 @@ public class AvroFileFormatFactory implements FileFormatFactory {
     }
 
     @Override
-    public FileFormat create(ReadableConfig formatOptions) {
+    public FileFormat create(Configuration formatOptions) {
         return new AvroFileFormat(formatOptions);
     }
 }

--- a/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/orc/OrcFileFormat.java
+++ b/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/orc/OrcFileFormat.java
@@ -18,8 +18,9 @@
 
 package org.apache.flink.table.store.format.orc;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.serialization.BulkWriter;
-import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.file.table.format.BulkDecodingFormat;
 import org.apache.flink.table.connector.format.EncodingFormat;
 import org.apache.flink.table.data.RowData;
@@ -33,11 +34,16 @@ import java.util.Optional;
 public class OrcFileFormat extends FileFormat {
 
     private final org.apache.flink.orc.OrcFileFormatFactory factory;
-    private final ReadableConfig formatOptions;
+    private final Configuration formatOptions;
 
-    public OrcFileFormat(ReadableConfig formatOptions) {
+    public OrcFileFormat(Configuration formatOptions) {
         this.factory = new org.apache.flink.orc.OrcFileFormatFactory();
         this.formatOptions = formatOptions;
+    }
+
+    @VisibleForTesting
+    Configuration formatOptions() {
+        return formatOptions;
     }
 
     @Override

--- a/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/orc/OrcFileFormatFactory.java
+++ b/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/orc/OrcFileFormatFactory.java
@@ -18,9 +18,10 @@
 
 package org.apache.flink.table.store.format.orc;
 
-import org.apache.flink.configuration.ReadableConfig;
-import org.apache.flink.table.store.file.format.FileFormat;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.store.file.format.FileFormatFactory;
+
+import java.util.Properties;
 
 /** Factory to create {@link OrcFileFormat}. */
 public class OrcFileFormatFactory implements FileFormatFactory {
@@ -31,7 +32,19 @@ public class OrcFileFormatFactory implements FileFormatFactory {
     }
 
     @Override
-    public FileFormat create(ReadableConfig formatOptions) {
-        return new OrcFileFormat(formatOptions);
+    public OrcFileFormat create(Configuration formatOptions) {
+        return new OrcFileFormat(supplyDefaultOptions(formatOptions));
+    }
+
+    private Configuration supplyDefaultOptions(Configuration options) {
+        if (!options.containsKey("compress")) {
+            Properties properties = new Properties();
+            options.addAllToProperties(properties);
+            properties.setProperty("compress", "lz4");
+            Configuration newOptions = new Configuration();
+            properties.forEach((k, v) -> newOptions.setString(k.toString(), v.toString()));
+            return newOptions;
+        }
+        return options;
     }
 }

--- a/flink-table-store-format/src/test/java/org/apache/flink/table/store/format/orc/OrcFileFormatTest.java
+++ b/flink-table-store-format/src/test/java/org/apache/flink/table/store/format/orc/OrcFileFormatTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.format.orc;
+
+import org.apache.flink.configuration.Configuration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link OrcFileFormatFactory}. */
+public class OrcFileFormatTest {
+
+    @Test
+    public void testAbsent() {
+        Configuration options = new Configuration();
+        options.setString("haha", "1");
+        OrcFileFormat orc = new OrcFileFormatFactory().create(options);
+        assertThat(orc.formatOptions().getString("haha", "")).isEqualTo("1");
+        assertThat(orc.formatOptions().getString("compress", "")).isEqualTo("lz4");
+    }
+
+    @Test
+    public void testPresent() {
+        Configuration options = new Configuration();
+        options.setString("haha", "1");
+        options.setString("compress", "zlib");
+        OrcFileFormat orc = new OrcFileFormatFactory().create(options);
+        assertThat(orc.formatOptions().getString("haha", "")).isEqualTo("1");
+        assertThat(orc.formatOptions().getString("compress", "")).isEqualTo("zlib");
+    }
+}


### PR DESCRIPTION
- By default, numLevels = numSortedRunMax + 1, this ensures that the compaction does not fall to level 0, but at least to level 1
- orc default compress is lz4, zlib is too slow