### PR TITLE
[FLINK-27172] Support bulk based format provided by Flink

### DIFF
--- a/flink-table-store-dist/pom.xml
+++ b/flink-table-store-dist/pom.xml
@@ -72,12 +72,6 @@ under the License.
 
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-connector-files</artifactId>
-            <version>${flink.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.flink</groupId>
             <artifactId>flink-sql-connector-kafka</artifactId>
             <version>${flink.version}</version>
         </dependency>
@@ -118,8 +112,6 @@ under the License.
                                     <include>org.apache.flink:flink-table-store-core</include>
                                     <include>org.apache.flink:flink-table-store-format</include>
                                     <include>org.apache.flink:flink-table-store-kafka</include>
-                                    <include>org.apache.flink:flink-connector-base</include>
-                                    <include>org.apache.flink:flink-connector-files</include>
                                     <include>org.apache.flink:flink-sql-connector-kafka</include>
                                     <include>org.apache.flink:flink-sql-avro</include>
                                     <include>org.apache.flink:flink-sql-orc</include>
@@ -167,6 +159,10 @@ under the License.
                                 <relocation>
                                     <pattern>org.apache.flink.connector</pattern>
                                     <shadedPattern>org.apache.flink.table.store.shaded.org.apache.flink.connector</shadedPattern>
+                                    <excludes>
+                                        <exclude>org.apache.flink.connector.base.*</exclude>
+                                        <exclude>org.apache.flink.connector.file.*</exclude>
+                                    </excludes>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.apache.flink.kafka</pattern>

--- a/flink-table-store-format/pom.xml
+++ b/flink-table-store-format/pom.xml
@@ -119,5 +119,48 @@ under the License.
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-csv</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-sql-parquet</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-client-core</artifactId>
+            <version>${hadoop.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-test</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-yarn-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-core-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 </project>

--- a/flink-table-store-format/src/test/java/org/apache/flink/table/store/format/BulkFileFormatTest.java
+++ b/flink-table-store-format/src/test/java/org/apache/flink/table/store/format/BulkFileFormatTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.format;
+
+import org.apache.flink.api.common.serialization.BulkWriter;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.connector.file.src.reader.BulkFormat;
+import org.apache.flink.connector.file.src.util.Utils;
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.file.FileStoreOptions;
+import org.apache.flink.table.store.file.format.FileFormat;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** test bulk based format. */
+public class BulkFileFormatTest {
+
+    @Test
+    public void testAvro(@TempDir java.nio.file.Path tempDir) throws IOException {
+        testFormatWriteRead(tempDir, "avro", "snappy");
+    }
+
+    @Test
+    public void testOrc(@TempDir java.nio.file.Path tempDir) throws IOException {
+        testFormatWriteRead(tempDir, "orc", "snappy");
+    }
+
+    @Test
+    public void testParquet(@TempDir java.nio.file.Path tempDir) throws IOException {
+        testFormatWriteRead(tempDir, "parquet", "snappy");
+    }
+
+    @Test
+    public void testCsv(@TempDir java.nio.file.Path tempDir) throws IOException {
+        testFormatWriteRead(tempDir, "csv", "snappy");
+    }
+
+    public FileFormat createFileFormat(String format, String codec) {
+        Configuration tableOptions = new Configuration();
+        tableOptions.set(FileStoreOptions.FILE_FORMAT, format);
+        tableOptions.setString(format + ".codec", codec);
+        return FileFormat.fromTableOptions(
+                this.getClass().getClassLoader(), tableOptions, FileStoreOptions.FILE_FORMAT);
+    }
+
+    public void testFormatWriteRead(
+            @TempDir java.nio.file.Path tempDir, String format, String codec) throws IOException {
+        FileFormat fileFormat = createFileFormat(format, codec);
+        RowType rowType = RowType.of(new IntType(), new IntType());
+
+        Path path = new Path(tempDir.toUri().toString(), "1." + format);
+        FileSystem fs = path.getFileSystem();
+
+        // write
+        List<RowData> expected = new ArrayList<>();
+        expected.add(GenericRowData.of(1, 1));
+        expected.add(GenericRowData.of(2, 2));
+        expected.add(GenericRowData.of(3, 3));
+        FSDataOutputStream out = fs.create(path, FileSystem.WriteMode.NO_OVERWRITE);
+        BulkWriter<RowData> writer = fileFormat.createWriterFactory(rowType).create(out);
+        for (RowData row : expected) {
+            writer.addElement(row);
+        }
+        writer.finish();
+        out.close();
+
+        // read
+        BulkFormat.Reader<RowData> reader =
+                fileFormat
+                        .createReaderFactory(rowType)
+                        .createReader(
+                                new Configuration(),
+                                new FileSourceSplit("", path, 0, fs.getFileStatus(path).getLen()));
+        List<RowData> result = new ArrayList<>();
+        Utils.forEachRemaining(
+                reader,
+                rowData -> result.add(GenericRowData.of(rowData.getInt(0), rowData.getInt(0))));
+
+        assertThat(result).isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
the following format should be supported in flink-table-store:
1. built in flink-table-store, such as avro/orc, supported already
2. provided by Flink, such as parquet/csv, has not been supported yet