### PR TITLE
[hotfix] Add logs to file store compact for better tunning

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/CompactManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/CompactManager.java
@@ -91,27 +91,29 @@ public class CompactManager {
                                     unit.outputLevel() != 0
                                             && unit.outputLevel() >= levels.nonEmptyHighestLevel();
 
-                            LOG.info(
-                                    "Submit compaction with files (level, size): "
-                                            + levels.levelSortedRuns().stream()
-                                                    .flatMap(lsr -> lsr.run().files().stream())
-                                                    .map(
-                                                            file ->
-                                                                    String.format(
-                                                                            "(%d, %d)",
-                                                                            file.level(),
-                                                                            file.fileSize()))
-                                                    .collect(Collectors.joining(", ")));
-                            LOG.info(
-                                    "Pick these files (level, size) for compaction: "
-                                            + unit.files().stream()
-                                                    .map(
-                                                            file ->
-                                                                    String.format(
-                                                                            "(%d, %d)",
-                                                                            file.level(),
-                                                                            file.fileSize()))
-                                                    .collect(Collectors.joining(", ")));
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug(
+                                        "Submit compaction with files (level, size): "
+                                                + levels.levelSortedRuns().stream()
+                                                        .flatMap(lsr -> lsr.run().files().stream())
+                                                        .map(
+                                                                file ->
+                                                                        String.format(
+                                                                                "(%d, %d)",
+                                                                                file.level(),
+                                                                                file.fileSize()))
+                                                        .collect(Collectors.joining(", ")));
+                                LOG.debug(
+                                        "Pick these files (level, size) for compaction: "
+                                                + unit.files().stream()
+                                                        .map(
+                                                                file ->
+                                                                        String.format(
+                                                                                "(%d, %d)",
+                                                                                file.level(),
+                                                                                file.fileSize()))
+                                                        .collect(Collectors.joining(", ")));
+                            }
 
                             CompactTask task = new CompactTask(unit, dropDelete);
                             taskFuture = executor.submit(task);
@@ -214,16 +216,20 @@ public class CompactManager {
                 }
             }
             rewrite(candidate, before, after);
-            LOG.info(
-                    "Done compacting {} files to {} files in {}ms. "
-                            + "Rewrite input size = {}, output size = {}, rewrite file num = {}, upgrade file num = {}",
-                    before.size(),
-                    after.size(),
-                    System.currentTimeMillis() - startMillis,
-                    rewriteInputSize,
-                    rewriteOutputSize,
-                    rewriteFilesNum,
-                    upgradeFilesNum);
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        "Done compacting {} files to {} files in {}ms. "
+                                + "Rewrite input size = {}, output size = {}, rewrite file num = {}, upgrade file num = {}",
+                        before.size(),
+                        after.size(),
+                        System.currentTimeMillis() - startMillis,
+                        rewriteInputSize,
+                        rewriteOutputSize,
+                        rewriteFilesNum,
+                        upgradeFilesNum);
+            }
+
             return result(before, after);
         }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/CompactManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/CompactManager.java
@@ -23,6 +23,9 @@ import org.apache.flink.table.store.file.mergetree.Levels;
 import org.apache.flink.table.store.file.mergetree.SortedRun;
 import org.apache.flink.table.store.file.mergetree.sst.SstFileMeta;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -31,11 +34,14 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
 
 /** Manager to submit compaction task. */
 public class CompactManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CompactManager.class);
 
     private final ExecutorService executor;
 
@@ -84,6 +90,29 @@ public class CompactManager {
                             boolean dropDelete =
                                     unit.outputLevel() != 0
                                             && unit.outputLevel() >= levels.nonEmptyHighestLevel();
+
+                            LOG.info(
+                                    "Submit compaction with files (level, size): "
+                                            + levels.levelSortedRuns().stream()
+                                                    .flatMap(lsr -> lsr.run().files().stream())
+                                                    .map(
+                                                            file ->
+                                                                    String.format(
+                                                                            "(%d, %d)",
+                                                                            file.level(),
+                                                                            file.fileSize()))
+                                                    .collect(Collectors.joining(", ")));
+                            LOG.info(
+                                    "Pick these files (level, size) for compaction: "
+                                            + unit.files().stream()
+                                                    .map(
+                                                            file ->
+                                                                    String.format(
+                                                                            "(%d, %d)",
+                                                                            file.level(),
+                                                                            file.fileSize()))
+                                                    .collect(Collectors.joining(", ")));
+
                             CompactTask task = new CompactTask(unit, dropDelete);
                             taskFuture = executor.submit(task);
                         });
