### PR TITLE
[FLINK-27408] Package Flink runtime dependencies into associated table store modules instead of flink-table-store-dist

### DIFF
--- a/flink-table-store-codegen-loader/pom.xml
+++ b/flink-table-store-codegen-loader/pom.xml
@@ -86,26 +86,6 @@ under the License.
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>shade-flink</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <artifactSet>
-                                <includes>
-                                    <include>org.apache.flink:flink-table-store-codegen</include>
-                                </includes>
-                            </artifactSet>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/flink-table-store-codegen-loader/src/main/java/org/apache/flink/table/store/codegen/CodeGenLoader.java
+++ b/flink-table-store-codegen-loader/src/main/java/org/apache/flink/table/store/codegen/CodeGenLoader.java
@@ -43,12 +43,6 @@ import java.util.stream.Stream;
 /** Copied and modified from the flink-table-planner-loader module. */
 class CodeGenLoader {
 
-    /**
-     * The name of the table planner dependency jar, bundled with flink-table-planner-loader module
-     * artifact.
-     */
-    static final String FLINK_TABLE_PLANNER_FAT_JAR = "flink-table-planner.jar";
-
     static final String FLINK_TABLE_STORE_CODEGEN_FAT_JAR = "flink-table-store-codegen.jar";
 
     private static final String[] OWNER_CLASSPATH =
@@ -84,20 +78,6 @@ class CodeGenLoader {
             final Path tmpDirectory =
                     Paths.get(ConfigurationUtils.parseTempDirectories(new Configuration())[0]);
             Files.createDirectories(tmpDirectory);
-
-            Path plannerJar =
-                    extractResource(
-                            FLINK_TABLE_PLANNER_FAT_JAR,
-                            flinkClassLoader,
-                            tmpDirectory,
-                            "Flink table planner could not be found.\n"
-                                    + "If you're running a test, please add the following dependency to your pom.xml.\n"
-                                    + "<dependency>\n"
-                                    + "    <groupId>org.apache.flink</groupId>\n"
-                                    + "    <artifactId>flink-table-planner-loader</artifactId>\n"
-                                    + "    <version>${flink.version}</version>\n"
-                                    + "    <scope>test</scope>\n"
-                                    + "</dependency>");
             Path delegateJar =
                     extractResource(
                             FLINK_TABLE_STORE_CODEGEN_FAT_JAR,
@@ -106,10 +86,9 @@ class CodeGenLoader {
                             "Flink table store codegen could not be found.\n"
                                     + "If you're running a test, please make sure you've built the codegen modules by running\n"
                                     + "mvn clean package -pl flink-table-store-codegen,flink-table-store-codegen-loader -DskipTests");
-
             this.submoduleClassLoader =
                     new ComponentClassLoader(
-                            new URL[] {plannerJar.toUri().toURL(), delegateJar.toUri().toURL()},
+                            new URL[] {delegateJar.toUri().toURL()},
                             flinkClassLoader,
                             OWNER_CLASSPATH,
                             COMPONENT_CLASSPATH,

--- a/flink-table-store-codegen/pom.xml
+++ b/flink-table-store-codegen/pom.xml
@@ -42,7 +42,6 @@ under the License.
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
             <version>${flink.version}</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 
@@ -59,6 +58,42 @@ under the License.
                         </goals>
                         <configuration>
                             <skip>true</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>shade-flink</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <minimizeJar>true</minimizeJar>
+                            <artifactSet>
+                                <includes combine.children="append">
+                                    <include>org.apache.flink:flink-table-planner_${scala.binary.version}</include>
+                                    <include>org.scala-lang:*</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>org.apache.flink:flink-table-planner_${scala.binary.version}</artifact>
+                                    <includes>
+                                        <include>org/apache/flink/table/planner/codegen/**</include>
+                                        <include>org/apache/flink/table/planner/plan/nodes/exec/spec/SortSpec**</include>
+                                        <include>org/apache/calcite/rex/**</include>
+                                        <include>org/apache/calcite/rel/**</include>
+                                        <include>org/apache/calcite/sql/**</include>
+                                        <include>scala/**</include>
+                                    </includes>
+                                </filter>
+                            </filters>
                         </configuration>
                     </execution>
                 </executions>

--- a/flink-table-store-core/pom.xml
+++ b/flink-table-store-core/pom.xml
@@ -85,13 +85,6 @@ under the License.
 
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-table-planner-loader</artifactId>
-            <version>${flink.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.flink</groupId>
             <artifactId>flink-avro</artifactId>
             <version>${flink.version}</version>
             <scope>test</scope>

--- a/flink-table-store-dist/pom.xml
+++ b/flink-table-store-dist/pom.xml
@@ -75,20 +75,6 @@ under the License.
             <artifactId>flink-sql-connector-kafka</artifactId>
             <version>${flink.version}</version>
         </dependency>
-
-        <!-- default formats -->
-
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-sql-avro</artifactId>
-            <version>${flink.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-sql-orc</artifactId>
-            <version>${flink.version}</version>
-        </dependency>
     </dependencies>
 
     <build>
@@ -113,8 +99,6 @@ under the License.
                                     <include>org.apache.flink:flink-table-store-format</include>
                                     <include>org.apache.flink:flink-table-store-kafka</include>
                                     <include>org.apache.flink:flink-sql-connector-kafka</include>
-                                    <include>org.apache.flink:flink-sql-avro</include>
-                                    <include>org.apache.flink:flink-sql-orc</include>
                                 </includes>
                             </artifactSet>
                             <filters>
@@ -131,18 +115,6 @@ under the License.
                                 </filter>
                                 <filter>
                                     <artifact>org.apache.flink:flink-sql-connector-kafka</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/services/**</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
-                                    <artifact>org.apache.flink:flink-sql-avro</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/services/**</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
-                                    <artifact>org.apache.flink:flink-sql-orc</artifact>
                                     <excludes>
                                         <exclude>META-INF/services/**</exclude>
                                     </excludes>
@@ -167,42 +139,6 @@ under the License.
                                 <relocation>
                                     <pattern>org.apache.flink.kafka</pattern>
                                     <shadedPattern>org.apache.flink.table.store.shaded.org.apache.flink.kafka</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.apache.flink.avro</pattern>
-                                    <shadedPattern>org.apache.flink.table.store.shaded.org.apache.flink.avro</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.apache.flink.orc</pattern>
-                                    <shadedPattern>org.apache.flink.table.store.shaded.org.apache.flink.orc</shadedPattern>
-                                </relocation>
-                                <!--
-                                flink-sql-orc module does not shade its dependencies, so we shade here.
-                                See maven-shade-plugin usage of flink-sql-orc for detailed dependency list.
-                                -->
-                                <relocation>
-                                    <pattern>org.apache.orc</pattern>
-                                    <shadedPattern>org.apache.flink.table.store.shaded.org.apache.orc</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.apache.hive</pattern>
-                                    <shadedPattern>org.apache.flink.table.store.shaded.org.apache.hive</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.apache.hadoop.hive</pattern>
-                                    <shadedPattern>org.apache.flink.table.store.shaded.org.apache.hadoop.hive</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>io.airlift</pattern>
-                                    <shadedPattern>org.apache.flink.table.store.shaded.io.airlift</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.apache.commons</pattern>
-                                    <shadedPattern>org.apache.flink.table.store.shaded.org.apache.commons</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.google.protobuf</pattern>
-                                    <shadedPattern>org.apache.flink.table.store.shaded.com.google.protobuf</shadedPattern>
                                 </relocation>
                                 <!--
                                 flink-sql-connector-kafka contains shaded kafka classes.

--- a/flink-table-store-format/pom.xml
+++ b/flink-table-store-format/pom.xml
@@ -64,9 +64,37 @@ under the License.
 
         <dependency>
             <groupId>org.apache.flink</groupId>
+            <artifactId>flink-sql-avro</artifactId>
+            <version>${flink.version}</version>
+            <scope>runtime</scope>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
             <artifactId>flink-orc</artifactId>
             <version>${flink.version}</version>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-sql-orc</artifactId>
+            <version>${flink.version}</version>
+            <scope>runtime</scope>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -163,4 +191,94 @@ under the License.
             </exclusions>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>shade-flink</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes combine.children="append">
+                                    <include>org.apache.flink:flink-sql-avro</include>
+                                    <include>org.apache.flink:flink-sql-orc</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <!--
+                                Throw away all META-INF/services,
+                                otherwise if user has the same format/connector jar in the classpath,
+                                FactoryUtil will complain about multiple matching factories.
+                                -->
+                                <filter>
+                                    <artifact>org.apache.flink:flink-sql-avro</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/services/**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.apache.flink:flink-sql-orc</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/services/**</exclude>
+                                    </excludes>
+                                </filter>
+                                <!-- Another copy of the Apache license, which we don't need. -->
+                                <filter>
+                                    <artifact>*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/LICENSE.txt</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache.flink.avro</pattern>
+                                    <shadedPattern>org.apache.flink.table.store.shaded.org.apache.flink.avro</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.flink.orc</pattern>
+                                    <shadedPattern>org.apache.flink.table.store.shaded.org.apache.flink.orc</shadedPattern>
+                                </relocation>
+                                <!--
+                                flink-sql-orc module does not shade its dependencies, so we shade here.
+                                See maven-shade-plugin usage of flink-sql-orc for detailed dependency list.
+                                -->
+                                <relocation>
+                                    <pattern>org.apache.orc</pattern>
+                                    <shadedPattern>org.apache.flink.table.store.shaded.org.apache.orc</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.hive</pattern>
+                                    <shadedPattern>org.apache.flink.table.store.shaded.org.apache.hive</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.hadoop.hive</pattern>
+                                    <shadedPattern>org.apache.flink.table.store.shaded.org.apache.hadoop.hive</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.airlift</pattern>
+                                    <shadedPattern>org.apache.flink.table.store.shaded.io.airlift</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons</pattern>
+                                    <shadedPattern>org.apache.flink.table.store.shaded.org.apache.commons</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.protobuf</pattern>
+                                    <shadedPattern>org.apache.flink.table.store.shaded.com.google.protobuf</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Currently all Flink dependencies needed at runtime (for example, flink-sql-avro) by table store are packaged in flink-table-store-dist module. If we would like to enable other systems to read from table store in the future all these dependencies need to be copied to the distribution module of that system.

So instead we should move these dependencies to the associated table store module so that the number of dependencies in flink-table-store-dist can be decreased.