### PR TITLE
[FLINK-27307] Flink table store support append-only ingestion without primary keys. 

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreFactoryOptions.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreFactoryOptions.java
@@ -21,7 +21,9 @@ package org.apache.flink.table.store.connector;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.description.Description;
 import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.store.file.WriteMode;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -56,6 +58,26 @@ public class TableStoreFactoryOptions {
                     .stringType()
                     .noDefaultValue()
                     .withDescription("The log system used to keep changes of the table.");
+
+    public static final ConfigOption<WriteMode> WRITE_MODE =
+            ConfigOptions.key("write-mode")
+                    .enumType(WriteMode.class)
+                    .defaultValue(WriteMode.CHANGE_LOG)
+                    .withDescription(
+                            Description.builder()
+                                    .text("Specify the write mode for table.")
+                                    .linebreak()
+                                    .text(
+                                            String.format(
+                                                    "%s: %s",
+                                                    WriteMode.APPEND_ONLY,
+                                                    WriteMode.APPEND_ONLY.description()))
+                                    .text(
+                                            String.format(
+                                                    "%s: %s",
+                                                    WriteMode.CHANGE_LOG,
+                                                    WriteMode.CHANGE_LOG.description()))
+                                    .build());
 
     public static final ConfigOption<Integer> SINK_PARALLELISM = FactoryUtil.SINK_PARALLELISM;
 

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSink.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSink.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.connector.sink.global.GlobalCommittingSink;
 import org.apache.flink.table.store.file.FileStore;
+import org.apache.flink.table.store.file.WriteMode;
 import org.apache.flink.table.store.file.manifest.ManifestCommittable;
 import org.apache.flink.table.store.file.manifest.ManifestCommittableSerializer;
 import org.apache.flink.table.store.file.operation.Lock;
@@ -58,6 +59,8 @@ public class StoreSink<WriterStateT, LogCommT>
 
     private final FileStore fileStore;
 
+    private final WriteMode writeMode;
+
     private final int[] partitions;
 
     private final int[] primaryKeys;
@@ -75,6 +78,7 @@ public class StoreSink<WriterStateT, LogCommT>
     public StoreSink(
             ObjectIdentifier tableIdentifier,
             FileStore fileStore,
+            WriteMode writeMode,
             int[] partitions,
             int[] primaryKeys,
             int[] logPrimaryKeys,
@@ -84,6 +88,7 @@ public class StoreSink<WriterStateT, LogCommT>
             @Nullable LogSinkProvider logSinkProvider) {
         this.tableIdentifier = tableIdentifier;
         this.fileStore = fileStore;
+        this.writeMode = writeMode;
         this.partitions = partitions;
         this.primaryKeys = primaryKeys;
         this.logPrimaryKeys = logPrimaryKeys;
@@ -122,6 +127,7 @@ public class StoreSink<WriterStateT, LogCommT>
                         partitions,
                         primaryKeys,
                         logPrimaryKeys),
+                writeMode,
                 overwritePartition != null,
                 logWriter,
                 logCallback);

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/TableStoreSink.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/TableStoreSink.java
@@ -43,6 +43,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.flink.table.store.connector.TableStoreFactoryOptions.SINK_PARALLELISM;
+import static org.apache.flink.table.store.connector.TableStoreFactoryOptions.WRITE_MODE;
 import static org.apache.flink.table.store.log.LogOptions.CHANGELOG_MODE;
 
 /** Table sink to create {@link StoreSink}. */
@@ -140,6 +141,7 @@ public class TableStoreSink
                                 .withLogSinkProvider(finalLogSinkProvider)
                                 .withOverwritePartition(overwrite ? staticPartitions : null)
                                 .withParallelism(tableStore.options().get(SINK_PARALLELISM))
+                                .withWriteMode(tableStore.options().get(WRITE_MODE))
                                 .build();
     }
 

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceReader.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceReader.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSourceReaderBase;
 import org.apache.flink.connector.file.src.util.RecordAndPosition;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.file.WriteMode;
 import org.apache.flink.table.store.file.operation.FileStoreRead;
 
 import javax.annotation.Nullable;