@@ -131,10 +160,21 @@ public class CompactManager {
 
         private final boolean dropDelete;
 
+        // metrics
+        private long rewriteInputSize;
+        private long rewriteOutputSize;
+        private int rewriteFilesNum;
+        private int upgradeFilesNum;
+
         private CompactTask(CompactUnit unit, boolean dropDelete) {
             this.outputLevel = unit.outputLevel();
             this.partitioned = new IntervalPartition(unit.files(), keyComparator).partition();
             this.dropDelete = dropDelete;
+
+            this.rewriteInputSize = 0;
+            this.rewriteOutputSize = 0;
+            this.rewriteFilesNum = 0;
+            this.upgradeFilesNum = 0;
         }
 
         @Override
@@ -143,6 +183,8 @@ public class CompactManager {
         }
 
         private CompactResult compact() throws Exception {
+            long startMillis = System.currentTimeMillis();
+
             List<List<SortedRun>> candidate = new ArrayList<>();
             List<SstFileMeta> before = new ArrayList<>();
             List<SstFileMeta> after = new ArrayList<>();
@@ -172,6 +214,16 @@ public class CompactManager {
                 }
             }
             rewrite(candidate, before, after);
+            LOG.info(
+                    "Done compacting {} files to {} files in {}ms. "
+                            + "Rewrite input size = {}, output size = {}, rewrite file num = {}, upgrade file num = {}",
+                    before.size(),
+                    after.size(),
+                    System.currentTimeMillis() - startMillis,
+                    rewriteInputSize,
+                    rewriteOutputSize,
+                    rewriteFilesNum,
+                    upgradeFilesNum);
             return result(before, after);
         }
 
@@ -179,6 +231,7 @@ public class CompactManager {
             if (file.level() != outputLevel) {
                 before.add(file);
                 after.add(file.upgrade(outputLevel));
+                upgradeFilesNum++;
             }
         }
 
@@ -200,8 +253,20 @@ public class CompactManager {
                     return;
                 }
             }
-            candidate.forEach(runs -> runs.forEach(run -> before.addAll(run.files())));
-            after.addAll(rewriter.rewrite(outputLevel, dropDelete, candidate));
+            candidate.forEach(
+                    runs ->
+                            runs.forEach(
+                                    run -> {
+                                        before.addAll(run.files());
+                                        rewriteInputSize +=
+                                                run.files().stream()
+                                                        .mapToLong(SstFileMeta::fileSize)
+                                                        .sum();
+                                        rewriteFilesNum += run.files().size();
+                                    }));
+            List<SstFileMeta> result = rewriter.rewrite(outputLevel, dropDelete, candidate);
+            after.addAll(result);
+            rewriteOutputSize += result.stream().mapToLong(SstFileMeta::fileSize).sum();
             candidate.clear();
         }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/UniversalCompaction.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/UniversalCompaction.java
@@ -56,14 +56,18 @@ public class UniversalCompaction implements CompactStrategy {
         // 1 checking for reducing size amplification
         CompactUnit unit = pickForSizeAmp(maxLevel, runs);
         if (unit != null) {
-            LOG.info("Universal compaction due to size amplification");
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Universal compaction due to size amplification");
+            }
             return Optional.of(unit);
         }
 
         // 2 checking for size ratio
         unit = pickForSizeRatio(maxLevel, runs);
         if (unit != null) {
-            LOG.info("Universal compaction due to size ratio");
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Universal compaction due to size ratio");
+            }
             return Optional.of(unit);
         }
 
@@ -71,7 +75,9 @@ public class UniversalCompaction implements CompactStrategy {
         if (runs.size() > maxRunNum) {
             // compacting for file num
             int candidateCount = runs.size() - maxRunNum + 1;
-            LOG.info("Universal compaction due to file num");
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Universal compaction due to file num");
+            }
             return Optional.ofNullable(pickForSizeRatio(maxLevel, runs, candidateCount));
         }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/UniversalCompaction.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/UniversalCompaction.java
@@ -22,6 +22,9 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.table.store.file.mergetree.LevelSortedRun;
 import org.apache.flink.table.store.file.mergetree.SortedRun;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -33,6 +36,8 @@ import java.util.Optional;
  * https://github.com/facebook/rocksdb/wiki/Universal-Compaction.
  */
 public class UniversalCompaction implements CompactStrategy {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UniversalCompaction.class);
 
     private final int maxSizeAmp;
     private final int sizeRatio;
@@ -51,12 +56,14 @@ public class UniversalCompaction implements CompactStrategy {
         // 1 checking for reducing size amplification
         CompactUnit unit = pickForSizeAmp(maxLevel, runs);
         if (unit != null) {
+            LOG.info("Universal compaction due to size amplification");
             return Optional.of(unit);
         }
 
         // 2 checking for size ratio
         unit = pickForSizeRatio(maxLevel, runs);
         if (unit != null) {
+            LOG.info("Universal compaction due to size ratio");
             return Optional.of(unit);
         }
 
@@ -64,6 +71,7 @@ public class UniversalCompaction implements CompactStrategy {
         if (runs.size() > maxRunNum) {
             // compacting for file num
             int candidateCount = runs.size() - maxRunNum + 1;
+            LOG.info("Universal compaction due to file num");
             return Optional.ofNullable(pickForSizeRatio(maxLevel, runs, candidateCount));
         }
 


### PR DESCRIPTION
Currently there is not enough log in `CompactManager`, for example what files are being compacted, what are their sizes, etc. This PR adds logs to file store compact for better tunning.