### PR TITLE
[FLINK-27286] Fix table store connector throws ClassNotFoundException: org.apache.flink.table.store.shaded.org.apache.flink.connector.file.table.RowDataPartitionComputer

### DIFF
--- a/flink-table-store-dist/pom.xml
+++ b/flink-table-store-dist/pom.xml
@@ -160,8 +160,8 @@ under the License.
                                     <pattern>org.apache.flink.connector</pattern>
                                     <shadedPattern>org.apache.flink.table.store.shaded.org.apache.flink.connector</shadedPattern>
                                     <excludes>
-                                        <exclude>org.apache.flink.connector.base.*</exclude>
-                                        <exclude>org.apache.flink.connector.file.*</exclude>
+                                        <exclude>org.apache.flink.connector.base.**</exclude>
+                                        <exclude>org.apache.flink.connector.file.**</exclude>
                                     </excludes>
                                 </relocation>
                                 <relocation>


### PR DESCRIPTION
This is caused by FLINK-27172. Currently table store excludes file connector dependencies shading as follows:
```
<exclude>org.apache.flink.connector.base.*</exclude>
<exclude>org.apache.flink.connector.file.*</exclude>
```

However this only excludes classes in org.apache.flink.connector.base and org.apache.flink.connector.file packages and does not exclude classes in their sub-packages. The correct excluding pattern should be:
```
<exclude>org.apache.flink.connector.base.**</exclude>
<exclude>org.apache.flink.connector.file.**</exclude>
```

This change will also be checked by e2e tests in the near future.