### PR TITLE
[FLINK-27335] Optimize async compaction in MergeTreeWriter

### DIFF
--- a/docs/content/docs/development/write-table.md
+++ b/docs/content/docs/development/write-table.md
@@ -183,22 +183,58 @@ following parameters control this tradeoff:
     </thead>
     <tbody>
     <tr>
-      <td><h5>num-sorted-run.max</h5></td>
+      <td><h5>num-sorted-run.compaction-trigger</h5></td>
       <td>No</td>
       <td style="word-wrap: break-word;">5</td>
       <td>Integer</td>
-      <td>The max sorted run number. Includes level0 files (one file one sorted run) and high-level runs (one level one sorted run).</td>
+      <td>The sorted run number to trigger compaction. Includes level0 files (one file one sorted run) and high-level runs (one level one sorted run).</td>
     </tr>
     </tbody>
 </table>
 
-- The larger `num-sorted-run.max`, the less merge cost when updating data, which
+The compaction-trigger determines the frequency of compaction. The smaller the number of
+sorted run, the more compaction occurs, and the larger the number of sorted run, the less compaction occurs.
+
+- The larger `num-sorted-run.compaction-trigger`, the less merge cost when updating data, which
   can avoid many invalid merges. However, if this value is too large, more memory 
   will be needed when merging files because each FileReader will take up a lot of
   memory.
 
-- The smaller `num-sorted-run.max`, the better performance when querying, fewer
+- The smaller `num-sorted-run.compaction-trigger`, the better performance when querying, fewer
   files will be merged.
+
+## Write Stalls
+
+The Writer automatically maintains the structure of the LSM, which means that there
+will be asynchronous threads constantly compaction, but if write speed is faster than the
+compaction speed, write stalls may occur. Writing will be stopping.
+
+If we don't limit writing, we will have the following problems:
+- Increasing space scaling, which can lead to running out of disk space.
+- Increasing read amplification, which greatly reduces read performance.
+
+The following parameters determine when to stop writing:
+
+<table class="table table-bordered">
+    <thead>
+    <tr>
+      <th class="text-left" style="width: 20%">Option</th>
+      <th class="text-center" style="width: 5%">Required</th>
+      <th class="text-center" style="width: 5%">Default</th>
+      <th class="text-center" style="width: 10%">Type</th>
+      <th class="text-center" style="width: 60%">Description</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td><h5>num-sorted-run.stop-trigger</h5></td>
+      <td>No</td>
+      <td style="word-wrap: break-word;">5</td>
+      <td>Integer</td>
+      <td>The number of sorted-runs that trigger the stopping of writes.</td>
+    </tr>
+    </tbody>
+</table>
 
 ## Memory
 
@@ -207,5 +243,5 @@ There are three main places in the Table Store's sink writer that take up memory
   bucket, and this memory value can be adjustable by the `write-buffer-size`
   option (default 64 MB).
 - The memory consumed by compaction for reading files, it can be adjusted by the
-  `num-sorted-run.max` option to change the maximum number of files to be merged.
+  `num-sorted-run.compaction-trigger` option to change the maximum number of files to be merged.
 - The memory consumed by writing file, which is not adjustable.

--- a/docs/content/docs/development/write-table.md
+++ b/docs/content/docs/development/write-table.md
@@ -229,7 +229,7 @@ The following parameters determine when to stop writing:
     <tr>
       <td><h5>num-sorted-run.stop-trigger</h5></td>
       <td>No</td>
