### PR TITLE
[FLINK-27366] Record schema on filesystem path

### DIFF
--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/LogStoreSinkITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/LogStoreSinkITCase.java
@@ -90,21 +90,12 @@ public class LogStoreSinkITCase extends KafkaTableTestBase {
         StreamExecutionEnvironment env = isBatch ? buildBatchEnv() : buildStreamEnv();
 
         // in eventual mode, failure will result in duplicate data
-        TableStore store = buildTableStore(isBatch || !transaction, TEMPORARY_FOLDER);
-        if (partitioned) {
-            if (hasPk) {
-                store.withPrimaryKeys(new int[] {1, 2});
-            } else {
-                store.withPrimaryKeys(new int[0]);
-            }
-            store.withPartitions(new int[] {1});
-        } else {
-            store.withPartitions(new int[0]);
-        }
-
-        if (!hasPk) {
-            store.withPrimaryKeys(new int[0]);
-        }
+        TableStore store =
+                buildTableStore(
+                        isBatch || !transaction,
+                        TEMPORARY_FOLDER,
+                        partitioned ? new int[] {1} : new int[0],
+                        hasPk ? new int[] {2} : new int[0]);
 
         // prepare log
         DynamicTableFactory.Context context =

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceTest.java
@@ -145,6 +145,7 @@ public class FileStoreSourceTest {
                 hasPk ? new DeduplicateMergeFunction() : new ValueCountMergeFunction();
         return new FileStoreImpl(
                 "/fake/path",
+                0,
                 new FileStoreOptions(new Configuration()),
                 user,
                 partitionType,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreImpl.java
@@ -48,6 +48,7 @@ import java.util.stream.Collectors;
 public class FileStoreImpl implements FileStore {
 
     private final String tablePath;
+    private final long schemaId;
     private final FileStoreOptions options;
     private final String user;
     private final RowType partitionType;
@@ -58,6 +59,7 @@ public class FileStoreImpl implements FileStore {
 
     public FileStoreImpl(
             String tablePath,
+            long schemaId,
             FileStoreOptions options,
             String user,
             RowType partitionType,
@@ -65,6 +67,7 @@ public class FileStoreImpl implements FileStore {
             RowType valueType,
             MergeFunction mergeFunction) {
         this.tablePath = tablePath;
+        this.schemaId = schemaId;
         this.options = options;
         this.user = user;
         this.partitionType = partitionType;
@@ -126,6 +129,7 @@ public class FileStoreImpl implements FileStore {
     @Override
     public FileStoreCommitImpl newCommit() {
         return new FileStoreCommitImpl(
+                schemaId,
                 user,
                 partitionType,
                 pathFactory(),
@@ -177,6 +181,7 @@ public class FileStoreImpl implements FileStore {
 
     public static FileStoreImpl createWithPrimaryKey(
             String tablePath,
+            long schemaId,
             FileStoreOptions options,
             String user,
             RowType partitionType,
@@ -213,11 +218,12 @@ public class FileStoreImpl implements FileStore {
         }
 
         return new FileStoreImpl(
-                tablePath, options, user, partitionType, keyType, rowType, mergeFunction);
+                tablePath, schemaId, options, user, partitionType, keyType, rowType, mergeFunction);
     }
 
     public static FileStoreImpl createWithValueCount(
             String tablePath,
+            long schemaId,
             FileStoreOptions options,
             String user,
             RowType partitionType,
@@ -227,6 +233,13 @@ public class FileStoreImpl implements FileStore {
                         new LogicalType[] {new BigIntType(false)}, new String[] {"_VALUE_COUNT"});
         MergeFunction mergeFunction = new ValueCountMergeFunction();
         return new FileStoreImpl(
-                tablePath, options, user, partitionType, rowType, countType, mergeFunction);
+                tablePath,
+                schemaId,
+                options,
+                user,
+                partitionType,
+                rowType,
+                countType,
+                mergeFunction);
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreOptions.java
@@ -146,6 +146,10 @@ public class FileStoreOptions implements Serializable {
         return allOptions;
     }
 
+    public FileStoreOptions(Map<String, String> options) {
+        this(Configuration.fromMap(options));
+    }
+
     public FileStoreOptions(Configuration options) {
         this.options = options;
         // TODO validate all keys

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
@@ -73,6 +73,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
 
     private static final Logger LOG = LoggerFactory.getLogger(FileStoreCommitImpl.class);
 
+    private final long schemaId;
     private final String commitUser;
     private final RowType partitionType;
     private final RowDataToObjectArrayConverter partitionObjectConverter;
@@ -87,6 +88,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
     @Nullable private Lock lock;
 
     public FileStoreCommitImpl(
+            long schemaId,
             String commitUser,
             RowType partitionType,
             FileStorePathFactory pathFactory,
@@ -96,6 +98,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             int numBucket,
             MemorySize manifestTargetSize,
             int manifestMergeMinCount) {
+        this.schemaId = schemaId;
         this.commitUser = commitUser;
         this.partitionType = partitionType;
         this.partitionObjectConverter = new RowDataToObjectArrayConverter(partitionType);
@@ -367,6 +370,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             newSnapshot =
                     new Snapshot(
                             newSnapshotId,
+                            schemaId,
                             previousChangesListName,
                             newChangesListName,
                             commitUser,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/ArrayDataType.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/ArrayDataType.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.schema;
+
+import org.apache.flink.table.types.logical.ArrayType;
+
+import java.util.Objects;
+
+/** A data type for array. */
+public class ArrayDataType extends DataType {
+
+    private static final long serialVersionUID = 1L;
+
+    private final DataType elementType;
+
+    public ArrayDataType(DataType elementType) {
+        super(new ArrayType(elementType.logicalType));
+        this.elementType = elementType;
+    }
+
+    public DataType elementType() {
+        return elementType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        ArrayDataType that = (ArrayDataType) o;
+        return Objects.equals(elementType, that.elementType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), elementType);
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/AtomicDataType.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/AtomicDataType.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.schema;
+
+import org.apache.flink.table.types.logical.LogicalType;
+
+/** A data type that does not contain further data types (e.g. {@code INT} or {@code BOOLEAN}). */
+public final class AtomicDataType extends DataType {
+
+    private static final long serialVersionUID = 1L;
+
+    public AtomicDataType(LogicalType logicalType) {
+        super(logicalType);
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/DataField.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/DataField.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.schema;
+
+import org.apache.flink.table.store.file.utils.JsonSerdeUtil;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/** Defines the field of a row type. */
+public final class DataField implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final int id;
+
+    private final String name;
+
+    private final DataType type;
+
+    private final @Nullable String description;
+
+    public DataField(int id, String name, DataType dataType) {
+        this(id, name, dataType, null);
+    }
+
+    public DataField(int id, String name, DataType type, @Nullable String description) {
+        this.id = id;
+        this.name = name;
+        this.type = type;
+        this.description = description;
+    }
+
+    public int id() {
+        return id;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public DataType type() {
+        return type;
+    }
+
+    @Nullable
+    public String description() {
+        return description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DataField field = (DataField) o;
+        return Objects.equals(id, field.id)
+                && Objects.equals(name, field.name)
+                && Objects.equals(type, field.type)
+                && Objects.equals(description, field.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, type, description);
+    }
+
+    @Override
+    public String toString() {
+        return JsonSerdeUtil.toJson(this);
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/DataFieldSerializer.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/DataFieldSerializer.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.schema;
+
+import org.apache.flink.table.store.file.utils.JsonSerializer;
+import org.apache.flink.table.types.logical.utils.LogicalTypeParser;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/** A {@link JsonSerializer} for {@link DataField}. */
+public class DataFieldSerializer implements JsonSerializer<DataField> {
+
+    public static final DataFieldSerializer INSTANCE = new DataFieldSerializer();
+
+    @Override
+    public void serialize(DataField dataField, JsonGenerator generator) throws IOException {
+        generator.writeStartObject();
+        generator.writeNumberField("id", dataField.id());
+        generator.writeStringField("name", dataField.name());
+        generator.writeFieldName("type");
+        typeToJson(dataField.type(), generator);
+        if (dataField.description() != null) {
+            generator.writeStringField("description", dataField.description());
+        }
+        generator.writeEndObject();
+    }
+
+    @Override
+    public DataField deserialize(JsonNode node) {
+        int id = node.get("id").asInt();
+        String name = node.get("name").asText();
+        DataType type = typeFromJson(node.get("type"));
+        JsonNode descriptionNode = node.get("description");
+        String description = null;
+        if (descriptionNode != null) {
+            description = descriptionNode.asText();
+        }
+        return new DataField(id, name, type, description);
+    }
+
+    private static void typeToJson(DataType type, JsonGenerator generator) throws IOException {
+        if (type instanceof AtomicDataType) {
+            generator.writeString(type.logicalType.asSerializableString());
+        } else if (type instanceof ArrayDataType) {
+            generator.writeStartObject();
+            generator.writeStringField("type", "array");
+            generator.writeFieldName("element");
+            typeToJson(((ArrayDataType) type).elementType(), generator);
+            generator.writeEndObject();
+        } else if (type instanceof MultisetDataType) {
+            generator.writeStartObject();
+            generator.writeStringField("type", "multiset");
+            generator.writeFieldName("element");
+            typeToJson(((MultisetDataType) type).elementType(), generator);
+            generator.writeEndObject();
+        } else if (type instanceof MapDataType) {
+            generator.writeStartObject();
+            generator.writeStringField("type", "map");
+            generator.writeFieldName("key");
+            typeToJson(((MapDataType) type).keyType(), generator);
+            generator.writeFieldName("value");
+            typeToJson(((MapDataType) type).valueType(), generator);
+            generator.writeEndObject();
+        } else if (type instanceof RowDataType) {
+            generator.writeStartObject();
+            generator.writeStringField("type", "row");
+            generator.writeArrayFieldStart("fields");
+            for (DataField field : ((RowDataType) type).fields()) {
+                INSTANCE.serialize(field, generator);
+            }
+            generator.writeEndArray();
+            generator.writeEndObject();
+        } else {
+            throw new UnsupportedOperationException("Unsupported type: " + type);
+        }
+    }
+
+    private static DataType typeFromJson(JsonNode json) {
+        if (json.isTextual()) {
+            return new AtomicDataType(LogicalTypeParser.parse(json.asText()));
+        } else if (json.isObject()) {
+            String typeString = json.get("type").asText();
+            if ("array".equals(typeString)) {
+                DataType element = typeFromJson(json.get("element"));
+                return new ArrayDataType(element);
+            } else if ("multiset".equals(typeString)) {
+                DataType element = typeFromJson(json.get("element"));
+                return new MultisetDataType(element);
+            } else if ("map".equals(typeString)) {
+                DataType key = typeFromJson(json.get("key"));
+                DataType value = typeFromJson(json.get("value"));
+                return new MapDataType(key, value);
+            } else if ("row".equals(typeString)) {
+                JsonNode fieldArray = json.get("fields");
+                Iterator<JsonNode> iterator = fieldArray.elements();
+                List<DataField> fields = new ArrayList<>(fieldArray.size());
+                while (iterator.hasNext()) {
+                    fields.add(INSTANCE.deserialize(iterator.next()));
+                }
+                return new RowDataType(fields);
+            }
+        }
+
+        throw new IllegalArgumentException("Can not parse: " + json);
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/DataType.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/DataType.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.schema;
+
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.util.Preconditions;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/** Describes the data type in the table store ecosystem. */
+public abstract class DataType implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    protected final LogicalType logicalType;
+
+    DataType(LogicalType logicalType) {
+        this.logicalType =
+                Preconditions.checkNotNull(logicalType, "Logical type must not be null.");
+    }
+
+    /**
+     * Returns the corresponding logical type.
+     *
+     * @return a parameterized instance of {@link LogicalType}
+     */
+    public LogicalType logicalType() {
+        return logicalType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DataType dataType = (DataType) o;
+        return Objects.equals(logicalType, dataType.logicalType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(logicalType);
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/MapDataType.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/MapDataType.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.schema;
+
+import org.apache.flink.table.types.logical.MapType;
+
+import java.util.Objects;
+
+/** A data type that contains a key and value data type. */
+public class MapDataType extends DataType {
+
+    private static final long serialVersionUID = 1L;
+
+    private final DataType keyType;
+
+    private final DataType valueType;
+
+    public MapDataType(DataType keyType, DataType valueType) {
+        super(new MapType(keyType.logicalType, valueType.logicalType));
+        this.keyType = keyType;
+        this.valueType = valueType;
+    }
+
+    public DataType keyType() {
+        return keyType;
+    }
+
+    public DataType valueType() {
+        return valueType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        MapDataType that = (MapDataType) o;
+        return Objects.equals(keyType, that.keyType) && Objects.equals(valueType, that.valueType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), keyType, valueType);
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/MultisetDataType.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/MultisetDataType.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.schema;
+
+import org.apache.flink.table.types.logical.ArrayType;
+
+import java.util.Objects;
+
+/** A data type for multiset. */
+public class MultisetDataType extends DataType {
+
+    private static final long serialVersionUID = 1L;
+
+    private final DataType elementType;
+
+    public MultisetDataType(DataType elementType) {
+        super(new ArrayType(elementType.logicalType));
+        this.elementType = elementType;
+    }
+
+    public DataType elementType() {
+        return elementType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        MultisetDataType that = (MultisetDataType) o;
+        return Objects.equals(elementType, that.elementType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), elementType);
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/RowDataType.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/RowDataType.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.schema;
+
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/** A data type that contains field data types. */
+public class RowDataType extends DataType {
+
+    private static final long serialVersionUID = 1L;
+
+    private final List<DataField> fields;
+
+    public RowDataType(List<DataField> fields) {
+        super(toRowType(fields));
+        this.fields = fields;
+    }
+
+    private static RowType toRowType(List<DataField> fields) {
+        List<RowType.RowField> typeFields = new ArrayList<>(fields.size());
+        for (DataField field : fields) {
+            typeFields.add(
+                    new RowType.RowField(
+                            field.name(), field.type().logicalType, field.description()));
+        }
+        return new RowType(typeFields);
+    }
+
+    public List<DataField> fields() {
+        return fields;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        RowDataType that = (RowDataType) o;
+        return Objects.equals(fields, that.fields);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), fields);
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/Schema.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/Schema.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.schema;
+
+import org.apache.flink.table.store.file.utils.JsonSerdeUtil;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.MultisetType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.Preconditions;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+/** Schema of table store. */
+public class Schema {
+
+    private final long id;
+
+    private final List<DataField> fields;
+
+    /** Not available from fields, as some fields may have been deleted. */
+    private final int highestFieldId;
+
+    private final List<String> partitionKeys;
+
+    private final List<String> primaryKeys;
+
+    private final Map<String, String> options;
+
+    public Schema(
+            long id,
+            List<DataField> fields,
+            int highestFieldId,
+            List<String> partitionKeys,
+            List<String> primaryKeys,
+            Map<String, String> options) {
+        this.id = id;
+        this.fields = fields;
+        this.highestFieldId = highestFieldId;
+        this.partitionKeys = partitionKeys;
+        this.primaryKeys = primaryKeys;
+        this.options = Collections.unmodifiableMap(options);
+
+        // try to trim to validate primary keys
+        trimmedPrimaryKeys();
+    }
+
+    public long id() {
+        return id;
+    }
+
+    public List<DataField> fields() {
+        return fields;
+    }
+
+    public int highestFieldId() {
+        return highestFieldId;
+    }
+
+    public List<String> partitionKeys() {
+        return partitionKeys;
+    }
+
+    public List<String> primaryKeys() {
+        return primaryKeys;
+    }
+
+    public List<String> trimmedPrimaryKeys() {
+        if (primaryKeys.size() > 0) {
+            Preconditions.checkState(
+                    primaryKeys.containsAll(partitionKeys),
+                    String.format(
+                            "Primary key constraint %s should include all partition fields %s",
+                            primaryKeys, partitionKeys));
+            List<String> adjusted =
+                    primaryKeys.stream()
+                            .filter(pk -> !partitionKeys.contains(pk))
+                            .collect(Collectors.toList());
+
+            Preconditions.checkState(
+                    adjusted.size() > 0,
+                    String.format(
+                            "Primary key constraint %s should not be same with partition fields %s, this will result in only one record in a partition",
+                            primaryKeys, partitionKeys));
+
+            return adjusted;
+        }
+
+        return primaryKeys;
+    }
+
+    public Map<String, String> options() {
+        return options;
+    }
+
+    public RowType logicalRowType() {
+        return (RowType) new RowDataType(fields).logicalType;
+    }
+
+    @Override
+    public String toString() {
+        return JsonSerdeUtil.toJson(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Schema schema = (Schema) o;
+        return Objects.equals(fields, schema.fields)
+                && Objects.equals(partitionKeys, schema.partitionKeys)
+                && Objects.equals(primaryKeys, schema.primaryKeys)
+                && Objects.equals(options, schema.options);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fields, partitionKeys, primaryKeys, options);
+    }
+
+    public static List<DataField> newFields(RowType rowType) {
+        return ((RowDataType) toDataType(rowType, new AtomicInteger(-1))).fields();
+    }
+
+    private static DataType toDataType(LogicalType type, AtomicInteger currentHighestFieldId) {
+        if (type instanceof ArrayType) {
+            DataType element =
+                    toDataType(((ArrayType) type).getElementType(), currentHighestFieldId);
+            return new ArrayDataType(element);
+        } else if (type instanceof MultisetType) {
+            DataType element =
+                    toDataType(((MultisetType) type).getElementType(), currentHighestFieldId);
+            return new MultisetDataType(element);
+        } else if (type instanceof MapType) {
+            DataType key = toDataType(((MapType) type).getKeyType(), currentHighestFieldId);
+            DataType value = toDataType(((MapType) type).getValueType(), currentHighestFieldId);
+            return new MapDataType(key, value);
+        } else if (type instanceof RowType) {
+            List<DataField> fields = new ArrayList<>();
+            for (RowType.RowField field : ((RowType) type).getFields()) {
+                int id = currentHighestFieldId.incrementAndGet();
+                DataType fieldType = toDataType(field.getType(), currentHighestFieldId);
+                fields.add(
+                        new DataField(
+                                id,
+                                field.getName(),
+                                fieldType,
+                                field.getDescription().orElse(null)));
+            }
+            return new RowDataType(fields);
+        } else {
+            return new AtomicDataType(type);
+        }
+    }
+
+    public static int currentHighestFieldId(List<DataField> fields) {
+        Set<Integer> fieldIds = new HashSet<>();
+        collectFieldIds(new RowDataType(fields), fieldIds);
+        return fieldIds.stream().max(Integer::compareTo).orElse(-1);
+    }
+
+    private static void collectFieldIds(DataType type, Set<Integer> fieldIds) {
+        if (type instanceof ArrayDataType) {
+            collectFieldIds(((ArrayDataType) type).elementType(), fieldIds);
+        } else if (type instanceof MultisetDataType) {
+            collectFieldIds(((MultisetDataType) type).elementType(), fieldIds);
+        } else if (type instanceof MapDataType) {
+            collectFieldIds(((MapDataType) type).keyType(), fieldIds);
+            collectFieldIds(((MapDataType) type).keyType(), fieldIds);
+        } else if (type instanceof RowDataType) {
+            for (DataField field : ((RowDataType) type).fields()) {
+                if (fieldIds.contains(field.id())) {
+                    throw new RuntimeException(
+                            String.format("Broken schema, field id %s is duplicated.", field.id()));
+                }
+                fieldIds.add(field.id());
+                collectFieldIds(field.type(), fieldIds);
+            }
+        }
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.schema;
+
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.store.file.operation.Lock;
+import org.apache.flink.table.store.file.utils.FileUtils;
+import org.apache.flink.table.store.file.utils.JsonSerdeUtil;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.table.store.file.utils.FileUtils.listVersionedFiles;
+
+/** Schema Manager to manage schema versions. */
+public class SchemaManager {
+
+    private static final String SCHEMA_PREFIX = "schema-";
+
+    private final Path tableRoot;
+
+    /** Default no lock. */
+    private Lock lock = Callable::call;
+
+    public SchemaManager(Path tableRoot) {
+        this.tableRoot = tableRoot;
+    }
+
+    public SchemaManager withLock(Lock lock) {
+        this.lock = lock;
+        return this;
+    }
+
+    /** @return latest schema. */
+    public Optional<Schema> latest() {
+        try {
+            return listVersionedFiles(schemaDirectory(), SCHEMA_PREFIX)
+                    .reduce(Math::max)
+                    .map(this::schema);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /** List all schema. */
+    public List<Schema> listAll() {
+        try {
+            return listVersionedFiles(schemaDirectory(), SCHEMA_PREFIX)
+                    .map(this::schema)
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /** Create a new schema from {@link UpdateSchema}. */
+    public Schema commitNewVersion(UpdateSchema updateSchema) throws Exception {
+        RowType rowType = updateSchema.rowType();
+        List<String> partitionKeys = updateSchema.partitionKeys();
+        List<String> primaryKeys = updateSchema.primaryKeys();
+        Map<String, String> options = updateSchema.options();
+
+        while (true) {
+            long id;
+            int highestFieldId;
+            List<DataField> fields;
+            Optional<Schema> latest = latest();
+            if (latest.isPresent()) {
+                Schema oldSchema = latest.get();
+                Preconditions.checkArgument(
+                        oldSchema.primaryKeys().equals(primaryKeys),
+                        "Primary key modification is not supported, "
+                                + "old primaryKeys is %s, new primaryKeys is %s",
+                        oldSchema.primaryKeys(),
+                        primaryKeys);
+
+                if (!updateSchema
+                                .rowType()
+                                .getFields()
+                                .equals(oldSchema.logicalRowType().getFields())
+                        || !updateSchema.partitionKeys().equals(oldSchema.partitionKeys())) {
+                    throw new UnsupportedOperationException(
+                            "TODO: support update field types and partition keys. ");
+                }
+
+                fields = oldSchema.fields();
+                id = oldSchema.id() + 1;
+                highestFieldId = oldSchema.highestFieldId();
+            } else {
+                fields = Schema.newFields(rowType);
+                highestFieldId = Schema.currentHighestFieldId(fields);
+                id = 0;
+            }
+
+            Schema schema =
+                    new Schema(id, fields, highestFieldId, partitionKeys, primaryKeys, options);
+
+            Path temp = toTmpSchemaPath(id);
+            Path finalFile = toSchemaPath(id);
+            FileUtils.writeFileUtf8(temp, schema.toString());
+
+            boolean success = false;
+            try {
+                success = lock.runWithLock(() -> temp.getFileSystem().rename(temp, finalFile));
+                if (success) {
+                    return schema;
+                }
+            } finally {
+                if (!success) {
+                    FileUtils.deleteOrWarn(temp);
+                }
+            }
+        }
+    }
+
+    /** Read schema for schema id. */
+    public Schema schema(long id) {
+        try {
+            return JsonSerdeUtil.fromJson(FileUtils.readFileUtf8(toSchemaPath(id)), Schema.class);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private Path schemaDirectory() {
+        return new Path(tableRoot + "/schema");
+    }
+
+    private Path toTmpSchemaPath(long id) {
+        return new Path(tableRoot + "/schema/." + SCHEMA_PREFIX + id + "-" + UUID.randomUUID());
+    }
+
+    private Path toSchemaPath(long id) {
+        return new Path(tableRoot + "/schema/" + SCHEMA_PREFIX + id);
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
@@ -121,10 +121,10 @@ public class SchemaManager {
 
             Path temp = toTmpSchemaPath(id);
             Path finalFile = toSchemaPath(id);
-            FileUtils.writeFileUtf8(temp, schema.toString());
 
             boolean success = false;
             try {
+                FileUtils.writeFileUtf8(temp, schema.toString());
                 success = lock.runWithLock(() -> temp.getFileSystem().rename(temp, finalFile));
                 if (success) {
                     return schema;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaSerializer.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaSerializer.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.schema;
+
+import org.apache.flink.table.store.file.utils.JsonSerializer;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/** A {@link JsonSerializer} for {@link Schema}. */
+public class SchemaSerializer implements JsonSerializer<Schema> {
+
+    public static final SchemaSerializer INSTANCE = new SchemaSerializer();
+
+    @Override
+    public void serialize(Schema schema, JsonGenerator generator) throws IOException {
+        generator.writeStartObject();
+
+        generator.writeNumberField("id", schema.id());
+
+        generator.writeArrayFieldStart("fields");
+        for (DataField field : schema.fields()) {
+            DataFieldSerializer.INSTANCE.serialize(field, generator);
+        }
+        generator.writeEndArray();
+
+        generator.writeNumberField("highestFieldId", schema.highestFieldId());
+
+        generator.writeArrayFieldStart("partitionKeys");
+        for (String partitionKey : schema.partitionKeys()) {
+            generator.writeString(partitionKey);
+        }
+        generator.writeEndArray();
+
+        generator.writeArrayFieldStart("primaryKeys");
+        for (String primaryKey : schema.primaryKeys()) {
+            generator.writeString(primaryKey);
+        }
+        generator.writeEndArray();
+
+        generator.writeObjectFieldStart("options");
+        for (Map.Entry<String, String> entry : schema.options().entrySet()) {
+            generator.writeStringField(entry.getKey(), entry.getValue());
+        }
+        generator.writeEndObject();
+
+        generator.writeEndObject();
+    }
+
+    @Override
+    public Schema deserialize(JsonNode node) {
+        int id = node.get("id").asInt();
+
+        Iterator<JsonNode> fieldJsons = node.get("fields").elements();
+        List<DataField> fields = new ArrayList<>();
+        while (fieldJsons.hasNext()) {
+            fields.add(DataFieldSerializer.INSTANCE.deserialize(fieldJsons.next()));
+        }
+
+        int highestFieldId = node.get("highestFieldId").asInt();
+
+        Iterator<JsonNode> partitionJsons = node.get("partitionKeys").elements();
+        List<String> partitionKeys = new ArrayList<>();
+        while (partitionJsons.hasNext()) {
+            partitionKeys.add(partitionJsons.next().asText());
+        }
+
+        Iterator<JsonNode> primaryJsons = node.get("primaryKeys").elements();
+        List<String> primaryKeys = new ArrayList<>();
+        while (primaryJsons.hasNext()) {
+            primaryKeys.add(primaryJsons.next().asText());
+        }
+
+        JsonNode optionsJson = node.get("options");
+        Map<String, String> options = new HashMap<>();
+        Iterator<String> optionsKeys = optionsJson.fieldNames();
+        while (optionsKeys.hasNext()) {
+            String key = optionsKeys.next();
+            options.put(key, optionsJson.get(key).asText());
+        }
+
+        return new Schema(id, fields, highestFieldId, partitionKeys, primaryKeys, options);
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/UpdateSchema.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/UpdateSchema.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.schema;
+
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.List;
+import java.util.Map;
+
+/** A update schema. */
+public class UpdateSchema {
+
+    private final RowType rowType;
+
+    private final List<String> partitionKeys;
+
+    private final List<String> primaryKeys;
+
+    private final Map<String, String> options;
+
+    public UpdateSchema(
+            RowType rowType,
+            List<String> partitionKeys,
+            List<String> primaryKeys,
+            Map<String, String> options) {
+        this.rowType = rowType;
+        this.partitionKeys = partitionKeys;
+        this.primaryKeys = primaryKeys;
+        this.options = options;
+    }
+
+    public RowType rowType() {
+        return rowType;
+    }
+
+    public List<String> partitionKeys() {
+        return partitionKeys;
+    }
+
+    public List<String> primaryKeys() {
+        return primaryKeys;
+    }
+
+    public Map<String, String> options() {
+        return options;
+    }
+
+    @Override
+    public String toString() {
+        return "UpdateSchema{"
+                + "rowType="
+                + rowType
+                + ", partitionKeys="
+                + partitionKeys
+                + ", primaryKeys="
+                + primaryKeys
+                + ", options="
+                + options
+                + '}';
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/FileUtils.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/FileUtils.java
@@ -42,9 +42,11 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinWorkerThread;
+import java.util.stream.Stream;
 
 /** Utils for file reading and writing. */
 public class FileUtils {
@@ -148,5 +150,31 @@ public class FileUtils {
             }
         }
         return statuses;
+    }
+
+    /**
+     * List versioned files for the directory.
+     *
+     * @return version stream
+     */
+    public static Stream<Long> listVersionedFiles(Path dir, String prefix) throws IOException {
+        if (!dir.getFileSystem().exists(dir)) {
+            return Stream.of();
+        }
+
+        FileStatus[] statuses = FileUtils.safelyListFileStatus(dir);
+
+        if (statuses == null) {
+            throw new RuntimeException(
+                    String.format(
+                            "The return value is null of the listStatus for the '%s' directory.",
+                            dir));
+        }
+
+        return Arrays.stream(statuses)
+                .map(FileStatus::getPath)
+                .map(Path::getName)
+                .filter(name -> name.startsWith(prefix))
+                .map(name -> Long.parseLong(name.substring(prefix.length())));
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/JsonSerdeUtil.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/JsonSerdeUtil.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.utils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.store.file.schema.DataField;
+import org.apache.flink.table.store.file.schema.DataFieldSerializer;
+import org.apache.flink.table.store.file.schema.Schema;
+import org.apache.flink.table.store.file.schema.SchemaSerializer;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationContext;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.Module;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.SerializerProvider;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.module.SimpleModule;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+/** A utility class that provide abilities for JSON serialization and deserialization. */
+@Internal
+public class JsonSerdeUtil {
+
+    /**
+     * Object mapper shared instance to serialize and deserialize the plan. Note that creating and
+     * copying of object mappers is expensive and should be avoided.
+     */
+    private static final ObjectMapper OBJECT_MAPPER_INSTANCE;
+
+    static {
+        OBJECT_MAPPER_INSTANCE = new ObjectMapper();
+        OBJECT_MAPPER_INSTANCE.registerModule(createTableStoreJacksonModule());
+    }
+
+    public static <T> T fromJson(String json, Class<T> clazz) {
+        try {
+            return OBJECT_MAPPER_INSTANCE.reader().readValue(json, clazz);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public static <T> String toJson(T t) {
+        try {
+            return OBJECT_MAPPER_INSTANCE.writer().writeValueAsString(t);
+        } catch (JsonProcessingException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static Module createTableStoreJacksonModule() {
+        SimpleModule module = new SimpleModule("Table store");
+        registerJsonObjects(module, Schema.class, SchemaSerializer.INSTANCE);
+        registerJsonObjects(module, DataField.class, DataFieldSerializer.INSTANCE);
+        return module;
+    }
+
+    private static <T> void registerJsonObjects(
+            SimpleModule module, Class<T> clazz, JsonSerializer<T> serializer) {
+        module.addSerializer(
+                new StdSerializer<T>(clazz) {
+                    @Override
+                    public void serialize(T t, JsonGenerator generator, SerializerProvider provider)
+                            throws IOException {
+                        serializer.serialize(t, generator);
+                    }
+                });
+        module.addDeserializer(
+                clazz,
+                new StdDeserializer<T>(clazz) {
+                    @Override
+                    public T deserialize(JsonParser parser, DeserializationContext context)
+                            throws IOException {
+                        return serializer.deserialize(parser.readValueAsTree());
+                    }
+                });
+    }
+
+    private JsonSerdeUtil() {}
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/JsonSerializer.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/JsonSerializer.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.utils;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+
+/** Json serializer for jackson. */
+public interface JsonSerializer<T> {
+
+    void serialize(T t, JsonGenerator generator) throws IOException;
+
+    T deserialize(JsonNode node);
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -113,6 +113,7 @@ public class TestFileStore extends FileStoreImpl {
             MergeFunction mergeFunction) {
         super(
                 options.path(ObjectIdentifier.of("catalog", "database", "table")).toString(),
+                0L,
                 options,
                 UUID.randomUUID().toString(),
                 partitionType,

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/schema/SchemaManagerTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/schema/SchemaManagerTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.schema;
+
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.store.file.utils.FailingAtomicRenameFileSystem;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.apache.flink.table.store.file.utils.FailingAtomicRenameFileSystem.retryArtificialException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/** Test for {@link SchemaManager}. */
+public class SchemaManagerTest {
+
+    @TempDir java.nio.file.Path tempDir;
+
+    private SchemaManager manager;
+
+    private final List<String> partitionKeys = Collections.singletonList("f0");
+    private final List<String> primaryKeys = Arrays.asList("f0", "f1");
+    private final Map<String, String> options = Collections.singletonMap("key", "value");
+    private final RowType rowType = RowType.of(new IntType(), new BigIntType(), new VarCharType());
+    private final UpdateSchema updateSchema =
+            new UpdateSchema(rowType, partitionKeys, primaryKeys, options);
+
+    @BeforeEach
+    public void beforeEach() throws IOException {
+        // for failure tests
+        FailingAtomicRenameFileSystem.get().reset(100, 5000);
+        String root = FailingAtomicRenameFileSystem.getFailingPath(tempDir.toString());
+        manager = new SchemaManager(new Path(root));
+    }
+
+    @AfterEach
+    public void afterEach() {
+        // assert no temp file
+        File schema = new File(tempDir.toFile(), "schema");
+        assertThat(schema.exists()).isTrue();
+        String[] versions = schema.list();
+        assertThat(versions).isNotNull();
+        for (String version : versions) {
+            assertThat(version.startsWith(".")).isFalse();
+        }
+    }
+
+    @Test
+    public void testCommitNewVersion() throws Exception {
+        Schema schema = retryArtificialException(() -> manager.commitNewVersion(updateSchema));
+
+        Optional<Schema> latest = retryArtificialException(() -> manager.latest());
+
+        List<DataField> fields =
+                Arrays.asList(
+                        new DataField(0, "f0", new AtomicDataType(new IntType())),
+                        new DataField(1, "f1", new AtomicDataType(new BigIntType())),
+                        new DataField(2, "f2", new AtomicDataType(new VarCharType())));
+
+        assertThat(latest.isPresent()).isTrue();
+        assertThat(schema).isEqualTo(latest.get());
+        assertThat(schema.fields()).isEqualTo(fields);
+        assertThat(schema.partitionKeys()).isEqualTo(partitionKeys);
+        assertThat(schema.primaryKeys()).isEqualTo(primaryKeys);
+        assertThat(schema.options()).isEqualTo(options);
+    }
+
+    @Test
+    public void testUpdateOptions() throws Exception {
+        retryArtificialException(() -> manager.commitNewVersion(updateSchema));
+        Map<String, String> newOptions = Collections.singletonMap("new_k", "new_v");
+        UpdateSchema updateSchema =
+                new UpdateSchema(rowType, partitionKeys, primaryKeys, newOptions);
+        retryArtificialException(() -> manager.commitNewVersion(updateSchema));
+        Optional<Schema> latest = retryArtificialException(() -> manager.latest());
+        assertThat(latest.isPresent()).isTrue();
+        assertThat(latest.get().options()).isEqualTo(newOptions);
+    }
+
+    @Test
+    public void testUpdateSchema() throws Exception {
+        retryArtificialException(() -> manager.commitNewVersion(updateSchema));
+        RowType newType = RowType.of(new IntType(), new BigIntType());
+        UpdateSchema updateSchema = new UpdateSchema(newType, partitionKeys, primaryKeys, options);
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> retryArtificialException(() -> manager.commitNewVersion(updateSchema)));
+    }
+
+    @Test
+    public void testConcurrentCommit() throws Exception {
+        int threadNumber = ThreadLocalRandom.current().nextInt(3) + 2;
+        List<Thread> threads = new ArrayList<>();
+        for (int i = 0; i < threadNumber; i++) {
+            int id = i;
+            threads.add(
+                    new Thread(
+                            () -> {
+                                // sleep to concurrent commit, exclude the effects of thread startup
+                                try {
+                                    Thread.sleep(100);
+                                } catch (InterruptedException e) {
+                                    throw new RuntimeException(e);
+                                }
+
+                                Map<String, String> options = new HashMap<>();
+                                options.put("id", String.valueOf(id));
+                                UpdateSchema updateSchema =
+                                        new UpdateSchema(
+                                                rowType, partitionKeys, primaryKeys, options);
+                                try {
+                                    retryArtificialException(
+                                            () -> manager.commitNewVersion(updateSchema));
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                }
+                            }));
+        }
+
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        // assert
+        List<String> ids =
+                retryArtificialException(() -> manager.listAll()).stream()
+                        .map(schema -> schema.options().get("id"))
+                        .collect(Collectors.toList());
+        assertThat(ids)
+                .containsExactlyInAnyOrder(
+                        IntStream.range(0, threadNumber)
+                                .mapToObj(String::valueOf)
+                                .toArray(String[]::new));
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/schema/SchemaSerializationTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/schema/SchemaSerializationTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.schema;
+
+import org.apache.flink.table.store.file.utils.JsonSerdeUtil;
+import org.apache.flink.table.types.logical.IntType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.table.store.file.schema.SchemaTest.newRowType;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for serialize {@link Schema}. */
+public class SchemaSerializationTest {
+
+    @Test
+    public void testSchema() {
+        List<DataField> fields =
+                Arrays.asList(
+                        new DataField(0, "f0", new AtomicDataType(new IntType())),
+                        new DataField(1, "f1", newRowType(2)),
+                        new DataField(3, "f2", new ArrayDataType(newRowType(4))),
+                        new DataField(5, "f3", new MultisetDataType(newRowType(6))),
+                        new DataField(7, "f4", new MapDataType(newRowType(8), newRowType(9))));
+        List<String> partitionKeys = Collections.singletonList("f0");
+        List<String> primaryKeys = Arrays.asList("f0", "f1");
+        Map<String, String> options = new HashMap<>();
+        options.put("option-1", "value-1");
+        options.put("option-2", "value-2");
+
+        Schema schema = new Schema(1, fields, 10, partitionKeys, primaryKeys, options);
+        String serialized = JsonSerdeUtil.toJson(schema);
+
+        Schema deserialized = JsonSerdeUtil.fromJson(serialized, Schema.class);
+        assertThat(deserialized).isEqualTo(schema);
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/schema/SchemaTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/schema/SchemaTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.schema;
+
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.MultisetType;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link Schema}. */
+public class SchemaTest {
+
+    @Test
+    public void testInvalidPrimaryKeys() {
+        List<DataField> fields =
+                Arrays.asList(
+                        new DataField(0, "f0", new AtomicDataType(new IntType())),
+                        new DataField(1, "f1", new AtomicDataType(new IntType())),
+                        new DataField(2, "f2", new AtomicDataType(new IntType())));
+        List<String> partitionKeys = Collections.singletonList("f0");
+        List<String> primaryKeys = Collections.singletonList("f1");
+        Map<String, String> options = new HashMap<>();
+
+        Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> new Schema(1, fields, 10, partitionKeys, primaryKeys, options));
+    }
+
+    @Test
+    public void testInvalidFieldIds() {
+        List<DataField> fields =
+                Arrays.asList(
+                        new DataField(0, "f0", new AtomicDataType(new IntType())),
+                        new DataField(0, "f1", new AtomicDataType(new IntType())));
+        Assertions.assertThrows(RuntimeException.class, () -> Schema.currentHighestFieldId(fields));
+    }
+
+    @Test
+    public void testHighestFieldId() {
+        List<DataField> fields =
+                Arrays.asList(
+                        new DataField(0, "f0", new AtomicDataType(new IntType())),
+                        new DataField(20, "f1", new AtomicDataType(new IntType())));
+        assertThat(Schema.currentHighestFieldId(fields)).isEqualTo(20);
+    }
+
+    @Test
+    public void testTypeToSchema() {
+        RowType type =
+                RowType.of(
+                        new LogicalType[] {
+                            new IntType(),
+                            newLogicalRowType(),
+                            new ArrayType(newLogicalRowType()),
+                            new MultisetType(newLogicalRowType()),
+                            new MapType(newLogicalRowType(), newLogicalRowType())
+                        },
+                        new String[] {"f0", "f1", "f2", "f3", "f4"});
+
+        List<DataField> fields =
+                Arrays.asList(
+                        new DataField(0, "f0", new AtomicDataType(new IntType())),
+                        new DataField(1, "f1", newRowType(2)),
+                        new DataField(3, "f2", new ArrayDataType(newRowType(4))),
+                        new DataField(5, "f3", new MultisetDataType(newRowType(6))),
+                        new DataField(7, "f4", new MapDataType(newRowType(8), newRowType(9))));
+
+        assertThat(Schema.newFields(type)).isEqualTo(fields);
+    }
+
+    static RowType newLogicalRowType() {
+        return new RowType(
+                Collections.singletonList(new RowType.RowField("nestedField", new IntType())));
+    }
+
+    static RowDataType newRowType(int fieldId) {
+        return new RowDataType(
+                Collections.singletonList(
+                        new DataField(fieldId, "nestedField", new AtomicDataType(new IntType()))));
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/FailingAtomicRenameFileSystem.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/FailingAtomicRenameFileSystem.java
@@ -25,9 +25,11 @@ import org.apache.flink.core.fs.FSDataOutputStreamWrapper;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.FileSystemFactory;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.util.ExceptionUtils;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -156,6 +158,18 @@ public class FailingAtomicRenameFileSystem extends TestAtomicRenameFileSystem {
                 throw new ArtificialException();
             }
             super.write(b, off, len);
+        }
+    }
+
+    public static <T> T retryArtificialException(Callable<T> callable) throws Exception {
+        while (true) {
+            try {
+                return callable.call();
+            } catch (Throwable t) {
+                if (!ExceptionUtils.findThrowable(t, ArtificialException.class).isPresent()) {
+                    throw t;
+                }
+            }
         }
     }
 }

--- a/flink-table-store-hive/src/main/java/org/apache/flink/table/store/mapred/TableStoreInputFormat.java
+++ b/flink-table-store-hive/src/main/java/org/apache/flink/table/store/mapred/TableStoreInputFormat.java
@@ -141,6 +141,7 @@ public class TableStoreInputFormat implements InputFormat<Void, RowDataContainer
                                     .collect(Collectors.toList()));
             return FileStoreImpl.createWithPrimaryKey(
                     tableLocation,
+                    0, // TODO
                     new FileStoreOptions(options),
                     user,
                     partitionType,
@@ -149,7 +150,12 @@ public class TableStoreInputFormat implements InputFormat<Void, RowDataContainer
                     FileStoreOptions.MergeEngine.DEDUPLICATE);
         } else {
             return FileStoreImpl.createWithValueCount(
-                    tableLocation, new FileStoreOptions(options), user, partitionType, rowType);
+                    tableLocation,
+                    0, // TODO
+                    new FileStoreOptions(options),
+                    user,
+                    partitionType,
+                    rowType);
         }
     }
 }

--- a/flink-table-store-hive/src/test/java/org/apache/flink/table/store/FileStoreTestHelper.java
+++ b/flink-table-store-hive/src/test/java/org/apache/flink/table/store/FileStoreTestHelper.java
@@ -71,6 +71,7 @@ public class FileStoreTestHelper {
         this.store =
                 new FileStoreImpl(
                         options.path(oi).toString(),
+                        0,
                         options,
                         UUID.randomUUID().toString(),
                         partitionType,


### PR DESCRIPTION
We can store the schema on the path of the table store, which includes type, options, etc.

This schema should be in a format that supports evolution, which means that the fields contain id information.