@@ -38,6 +39,7 @@ public final class FileStoreSourceReader
                 FileStoreSourceSplitState> {
 
     public FileStoreSourceReader(
+            WriteMode writeMode,
             SourceReaderContext readerContext,
             FileStoreRead fileStoreRead,
             boolean valueCountMode,
@@ -45,7 +47,7 @@ public final class FileStoreSourceReader
         super(
                 () ->
                         new FileStoreSourceSplitReader(
-                                fileStoreRead, valueCountMode, valueCountModeProjects),
+                                fileStoreRead, writeMode, valueCountMode, valueCountModeProjects),
                 (element, output, splitState) -> {
                     output.collect(element.getRecord());
                     splitState.setPosition(element);

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TestAppendOnlyTable.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TestAppendOnlyTable.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector;
+
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
+
+import org.apache.commons.compress.utils.Lists;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.util.List;
+
+/** Test case for append-only managed table. */
+public class TestAppendOnlyTable {
+    @ClassRule public static final TemporaryFolder TEMP = new TemporaryFolder();
+
+    @ClassRule
+    public static final MiniClusterWithClientResource MINI_CLUSTER =
+            new MiniClusterWithClientResource(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(1)
+                            .setNumberSlotsPerTaskManager(4)
+                            .build());
+
+    private volatile TableEnvironment tEnv;
+
+    @Test
+    public void testReadWrite() throws IOException {
+        sql(
+                "CREATE TABLE append_table (id INT, data STRING) WITH ('write-mode'='append-only', 'path'='%s')",
+                TEMP.newFolder().getAbsolutePath());
+        sql("INSERT INTO append_table VALUES (1, 'AAA'), (2, 'BBB')");
+
+        List<Row> rows = sql("SELECT * FROM append_table");
+        Assert.assertEquals(2, rows.size());
+        Assert.assertEquals(ImmutableList.of(Row.of(1, "AAA"), Row.of(2, "BBB")), rows);
+
+        rows = sql("SELECT id FROM append_table");
+        Assert.assertEquals(2, rows.size());
+        Assert.assertEquals(ImmutableList.of(Row.of(1), Row.of(2)), rows);
+
+        rows = sql("SELECT data from append_table");
+        Assert.assertEquals(2, rows.size());
+        Assert.assertEquals(ImmutableList.of(Row.of("AAA"), Row.of("BBB")), rows);
+    }
+
+    private List<Row> sql(String query, Object... args) {
+        TableResult tableResult = tableEnv().executeSql(String.format(query, args));
+
+        try (CloseableIterator<Row> iter = tableResult.collect()) {
+            return Lists.newArrayList(iter);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to collect the table result.", e);
+        }
+    }
+
+    private TableEnvironment tableEnv() {
+        if (tEnv == null) {
+            synchronized (this) {
+                if (tEnv == null) {
+                    EnvironmentSettings.Builder settingsBuilder =
+                            EnvironmentSettings.newInstance().inBatchMode();
+                    tEnv = TableEnvironment.create(settingsBuilder.build());
+                }
+            }
+        }
+        return tEnv;
+    }
+}

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/StoreSinkTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/StoreSinkTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.store.connector.sink.TestFileStore.TestRecordWriter;
+import org.apache.flink.table.store.file.WriteMode;
 import org.apache.flink.table.store.file.manifest.ManifestCommittable;
 import org.apache.flink.table.store.file.writer.RecordWriter;
 import org.apache.flink.table.types.logical.BigIntType;
@@ -120,6 +121,7 @@ public class StoreSinkTest {
                 new StoreSink<>(
                         identifier,
                         fileStore,
+                        WriteMode.CHANGE_LOG,
                         partitions,
                         primaryKeys,
                         primaryKeys,
@@ -251,6 +253,7 @@ public class StoreSinkTest {
         return new StoreSink<>(
                 identifier,
                 fileStore,
+                WriteMode.CHANGE_LOG,
                 partitions,
                 primaryKeys,
                 primaryKeys,

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceReaderTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceReaderTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.store.connector.source;
 
 import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
+import org.apache.flink.table.store.file.WriteMode;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -58,7 +59,11 @@ public class FileStoreSourceReaderTest {
 
     private FileStoreSourceReader createReader(TestingReaderContext context) {
         return new FileStoreSourceReader(
-                context, new TestDataReadWrite(tempDir.toString(), null).createRead(), false, null);
+                WriteMode.CHANGE_LOG,
+                context,
+                new TestDataReadWrite(tempDir.toString(), null).createRead(),
+                false,
+                null);
     }
 
     private static FileStoreSourceSplit createTestFileSplit() {

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.store.file.FileStore;
 import org.apache.flink.table.store.file.FileStoreImpl;
 import org.apache.flink.table.store.file.FileStoreOptions;
+import org.apache.flink.table.store.file.WriteMode;
 import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.mergetree.compact.DeduplicateMergeFunction;
 import org.apache.flink.table.store.file.mergetree.compact.MergeFunction;
@@ -87,6 +88,7 @@ public class FileStoreSourceTest {
         FileStoreSource source =
                 new FileStoreSource(
                         fileStore,
+                        WriteMode.CHANGE_LOG,
                         !hasPk,
                         true,
                         Duration.ofSeconds(1).toMillis(),
@@ -146,6 +148,7 @@ public class FileStoreSourceTest {
         return new FileStoreImpl(
                 "/fake/path",
                 new FileStoreOptions(new Configuration()),
+                WriteMode.CHANGE_LOG,
                 user,
                 partitionType,
                 keyType,

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/TestDataReadWrite.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/TestDataReadWrite.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.store.file.ValueKind;
+import org.apache.flink.table.store.file.WriteMode;
 import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.format.FileFormat;
 import org.apache.flink.table.store.file.mergetree.MergeTreeOptions;
@@ -48,7 +49,6 @@ import static java.util.Collections.singletonList;
 
 /** Util class to read and write data for source tests. */
 public class TestDataReadWrite {
-
     private static final RowType KEY_TYPE =
             new RowType(singletonList(new RowType.RowField("k", new BigIntType())));
     private static final RowType VALUE_TYPE =
@@ -73,6 +73,7 @@ public class TestDataReadWrite {
 
     public FileStoreRead createRead() {
         return new FileStoreReadImpl(
+                WriteMode.CHANGE_LOG,
                 KEY_TYPE,
                 VALUE_TYPE,
                 COMPARATOR,
@@ -97,6 +98,7 @@ public class TestDataReadWrite {
     public RecordWriter createMergeTreeWriter(BinaryRowData partition, int bucket) {
         MergeTreeOptions options = new MergeTreeOptions(new Configuration());
         return new FileStoreWriteImpl(
+                        WriteMode.CHANGE_LOG,
                         KEY_TYPE,
                         VALUE_TYPE,
                         () -> COMPARATOR,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreImpl.java
@@ -48,6 +48,7 @@ import java.util.stream.Collectors;
 public class FileStoreImpl implements FileStore {
 
     private final String tablePath;
+    private final WriteMode writeMode;
     private final FileStoreOptions options;
     private final String user;
     private final RowType partitionType;
@@ -59,6 +60,7 @@ public class FileStoreImpl implements FileStore {
     public FileStoreImpl(
             String tablePath,
             FileStoreOptions options,
+            WriteMode writeMode,
             String user,
             RowType partitionType,
             RowType keyType,
@@ -66,6 +68,7 @@ public class FileStoreImpl implements FileStore {
             MergeFunction mergeFunction) {
         this.tablePath = tablePath;
         this.options = options;
+        this.writeMode = writeMode;
         this.user = user;
         this.partitionType = partitionType;
         this.keyType = keyType;
@@ -102,6 +105,7 @@ public class FileStoreImpl implements FileStore {
     @Override
     public FileStoreWriteImpl newWrite() {
         return new FileStoreWriteImpl(
+                writeMode,
                 keyType,
                 valueType,
                 this::newKeyComparator,
@@ -115,6 +119,7 @@ public class FileStoreImpl implements FileStore {
     @Override
     public FileStoreReadImpl newRead() {
         return new FileStoreReadImpl(
+                writeMode,
                 keyType,
                 valueType,
                 newKeyComparator(),
@@ -213,7 +218,14 @@ public class FileStoreImpl implements FileStore {
         }
 
         return new FileStoreImpl(
-                tablePath, options, user, partitionType, keyType, rowType, mergeFunction);
+                tablePath,
+                options,
+                WriteMode.CHANGE_LOG,
+                user,
+                partitionType,
+                keyType,
+                rowType,
+                mergeFunction);
     }
 
     public static FileStoreImpl createWithValueCount(
@@ -227,6 +239,13 @@ public class FileStoreImpl implements FileStore {
                         new LogicalType[] {new BigIntType(false)}, new String[] {"_VALUE_COUNT"});
         MergeFunction mergeFunction = new ValueCountMergeFunction();
         return new FileStoreImpl(
-                tablePath, options, user, partitionType, rowType, countType, mergeFunction);
+                tablePath,
+                options,
+                WriteMode.CHANGE_LOG,
+                user,
+                partitionType,
+                rowType,
+                countType,
+                mergeFunction);
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/WriteMode.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/WriteMode.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file;
+
+/** Defines the write mode for flink table store. */
+public enum WriteMode {
+    APPEND_ONLY(
+            "append-only",
+            "The table can only accept append-only insert operations. All rows will be "
+                    + "inserted into the table store without any deduplication or primary/unique key constraint."),
+    CHANGE_LOG("change-log", "The table can accept both insert/delete/update operations.");
+
+    private final String writeMode;
+    private final String description;
+
+    WriteMode(String writeMode, String description) {
+        this.writeMode = writeMode;
+        this.description = description;
+    }
+
+    @Override
+    public String toString() {
+        return writeMode;
+    }
+
+    public String description() {
+        return description;
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreWriteImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreWriteImpl.java
@@ -20,7 +20,9 @@ package org.apache.flink.table.store.file.operation;
 
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.store.file.WriteMode;
 import org.apache.flink.table.store.file.data.DataFileMeta;
+import org.apache.flink.table.store.file.data.DataFilePathFactory;
 import org.apache.flink.table.store.file.data.DataFileReader;
 import org.apache.flink.table.store.file.data.DataFileWriter;
 import org.apache.flink.table.store.file.format.FileFormat;
@@ -36,21 +38,26 @@ import org.apache.flink.table.store.file.mergetree.compact.MergeFunction;
 import org.apache.flink.table.store.file.mergetree.compact.UniversalCompaction;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 import org.apache.flink.table.store.file.utils.RecordReaderIterator;
+import org.apache.flink.table.store.file.writer.AppendOnlyWriter;
 import org.apache.flink.table.store.file.writer.RecordWriter;
 import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
 
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 /** Default implementation of {@link FileStoreWrite}. */
 public class FileStoreWriteImpl implements FileStoreWrite {
 
+    private final WriteMode writeMode;
+    private final RowType valueType;
     private final DataFileReader.Factory dataFileReaderFactory;
     private final DataFileWriter.Factory dataFileWriterFactory;
+    private final FileFormat fileFormat;
     private final Supplier<Comparator<RowData>> keyComparatorSupplier;
     private final MergeFunction mergeFunction;
     private final FileStorePathFactory pathFactory;
@@ -58,6 +65,7 @@ public class FileStoreWriteImpl implements FileStoreWrite {
     private final MergeTreeOptions options;
 
     public FileStoreWriteImpl(
+            WriteMode writeMode,
             RowType keyType,
             RowType valueType,
             Supplier<Comparator<RowData>> keyComparatorSupplier,
@@ -66,11 +74,14 @@ public class FileStoreWriteImpl implements FileStoreWrite {
             FileStorePathFactory pathFactory,
             FileStoreScan scan,
             MergeTreeOptions options) {
+        this.valueType = valueType;
         this.dataFileReaderFactory =
                 new DataFileReader.Factory(keyType, valueType, fileFormat, pathFactory);
         this.dataFileWriterFactory =
                 new DataFileWriter.Factory(
                         keyType, valueType, fileFormat, pathFactory, options.targetFileSize);
+        this.writeMode = writeMode;
+        this.fileFormat = fileFormat;
         this.keyComparatorSupplier = keyComparatorSupplier;
         this.mergeFunction = mergeFunction;
         this.pathFactory = pathFactory;
@@ -82,18 +93,39 @@ public class FileStoreWriteImpl implements FileStoreWrite {
     public RecordWriter createWriter(
             BinaryRowData partition, int bucket, ExecutorService compactExecutor) {
         Long latestSnapshotId = pathFactory.latestSnapshotId();
-        if (latestSnapshotId == null) {
-            return createEmptyWriter(partition, bucket, compactExecutor);
-        } else {
-            return createMergeTreeWriter(
-                    partition,
-                    bucket,
-                    scan.withSnapshot(latestSnapshotId)
-                            .withPartitionFilter(Collections.singletonList(partition))
-                            .withBucket(bucket).plan().files().stream()
-                            .map(ManifestEntry::file)
-                            .collect(Collectors.toList()),
-                    compactExecutor);
+        List<DataFileMeta> existingFileMetas = Lists.newArrayList();
+        if (latestSnapshotId != null) {
+            // Concat all the DataFileMeta of existing files into existingFileMetas.
+            scan.withSnapshot(latestSnapshotId)
+                    .withPartitionFilter(Collections.singletonList(partition)).withBucket(bucket)
+                    .plan().files().stream()
+                    .map(ManifestEntry::file)
+                    .forEach(existingFileMetas::add);
+        }
+
+        switch (writeMode) {
+            case APPEND_ONLY:
+                DataFilePathFactory factory =
+                        pathFactory.createDataFilePathFactory(partition, bucket);
+                long maxSeqNum =
+                        existingFileMetas.stream()
+                                .map(DataFileMeta::maxSequenceNumber)
+                                .max(Long::compare)
+                                .orElse(-1L);
+
+                return new AppendOnlyWriter(
+                        fileFormat, options.targetFileSize, valueType, maxSeqNum, factory);
+
+            case CHANGE_LOG:
+                if (latestSnapshotId == null) {
+                    return createEmptyWriter(partition, bucket, compactExecutor);
+                } else {
+                    return createMergeTreeWriter(
+                            partition, bucket, existingFileMetas, compactExecutor);
+                }
+
+            default:
+                throw new UnsupportedOperationException("Unknown write mode: " + writeMode);
         }
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/AppendOnlyRowDataSupplier.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/AppendOnlyRowDataSupplier.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.table.store.file.utils;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.file.KeyValue;
+import org.apache.flink.table.store.file.ValueKind;
+import org.apache.flink.util.Preconditions;
+
+import java.util.function.Supplier;
+
+/** A {@link Supplier} to read {@link RowData} from {@link KeyValue} for an append-only table. */
+public class AppendOnlyRowDataSupplier implements Supplier<RowData> {
+    private final Supplier<KeyValue> kvSupplier;
+
+    public AppendOnlyRowDataSupplier(Supplier<KeyValue> kvSupplier) {
+        this.kvSupplier = kvSupplier;
+    }
+
+    @Override
+    public RowData get() {
+        KeyValue kv = kvSupplier.get();
+        if (kv == null) {
+            return null;
+        }
+        Preconditions.checkState(kv.valueKind() == ValueKind.ADD, "Must be ADD value kind.");
+
+        return kv.value();
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -114,6 +114,7 @@ public class TestFileStore extends FileStoreImpl {
         super(
                 options.path(ObjectIdentifier.of("catalog", "database", "table")).toString(),
                 options,
+                WriteMode.CHANGE_LOG,
                 UUID.randomUUID().toString(),
                 partitionType,
                 keyType,


### PR DESCRIPTION
This PR is trying to provide table store the ability to accept append-only ingestion without any defined primary keys.

The previous table store abstraction are built on top of primary keys,  so in theory all the read & write path will need to be reconsidered  or refactored, so that we can abstract the correct API which works fine for both primary keys storage and immutable logs (without primary keys). 

The current version is a draft PR (Actually,  I'm not quite familiar with the flink-table-store project before, so I'm trying to implement this append-only abstraction to understand the API & implementation better). 

There are TODO issues that I didn't consider clearly in this PRs ( I think I will need the next update to address those things): 

1.  The append-only table's file level statistics are quite different with the primary key tables.  For example, the primary key tables will generate a  collection of `SstFileMeta`  when calling the `writer#prepareCommit()`, and then accomplish the first stage commit in the flink's two-phrase commit.  The `SstFileMeta`  will include the statistics for both key fields and value fields, while in the append-only table we don't have any key fields (its statistic information should include all columns' max-min, count etc.) . So  in theory, we are required to abstract the common file level statistic informations data structure for both two kinds of table; 

2.  The different manifests design for both two kinds of tables.

3.  What's the read API abstraction for those two kinds of tables.  I still don't have a clearly propose for it. Will try to update this PR for this.