-      <td style="word-wrap: break-word;">5</td>
+      <td style="word-wrap: break-word;">10</td>
       <td>Integer</td>
       <td>The number of sorted-runs that trigger the stopping of writes.</td>
     </tr>

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/TestDataReadWrite.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/TestDataReadWrite.java
@@ -99,7 +99,7 @@ public class TestDataReadWrite {
         return new FileStoreWriteImpl(
                         KEY_TYPE,
                         VALUE_TYPE,
-                        COMPARATOR,
+                        () -> COMPARATOR,
                         new DeduplicateMergeFunction(),
                         avro,
                         pathFactory,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreImpl.java
@@ -99,7 +99,7 @@ public class FileStoreImpl implements FileStore {
         return new FileStoreWriteImpl(
                 keyType,
                 valueType,
-                newKeyComparator(),
+                this::newKeyComparator,
                 mergeFunction,
                 options.fileFormat(),
                 pathFactory(),

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/Levels.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/Levels.java
@@ -72,6 +72,16 @@ public class Levels {
         return levels.size() + 1;
     }
 
+    public int numberOfSortedRuns() {
+        int numberOfSortedRuns = level0.size();
+        for (SortedRun run : levels) {
+            if (run.nonEmpty()) {
+                numberOfSortedRuns++;
+            }
+        }
+        return numberOfSortedRuns;
+    }
+
     /** @return the highest non-empty level or -1 if all levels empty. */
     public int nonEmptyHighestLevel() {
         int i;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeOptions.java
@@ -56,6 +56,12 @@ public class MergeTreeOptions {
                             "The max sorted run number. Includes level0 files (one file one sorted run) and "
                                     + "high-level runs (one level one sorted run).");
 
+    public static final ConfigOption<Integer> NUM_SORTED_RUNS_STOP_TRIGGER =
+            ConfigOptions.key("num-sorted-run.stop-trigger")
+                    .intType()
+                    .defaultValue(10)
+                    .withDescription("The number of sorted-runs that trigger the stopping of writes.s");
+
     public static final ConfigOption<Integer> NUM_LEVELS =
             ConfigOptions.key("num-levels")
                     .intType()
@@ -94,6 +100,8 @@ public class MergeTreeOptions {
 
     public final int numSortedRunMax;
 
+    public final int numSortedRunStopTrigger;
+
     public final int numLevels;
 
     public final boolean commitForceCompact;
@@ -107,6 +115,7 @@ public class MergeTreeOptions {
             long pageSize,
             long targetFileSize,
             int numSortedRunMax,
+            int numSortedRunStopTrigger,
             Integer numLevels,
             boolean commitForceCompact,
             int maxSizeAmplificationPercent,
@@ -115,6 +124,7 @@ public class MergeTreeOptions {
         this.pageSize = pageSize;
         this.targetFileSize = targetFileSize;
         this.numSortedRunMax = numSortedRunMax;
+        this.numSortedRunStopTrigger = numSortedRunStopTrigger;
         // By default, this ensures that the compaction does not fall to level 0, but at least to
         // level 1
         this.numLevels = numLevels == null ? numSortedRunMax + 1 : numLevels;
@@ -129,6 +139,7 @@ public class MergeTreeOptions {
                 config.get(PAGE_SIZE).getBytes(),
                 config.get(TARGET_FILE_SIZE).getBytes(),
                 config.get(NUM_SORTED_RUNS_MAX),
+                config.get(NUM_SORTED_RUNS_STOP_TRIGGER),
                 config.get(NUM_LEVELS),
                 config.get(COMMIT_FORCE_COMPACT),
                 config.get(COMPACTION_MAX_SIZE_AMPLIFICATION_PERCENT),
@@ -141,6 +152,7 @@ public class MergeTreeOptions {
         allOptions.add(PAGE_SIZE);
         allOptions.add(TARGET_FILE_SIZE);
         allOptions.add(NUM_SORTED_RUNS_MAX);
+        allOptions.add(NUM_SORTED_RUNS_STOP_TRIGGER);
         allOptions.add(NUM_LEVELS);
         allOptions.add(COMMIT_FORCE_COMPACT);
         allOptions.add(COMPACTION_MAX_SIZE_AMPLIFICATION_PERCENT);

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeOptions.java
@@ -125,7 +125,8 @@ public class MergeTreeOptions {
         this.pageSize = pageSize;
         this.targetFileSize = targetFileSize;
         this.numSortedRunCompactionTrigger = numSortedRunCompactionTrigger;
-        this.numSortedRunStopTrigger = Math.max(numSortedRunCompactionTrigger, numSortedRunStopTrigger);
+        this.numSortedRunStopTrigger =
+                Math.max(numSortedRunCompactionTrigger, numSortedRunStopTrigger);
         // By default, this ensures that the compaction does not fall to level 0, but at least to
         // level 1
         this.numLevels = numLevels == null ? numSortedRunCompactionTrigger + 1 : numLevels;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeOptions.java
@@ -60,7 +60,7 @@ public class MergeTreeOptions {
             ConfigOptions.key("num-sorted-run.stop-trigger")
                     .intType()
                     .defaultValue(10)
-                    .withDescription("The number of sorted-runs that trigger the stopping of writes.s");
+                    .withDescription("The number of sorted-runs that trigger the stopping of writes.");
 
     public static final ConfigOption<Integer> NUM_LEVELS =
             ConfigOptions.key("num-levels")

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeOptions.java
@@ -125,7 +125,7 @@ public class MergeTreeOptions {
         this.pageSize = pageSize;
         this.targetFileSize = targetFileSize;
         this.numSortedRunMax = numSortedRunMax;
-        this.numSortedRunStopTrigger = numSortedRunStopTrigger;
+        this.numSortedRunStopTrigger = Math.max(numSortedRunMax, numSortedRunStopTrigger);
         // By default, this ensures that the compaction does not fall to level 0, but at least to
         // level 1
         this.numLevels = numLevels == null ? numSortedRunMax + 1 : numLevels;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeOptions.java
@@ -48,12 +48,12 @@ public class MergeTreeOptions {
                     .defaultValue(MemorySize.ofMebiBytes(128))
                     .withDescription("Target size of a file.");
 
-    public static final ConfigOption<Integer> NUM_SORTED_RUNS_MAX =
-            ConfigOptions.key("num-sorted-run.max")
+    public static final ConfigOption<Integer> NUM_SORTED_RUNS_COMPACTION_TRIGGER =
+            ConfigOptions.key("num-sorted-run.compaction-trigger")
                     .intType()
                     .defaultValue(5)
                     .withDescription(
-                            "The max sorted run number. Includes level0 files (one file one sorted run) and "
+                            "The sorted run number to trigger compaction. Includes level0 files (one file one sorted run) and "
                                     + "high-level runs (one level one sorted run).");
 
     public static final ConfigOption<Integer> NUM_SORTED_RUNS_STOP_TRIGGER =
@@ -99,7 +99,7 @@ public class MergeTreeOptions {
 
     public final long targetFileSize;
 
-    public final int numSortedRunMax;
+    public final int numSortedRunCompactionTrigger;
 
     public final int numSortedRunStopTrigger;
 
@@ -115,7 +115,7 @@ public class MergeTreeOptions {
             long writeBufferSize,
             long pageSize,
             long targetFileSize,
-            int numSortedRunMax,
+            int numSortedRunCompactionTrigger,
             int numSortedRunStopTrigger,
             Integer numLevels,
             boolean commitForceCompact,
@@ -124,11 +124,11 @@ public class MergeTreeOptions {
         this.writeBufferSize = writeBufferSize;
         this.pageSize = pageSize;
         this.targetFileSize = targetFileSize;
-        this.numSortedRunMax = numSortedRunMax;
-        this.numSortedRunStopTrigger = Math.max(numSortedRunMax, numSortedRunStopTrigger);
+        this.numSortedRunCompactionTrigger = numSortedRunCompactionTrigger;
+        this.numSortedRunStopTrigger = Math.max(numSortedRunCompactionTrigger, numSortedRunStopTrigger);
         // By default, this ensures that the compaction does not fall to level 0, but at least to
         // level 1
-        this.numLevels = numLevels == null ? numSortedRunMax + 1 : numLevels;
+        this.numLevels = numLevels == null ? numSortedRunCompactionTrigger + 1 : numLevels;
         this.commitForceCompact = commitForceCompact;
         this.maxSizeAmplificationPercent = maxSizeAmplificationPercent;
         this.sizeRatio = sizeRatio;
@@ -139,7 +139,7 @@ public class MergeTreeOptions {
                 config.get(WRITE_BUFFER_SIZE).getBytes(),
                 config.get(PAGE_SIZE).getBytes(),
                 config.get(TARGET_FILE_SIZE).getBytes(),
-                config.get(NUM_SORTED_RUNS_MAX),
+                config.get(NUM_SORTED_RUNS_COMPACTION_TRIGGER),
                 config.get(NUM_SORTED_RUNS_STOP_TRIGGER),
                 config.get(NUM_LEVELS),
                 config.get(COMMIT_FORCE_COMPACT),
@@ -152,7 +152,7 @@ public class MergeTreeOptions {
         allOptions.add(WRITE_BUFFER_SIZE);
         allOptions.add(PAGE_SIZE);
         allOptions.add(TARGET_FILE_SIZE);
-        allOptions.add(NUM_SORTED_RUNS_MAX);
+        allOptions.add(NUM_SORTED_RUNS_COMPACTION_TRIGGER);
         allOptions.add(NUM_SORTED_RUNS_STOP_TRIGGER);
         allOptions.add(NUM_LEVELS);
         allOptions.add(COMMIT_FORCE_COMPACT);

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeOptions.java
@@ -60,7 +60,8 @@ public class MergeTreeOptions {
             ConfigOptions.key("num-sorted-run.stop-trigger")
                     .intType()
                     .defaultValue(10)
-                    .withDescription("The number of sorted-runs that trigger the stopping of writes.");
+                    .withDescription(
+                            "The number of sorted-runs that trigger the stopping of writes.");
 
     public static final ConfigOption<Integer> NUM_LEVELS =
             ConfigOptions.key("num-levels")

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeWriter.java
@@ -183,7 +183,8 @@ public class MergeTreeWriter implements RecordWriter {
     }
 
     private void finishCompaction(boolean blocking) throws Exception {
-        Optional<CompactManager.CompactResult> result = compactManager.finishCompaction(levels, blocking);
+        Optional<CompactManager.CompactResult> result =
+                compactManager.finishCompaction(levels, blocking);
         result.ifPresent(this::updateCompactResult);
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/UniversalCompaction.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/UniversalCompaction.java
@@ -41,12 +41,12 @@ public class UniversalCompaction implements CompactStrategy {
 
     private final int maxSizeAmp;
     private final int sizeRatio;
-    private final int maxRunNum;
+    private final int numRunCompactionTrigger;
 
-    public UniversalCompaction(int maxSizeAmp, int sizeRatio, int maxRunNum) {
+    public UniversalCompaction(int maxSizeAmp, int sizeRatio, int numRunCompactionTrigger) {
         this.maxSizeAmp = maxSizeAmp;
         this.sizeRatio = sizeRatio;
-        this.maxRunNum = maxRunNum;
+        this.numRunCompactionTrigger = numRunCompactionTrigger;
     }
 
     @Override
@@ -72,9 +72,9 @@ public class UniversalCompaction implements CompactStrategy {
         }
 
         // 3 checking for file num
-        if (runs.size() > maxRunNum) {
+        if (runs.size() > numRunCompactionTrigger) {
             // compacting for file num
-            int candidateCount = runs.size() - maxRunNum + 1;
+            int candidateCount = runs.size() - numRunCompactionTrigger + 1;
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Universal compaction due to file num");
             }
@@ -86,7 +86,7 @@ public class UniversalCompaction implements CompactStrategy {
 
     @VisibleForTesting
     CompactUnit pickForSizeAmp(int maxLevel, List<LevelSortedRun> runs) {
-        if (runs.size() < maxRunNum) {
+        if (runs.size() < numRunCompactionTrigger) {
             return null;
         }
 
@@ -108,7 +108,7 @@ public class UniversalCompaction implements CompactStrategy {
 
     @VisibleForTesting
     CompactUnit pickForSizeRatio(int maxLevel, List<LevelSortedRun> runs) {
-        if (runs.size() < maxRunNum) {
+        if (runs.size() < numRunCompactionTrigger) {
             return null;
         }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreWriteImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreWriteImpl.java
@@ -127,7 +127,8 @@ public class FileStoreWriteImpl implements FileStoreWrite {
                 keyComparator,
                 mergeFunction.copy(),
                 sstFileWriter,
-                options.commitForceCompact);
+                options.commitForceCompact,
+                options.numSortedRunStopTrigger);
     }
 
     private CompactManager createCompactManager(

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreWriteImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreWriteImpl.java
@@ -43,6 +43,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /** Default implementation of {@link FileStoreWrite}. */
@@ -50,7 +51,7 @@ public class FileStoreWriteImpl implements FileStoreWrite {
 
     private final SstFileReader.Factory sstFileReaderFactory;
     private final SstFileWriter.Factory sstFileWriterFactory;
-    private final Comparator<RowData> keyComparator;
+    private final Supplier<Comparator<RowData>> keyComparatorSupplier;
     private final MergeFunction mergeFunction;
     private final FileStorePathFactory pathFactory;
     private final FileStoreScan scan;
@@ -59,7 +60,7 @@ public class FileStoreWriteImpl implements FileStoreWrite {
     public FileStoreWriteImpl(
             RowType keyType,
             RowType valueType,
-            Comparator<RowData> keyComparator,
+            Supplier<Comparator<RowData>> keyComparatorSupplier,
             MergeFunction mergeFunction,
             FileFormat fileFormat,
             FileStorePathFactory pathFactory,
@@ -70,7 +71,7 @@ public class FileStoreWriteImpl implements FileStoreWrite {
         this.sstFileWriterFactory =
                 new SstFileWriter.Factory(
                         keyType, valueType, fileFormat, pathFactory, options.targetFileSize);
-        this.keyComparator = keyComparator;
+        this.keyComparatorSupplier = keyComparatorSupplier;
         this.mergeFunction = mergeFunction;
         this.pathFactory = pathFactory;
         this.scan = scan;
@@ -113,6 +114,7 @@ public class FileStoreWriteImpl implements FileStoreWrite {
                         .max(Long::compare)
                         .orElse(-1L);
         SstFileWriter sstFileWriter = sstFileWriterFactory.create(partition, bucket);
+        Comparator<RowData> keyComparator = keyComparatorSupplier.get();
         return new MergeTreeWriter(
                 new SortBufferMemTable(
                         sstFileWriter.keyType(),
@@ -136,6 +138,7 @@ public class FileStoreWriteImpl implements FileStoreWrite {
                         options.sizeRatio,
                         options.numSortedRunMax);
         SstFileWriter sstFileWriter = sstFileWriterFactory.create(partition, bucket);
+        Comparator<RowData> keyComparator = keyComparatorSupplier.get();
         CompactManager.Rewriter rewriter =
                 (outputLevel, dropDelete, sections) ->
                         sstFileWriter.write(

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreWriteImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreWriteImpl.java
@@ -137,7 +137,7 @@ public class FileStoreWriteImpl implements FileStoreWrite {
                 new UniversalCompaction(
                         options.maxSizeAmplificationPercent,
                         options.sizeRatio,
-                        options.numSortedRunMax);
+                        options.numSortedRunCompactionTrigger);
         SstFileWriter sstFileWriter = sstFileWriterFactory.create(partition, bucket);
         Comparator<RowData> keyComparator = keyComparatorSupplier.get();
         CompactManager.Rewriter rewriter =

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/MergeTreeTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/MergeTreeTest.java
@@ -275,7 +275,7 @@ public class MergeTreeTest {
                 new UniversalCompaction(
                         options.maxSizeAmplificationPercent,
                         options.sizeRatio,
-                        options.numSortedRunMax);
+                        options.numSortedRunCompactionTrigger);
         CompactManager.Rewriter rewriter =
                 (outputLevel, dropDelete, sections) ->
                         sstFileWriter.write(

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/MergeTreeTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/MergeTreeTest.java
@@ -265,7 +265,8 @@ public class MergeTreeTest {
                 comparator,
                 new DeduplicateMergeFunction(),
                 sstFileWriter,
-                options.commitForceCompact);
+                options.commitForceCompact,
+                options.numSortedRunStopTrigger);
     }
 
     private CompactManager createCompactManager(

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/CompactManagerTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/CompactManagerTest.java
@@ -197,7 +197,7 @@ public class CompactManagerTest {
                 new CompactManager(
                         service, strategy, comparator, 2, testRewriter(expectedDropDelete));
         manager.submitCompaction(levels);
-        manager.finishCompaction(levels);
+        manager.finishCompaction(levels, true);
         List<LevelMinMax> outputs =
                 levels.allFiles().stream().map(LevelMinMax::new).collect(Collectors.toList());
         assertThat(outputs).isEqualTo(expected);


### PR DESCRIPTION
Currently Full Compaction may cause the writer to be blocked, which has an impact on LogStore latency.

We need to decouple compact and write, compact completely asynchronous.
But too many files will lead to unstable reads, when too many files, Compaction processing speed can not keep up with Writer, need to back press Writer.

Stop parameter: num-sorted-run.stop-trigger, default 10