### PR TITLE
[FLINK-27336] Avoid merging when there is only one record

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/MergeFunctionHelper.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/MergeFunctionHelper.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.mergetree.compact;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+
+import static org.apache.flink.table.store.file.mergetree.compact.ValueCountMergeFunction.count;
+
+/** Helper functions for the interaction with {@link MergeFunction}. */
+public class MergeFunctionHelper {
+
+    private final MergeFunction mergeFunction;
+
+    private RowData rowData;
+    private boolean isInitialized;
+
+    public MergeFunctionHelper(MergeFunction mergeFunction) {
+        this.mergeFunction = mergeFunction;
+    }
+
+    /**
+     * Resets the {@link MergeFunction} helper to its default state: 1. Clears the one record which
+     * the helper maintains. 2. Resets the {@link MergeFunction} to its default state. 3. Clears the
+     * initialized state of the {@link MergeFunction}.
+     */
+    public void reset() {
+        rowData = null;
+        mergeFunction.reset();
+        isInitialized = false;
+    }
+
+    /** Adds the given {@link RowData} to the {@link MergeFunction} helper. */
+    public void add(RowData value) {
+        if (rowData == null) {
+            rowData = value;
+        } else {
+            if (!isInitialized) {
+                mergeFunction.add(rowData);
+                isInitialized = true;
+            }
+            mergeFunction.add(value);
+        }
+    }
+
+    /**
+     * Get current value of the {@link MergeFunction} helper. Return null if the value should be
+     * skipped.
+     */
+    public RowData getValue() {
+        return isInitialized
+                ? mergeFunction.getValue()
+                : mergeFunction instanceof ValueCountMergeFunction
+                        ? (count(rowData) == 0 ? null : GenericRowData.of(count(rowData)))
+                        : rowData;
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/MergeFunctionHelper.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/MergeFunctionHelper.java
@@ -18,10 +18,7 @@
 
 package org.apache.flink.table.store.file.mergetree.compact;
 
-import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
-
-import static org.apache.flink.table.store.file.mergetree.compact.ValueCountMergeFunction.count;
 
 /** Helper functions for the interaction with {@link MergeFunction}. */
 public class MergeFunctionHelper {
@@ -64,10 +61,6 @@ public class MergeFunctionHelper {
      * skipped.
      */
     public RowData getValue() {
-        return isInitialized
-                ? mergeFunction.getValue()
-                : mergeFunction instanceof ValueCountMergeFunction
-                        ? (count(rowData) == 0 ? null : GenericRowData.of(count(rowData)))
-                        : rowData;
+        return isInitialized ? mergeFunction.getValue() : rowData;
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/SortMergeReader.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/SortMergeReader.java
@@ -42,7 +42,7 @@ public class SortMergeReader implements RecordReader<KeyValue> {
 
     private final List<RecordReader<KeyValue>> nextBatchReaders;
     private final Comparator<RowData> userKeyComparator;
-    private final MergeFunction mergeFunction;
+    private final MergeFunctionHelper mergeFunctionHelper;
 
     private final PriorityQueue<Element> minHeap;
     private final List<Element> polled;
@@ -53,7 +53,7 @@ public class SortMergeReader implements RecordReader<KeyValue> {
             MergeFunction mergeFunction) {
         this.nextBatchReaders = new ArrayList<>(readers);
         this.userKeyComparator = userKeyComparator;
-        this.mergeFunction = mergeFunction;
+        this.mergeFunctionHelper = new MergeFunctionHelper(mergeFunction);
 
         this.minHeap =
                 new PriorityQueue<>(
@@ -130,7 +130,7 @@ public class SortMergeReader implements RecordReader<KeyValue> {
                 if (!hasMore) {
                     return null;
                 }
-                RowData mergedValue = mergeFunction.getValue();
+                RowData mergedValue = mergeFunctionHelper.getValue();
                 if (mergedValue != null) {
                     return polled.get(polled.size() - 1).kv.setValue(mergedValue);
                 }
@@ -163,7 +163,7 @@ public class SortMergeReader implements RecordReader<KeyValue> {
                 return false;
             }
 
-            mergeFunction.reset();
+            mergeFunctionHelper.reset();
             RowData key =
                     Preconditions.checkNotNull(minHeap.peek(), "Min heap is empty. This is a bug.")
                             .kv
@@ -177,7 +177,7 @@ public class SortMergeReader implements RecordReader<KeyValue> {
                     break;
                 }
                 minHeap.poll();
-                mergeFunction.add(element.kv.value());
+                mergeFunctionHelper.add(element.kv.value());
                 polled.add(element);
             }
             return true;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/ValueCountMergeFunction.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/ValueCountMergeFunction.java
@@ -56,7 +56,7 @@ public class ValueCountMergeFunction implements MergeFunction {
         return new ValueCountMergeFunction();
     }
 
-    protected static long count(RowData value) {
+    private long count(RowData value) {
         checkArgument(!value.isNullAt(0), "Value count should not be null.");
         return value.getLong(0);
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/ValueCountMergeFunction.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/ValueCountMergeFunction.java
@@ -56,7 +56,7 @@ public class ValueCountMergeFunction implements MergeFunction {
         return new ValueCountMergeFunction();
     }
 
-    private long count(RowData value) {
+    protected static long count(RowData value) {
         checkArgument(!value.isNullAt(0), "Value count should not be null.");
         return value.getLong(0);
     }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/MergeFunctionHelperTestBase.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/MergeFunctionHelperTestBase.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.mergetree.compact;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.apache.flink.table.store.file.data.DataFileTestUtils.row;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Tests for {@link MergeFunctionHelper}. */
+public abstract class MergeFunctionHelperTestBase {
+
+    protected MergeFunctionHelper mergeFunctionHelper;
+
+    private List<RowData> rows;
+
+    protected abstract MergeFunction createMergeFunction();
+
+    protected abstract RowData getExpected(List<RowData> rows);
+
+    @BeforeEach
+    void setUp() {
+        mergeFunctionHelper = new MergeFunctionHelper(createMergeFunction());
+    }
+
+    @MethodSource("provideMergedRowData")
+    @ParameterizedTest
+    public void testMergeFunctionHelper(List<RowData> rows) {
+        rows.forEach(r -> mergeFunctionHelper.add(r));
+        assertEquals(getExpected(rows), mergeFunctionHelper.getValue());
+    }
+
+    public static Stream<Arguments> provideMergedRowData() {
+        return Stream.of(
+                Arguments.of(Collections.singletonList(row(0))),
+                Arguments.of(Collections.singletonList(row(1))),
+                Arguments.of(Arrays.asList(row(-1), row(0), row(1))),
+                Arguments.of(Arrays.asList(row(0), row(1), row(2))));
+    }
+
+    /** Tests for {@link MergeFunctionHelper} with {@link DeduplicateMergeFunction}. */
+    public static class WithDeduplicateMergeFunctionTest extends MergeFunctionHelperTestBase {
+
+        @Override
+        protected MergeFunction createMergeFunction() {
+            return new DeduplicateMergeFunction();
+        }
+
+        @Override
+        protected RowData getExpected(List<RowData> rows) {
+            return rows.get(rows.size() - 1);
+        }
+    }
+
+    /** Tests for {@link MergeFunctionHelper} with {@link ValueCountMergeFunction}. */
+    public static class WithValueRecordMergeFunctionTest extends MergeFunctionHelperTestBase {
+
+        @Override
+        protected MergeFunction createMergeFunction() {
+            return new ValueCountMergeFunction();
+        }
+
+        @Override
+        protected RowData getExpected(List<RowData> rows) {
+            long total = rows.stream().mapToLong(r -> r.getLong(0)).sum();
+            return total == 0 ? null : GenericRowData.of(total);
+        }
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/MergeFunctionHelperTestBase.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/MergeFunctionHelperTestBase.java
@@ -39,8 +39,6 @@ public abstract class MergeFunctionHelperTestBase {
 
     protected MergeFunctionHelper mergeFunctionHelper;
 
-    private List<RowData> rows;
-
     protected abstract MergeFunction createMergeFunction();
 
     protected abstract RowData getExpected(List<RowData> rows);
@@ -59,10 +57,9 @@ public abstract class MergeFunctionHelperTestBase {
 
     public static Stream<Arguments> provideMergedRowData() {
         return Stream.of(
-                Arguments.of(Collections.singletonList(row(0))),
                 Arguments.of(Collections.singletonList(row(1))),
-                Arguments.of(Arrays.asList(row(-1), row(0), row(1))),
-                Arguments.of(Arrays.asList(row(0), row(1), row(2))));
+                Arguments.of(Arrays.asList(row(-1), row(1))),
+                Arguments.of(Arrays.asList(row(1), row(2))));
     }
 
     /** Tests for {@link MergeFunctionHelper} with {@link DeduplicateMergeFunction}. */
@@ -89,8 +86,12 @@ public abstract class MergeFunctionHelperTestBase {
 
         @Override
         protected RowData getExpected(List<RowData> rows) {
-            long total = rows.stream().mapToLong(r -> r.getLong(0)).sum();
-            return total == 0 ? null : GenericRowData.of(total);
+            if (rows.size() == 1) {
+                return rows.get(0);
+            } else {
+                long total = rows.stream().mapToLong(r -> r.getLong(0)).sum();
+                return total == 0 ? null : GenericRowData.of(total);
+            }
         }
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/ReusingTestData.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/ReusingTestData.java
@@ -105,7 +105,7 @@ public class ReusingTestData implements Comparable<ReusingTestData> {
                             random.nextInt(numRecords),
                             generator.next(),
                             random.nextBoolean() || onlyAdd ? RowKind.INSERT : RowKind.DELETE,
-                            random.nextInt(10) - 5));
+                            getValue(random)));
         }
         return result;
     }
@@ -123,9 +123,14 @@ public class ReusingTestData implements Comparable<ReusingTestData> {
                             key,
                             generator.next(),
                             random.nextBoolean() || onlyAdd ? RowKind.INSERT : RowKind.DELETE,
-                            random.nextInt(10) - 5));
+                            getValue(random)));
         }
         return new ArrayList<>(result.values());
+    }
+
+    private static long getValue(ThreadLocalRandom random) {
+        int value = random.nextInt(10) - 5;
+        return value == 0 ? getValue(random) : value;
     }
 
     private static class SequenceNumberGenerator {


### PR DESCRIPTION
If there is just one record, still use `MergeFunction` to merge. This is not necessary, just output directly.

**The brief change log**

- Updates the merge in the `SortBufferMemTable` and `SortMergeReader` to output directly if there is only one record, and use `MergeFunction` to merge in the case of multiple records.