### PR TITLE
[FLINK-27503] Rename sst file to data file

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplit.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplit.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.store.connector.source;
 
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.table.data.binary.BinaryRowData;
-import org.apache.flink.table.store.file.mergetree.sst.SstFileMeta;
+import org.apache.flink.table.store.file.data.DataFileMeta;
 
 import java.util.List;
 import java.util.Objects;
@@ -35,12 +35,12 @@ public class FileStoreSourceSplit implements SourceSplit {
 
     private final int bucket;
 
-    private final List<SstFileMeta> files;
+    private final List<DataFileMeta> files;
 
     private final long recordsToSkip;
 
     public FileStoreSourceSplit(
-            String id, BinaryRowData partition, int bucket, List<SstFileMeta> files) {
+            String id, BinaryRowData partition, int bucket, List<DataFileMeta> files) {
         this(id, partition, bucket, files, 0);
     }
 
@@ -48,7 +48,7 @@ public class FileStoreSourceSplit implements SourceSplit {
             String id,
             BinaryRowData partition,
             int bucket,
-            List<SstFileMeta> files,
+            List<DataFileMeta> files,
             long recordsToSkip) {
         this.id = id;
         this.partition = partition;
@@ -65,7 +65,7 @@ public class FileStoreSourceSplit implements SourceSplit {
         return bucket;
     }
 
-    public List<SstFileMeta> files() {
+    public List<DataFileMeta> files() {
         return files;
     }
 

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitSerializer.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitSerializer.java
@@ -22,7 +22,7 @@ import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.table.runtime.typeutils.BinaryRowDataSerializer;
-import org.apache.flink.table.store.file.mergetree.sst.SstFileMetaSerializer;
+import org.apache.flink.table.store.file.data.DataFileMetaSerializer;
 import org.apache.flink.table.types.logical.RowType;
 
 import java.io.ByteArrayOutputStream;
@@ -33,12 +33,12 @@ public class FileStoreSourceSplitSerializer
         implements SimpleVersionedSerializer<FileStoreSourceSplit> {
 
     private final BinaryRowDataSerializer partSerializer;
-    private final SstFileMetaSerializer sstSerializer;
+    private final DataFileMetaSerializer dataFileSerializer;
 
     public FileStoreSourceSplitSerializer(
             RowType partitionType, RowType keyType, RowType valueType) {
         this.partSerializer = new BinaryRowDataSerializer(partitionType.getFieldCount());
-        this.sstSerializer = new SstFileMetaSerializer(keyType, valueType);
+        this.dataFileSerializer = new DataFileMetaSerializer(keyType, valueType);
     }
 
     @Override
@@ -53,7 +53,7 @@ public class FileStoreSourceSplitSerializer
         view.writeUTF(split.splitId());
         partSerializer.serialize(split.partition(), view);
         view.writeInt(split.bucket());
-        sstSerializer.serializeList(split.files(), view);
+        dataFileSerializer.serializeList(split.files(), view);
         view.writeLong(split.recordsToSkip());
         return out.toByteArray();
     }
@@ -65,7 +65,7 @@ public class FileStoreSourceSplitSerializer
                 view.readUTF(),
                 partSerializer.deserialize(view),
                 view.readInt(),
-                sstSerializer.deserializeList(view),
+                dataFileSerializer.deserializeList(view),
                 view.readLong());
     }
 }

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ReadWriteTableTestBase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ReadWriteTableTestBase.java
@@ -78,7 +78,7 @@ public class ReadWriteTableTestBase extends KafkaTableTestBase {
         assertThat(Paths.get(rootPath, relativeFilePath, "snapshot")).exists();
         // check manifest file path
         assertThat(Paths.get(rootPath, relativeFilePath, "manifest")).exists();
-        // check sst file path
+        // check data file path
         if (partitionList == null) {
             // at least exists bucket-0
             assertThat(Paths.get(rootPath, relativeFilePath, "bucket-0")).exists();

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/TestFileStore.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/TestFileStore.java
@@ -22,9 +22,9 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.store.file.FileStore;
 import org.apache.flink.table.store.file.ValueKind;
+import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.manifest.ManifestCommittable;
 import org.apache.flink.table.store.file.mergetree.Increment;
-import org.apache.flink.table.store.file.mergetree.sst.SstFileMeta;
 import org.apache.flink.table.store.file.operation.FileStoreCommit;
 import org.apache.flink.table.store.file.operation.FileStoreExpire;
 import org.apache.flink.table.store.file.operation.FileStoreRead;
@@ -184,11 +184,11 @@ public class TestFileStore implements FileStore {
 
         @Override
         public Increment prepareCommit() {
-            List<SstFileMeta> newFiles =
+            List<DataFileMeta> newFiles =
                     records.stream()
                             .map(
                                     s ->
-                                            new SstFileMeta(
+                                            new DataFileMeta(
                                                     s,
                                                     0,
                                                     0,
@@ -215,7 +215,7 @@ public class TestFileStore implements FileStore {
         }
 
         @Override
-        public List<SstFileMeta> close() {
+        public List<DataFileMeta> close() {
             closed = true;
             return Collections.emptyList();
         }
@@ -260,7 +260,7 @@ public class TestFileStore implements FileStore {
                                                                         bucket,
                                                                         k -> new ArrayList<>());
                                                 files.stream()
-                                                        .map(SstFileMeta::fileName)
+                                                        .map(DataFileMeta::fileName)
                                                         .forEach(committed::add);
                                             }));
         }

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitGeneratorTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitGeneratorTest.java
@@ -19,8 +19,8 @@
 package org.apache.flink.table.store.connector.source;
 
 import org.apache.flink.table.store.file.ValueKind;
+import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.manifest.ManifestEntry;
-import org.apache.flink.table.store.file.mergetree.sst.SstFileMeta;
 import org.apache.flink.table.store.file.operation.FileStoreScan;
 import org.apache.flink.table.store.file.stats.FieldStats;
 
@@ -94,7 +94,7 @@ public class FileStoreSourceSplitGeneratorTest {
         assertThat(split.splitId()).isEqualTo(splitId);
         assertThat(split.partition().getInt(0)).isEqualTo(part);
         assertThat(split.bucket()).isEqualTo(bucket);
-        assertThat(split.files().stream().map(SstFileMeta::fileName).collect(Collectors.toList()))
+        assertThat(split.files().stream().map(DataFileMeta::fileName).collect(Collectors.toList()))
                 .isEqualTo(files);
     }
 
@@ -104,7 +104,7 @@ public class FileStoreSourceSplitGeneratorTest {
                 row(partition), // not used
                 bucket, // not used
                 0, // not used
-                new SstFileMeta(
+                new DataFileMeta(
                         fileName,
                         0, // not used
                         0, // not used

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitReaderTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitReaderTest.java
@@ -26,7 +26,7 @@ import org.apache.flink.connector.file.src.util.RecordAndPosition;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.file.ValueKind;
-import org.apache.flink.table.store.file.mergetree.sst.SstFileMeta;
+import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.utils.RecordWriter;
 import org.apache.flink.types.RowKind;
 
@@ -92,7 +92,7 @@ public class FileStoreSourceSplitReaderTest {
                 new FileStoreSourceSplitReader(rw.createRead(), valueCountMode);
 
         List<Tuple2<Long, Long>> input = kvs();
-        List<SstFileMeta> files = rw.writeFiles(row(1), 0, input);
+        List<DataFileMeta> files = rw.writeFiles(row(1), 0, input);
 
         assignSplit(reader, new FileStoreSourceSplit("id1", row(1), 0, files, skip));
 
@@ -139,7 +139,7 @@ public class FileStoreSourceSplitReaderTest {
             writer.write(ValueKind.ADD, GenericRowData.of(tuple2.f0), GenericRowData.of(tuple2.f1));
         }
         writer.write(ValueKind.DELETE, GenericRowData.of(222L), GenericRowData.of(333L));
-        List<SstFileMeta> files = writer.prepareCommit().newFiles();
+        List<DataFileMeta> files = writer.prepareCommit().newFiles();
         writer.close();
 
         assignSplit(reader, new FileStoreSourceSplit("id1", row(1), 0, files));
@@ -166,10 +166,10 @@ public class FileStoreSourceSplitReaderTest {
         FileStoreSourceSplitReader reader = new FileStoreSourceSplitReader(rw.createRead(), false);
 
         List<Tuple2<Long, Long>> input1 = kvs();
-        List<SstFileMeta> files = rw.writeFiles(row(1), 0, input1);
+        List<DataFileMeta> files = rw.writeFiles(row(1), 0, input1);
 
         List<Tuple2<Long, Long>> input2 = kvs(6);
-        List<SstFileMeta> files2 = rw.writeFiles(row(1), 0, input2);
+        List<DataFileMeta> files2 = rw.writeFiles(row(1), 0, input2);
         files.addAll(files2);
 
         assignSplit(reader, new FileStoreSourceSplit("id1", row(1), 0, files));
@@ -202,7 +202,7 @@ public class FileStoreSourceSplitReaderTest {
         FileStoreSourceSplitReader reader = new FileStoreSourceSplitReader(rw.createRead(), false);
 
         List<Tuple2<Long, Long>> input = kvs();
-        List<SstFileMeta> files = rw.writeFiles(row(1), 0, input);
+        List<DataFileMeta> files = rw.writeFiles(row(1), 0, input);
 
         assignSplit(reader, new FileStoreSourceSplit("id1", row(1), 0, files, 3));
 
@@ -228,10 +228,10 @@ public class FileStoreSourceSplitReaderTest {
         FileStoreSourceSplitReader reader = new FileStoreSourceSplitReader(rw.createRead(), false);
 
         List<Tuple2<Long, Long>> input1 = kvs();
-        List<SstFileMeta> files = rw.writeFiles(row(1), 0, input1);
+        List<DataFileMeta> files = rw.writeFiles(row(1), 0, input1);
 
         List<Tuple2<Long, Long>> input2 = kvs(6);
-        List<SstFileMeta> files2 = rw.writeFiles(row(1), 0, input2);
+        List<DataFileMeta> files2 = rw.writeFiles(row(1), 0, input2);
         files.addAll(files2);
 
         assignSplit(reader, new FileStoreSourceSplit("id1", row(1), 0, files, 7));
@@ -259,11 +259,11 @@ public class FileStoreSourceSplitReaderTest {
         FileStoreSourceSplitReader reader = new FileStoreSourceSplitReader(rw.createRead(), false);
 
         List<Tuple2<Long, Long>> input1 = kvs();
-        List<SstFileMeta> files1 = rw.writeFiles(row(1), 0, input1);
+        List<DataFileMeta> files1 = rw.writeFiles(row(1), 0, input1);
         assignSplit(reader, new FileStoreSourceSplit("id1", row(1), 0, files1));
 
         List<Tuple2<Long, Long>> input2 = kvs();
-        List<SstFileMeta> files2 = rw.writeFiles(row(2), 1, input2);
+        List<DataFileMeta> files2 = rw.writeFiles(row(2), 1, input2);
         assignSplit(reader, new FileStoreSourceSplit("id2", row(2), 1, files2));
 
         RecordsWithSplitIds<RecordAndPosition<RowData>> records = reader.fetch();

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitSerializerTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitSerializerTest.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.store.connector.source;
 
 import org.apache.flink.core.io.SimpleVersionedSerialization;
-import org.apache.flink.table.store.file.mergetree.sst.SstFileMeta;
+import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.stats.FieldStats;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
@@ -73,8 +73,8 @@ public class FileStoreSourceSplitSerializerTest {
     //  test utils
     // ------------------------------------------------------------------------
 
-    public static SstFileMeta newFile(int level) {
-        return new SstFileMeta(
+    public static DataFileMeta newFile(int level) {
+        return new DataFileMeta(
                 "",
                 0,
                 1,

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/TestDataReadWrite.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/TestDataReadWrite.java
@@ -25,10 +25,10 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.store.file.ValueKind;
+import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.format.FileFormat;
 import org.apache.flink.table.store.file.mergetree.MergeTreeOptions;
 import org.apache.flink.table.store.file.mergetree.compact.DeduplicateMergeFunction;
-import org.apache.flink.table.store.file.mergetree.sst.SstFileMeta;
 import org.apache.flink.table.store.file.operation.FileStoreRead;
 import org.apache.flink.table.store.file.operation.FileStoreReadImpl;
 import org.apache.flink.table.store.file.operation.FileStoreWriteImpl;
@@ -81,7 +81,7 @@ public class TestDataReadWrite {
                 pathFactory);
     }
 
-    public List<SstFileMeta> writeFiles(
+    public List<DataFileMeta> writeFiles(
             BinaryRowData partition, int bucket, List<Tuple2<Long, Long>> kvs) throws Exception {
         Preconditions.checkNotNull(
                 service, "ExecutorService must be provided if writeFiles is needed");
@@ -89,7 +89,7 @@ public class TestDataReadWrite {
         for (Tuple2<Long, Long> tuple2 : kvs) {
             writer.write(ValueKind.ADD, GenericRowData.of(tuple2.f0), GenericRowData.of(tuple2.f1));
         }
-        List<SstFileMeta> files = writer.prepareCommit().newFiles();
+        List<DataFileMeta> files = writer.prepareCommit().newFiles();
         writer.close();
         return new ArrayList<>(files);
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/Snapshot.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/Snapshot.java
@@ -174,7 +174,7 @@ public class Snapshot {
         /** Changes flushed from the mem table. */
         APPEND,
 
-        /** Changes by compacting existing sst files. */
+        /** Changes by compacting existing data files. */
         COMPACT,
 
         /** Changes that clear up the whole partition and then add new records. */

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileMeta.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileMeta.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.store.file.mergetree.sst;
+package org.apache.flink.table.store.file.data;
 
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.store.file.stats.FieldStats;
@@ -33,8 +33,8 @@ import java.util.Objects;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 
-/** Metadata of a SST file. */
-public class SstFileMeta {
+/** Metadata of a data file. */
+public class DataFileMeta {
 
     private final String fileName;
     private final long fileSize;
@@ -49,7 +49,7 @@ public class SstFileMeta {
     private final long maxSequenceNumber;
     private final int level;
 
-    public SstFileMeta(
+    public DataFileMeta(
             String fileName,
             long fileSize,
             long rowCount,
@@ -114,9 +114,9 @@ public class SstFileMeta {
         return level;
     }
 
-    public SstFileMeta upgrade(int newLevel) {
+    public DataFileMeta upgrade(int newLevel) {
         checkArgument(newLevel > this.level);
-        return new SstFileMeta(
+        return new DataFileMeta(
                 fileName,
                 fileSize,
                 rowCount,
@@ -131,10 +131,10 @@ public class SstFileMeta {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof SstFileMeta)) {
+        if (!(o instanceof DataFileMeta)) {
             return false;
         }
-        SstFileMeta that = (SstFileMeta) o;
+        DataFileMeta that = (DataFileMeta) o;
         return Objects.equals(fileName, that.fileName)
                 && fileSize == that.fileSize
                 && rowCount == that.rowCount

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileMetaSerializer.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileMetaSerializer.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.store.file.mergetree.sst;
+package org.apache.flink.table.store.file.data;
 
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
@@ -26,8 +26,8 @@ import org.apache.flink.table.store.file.stats.FieldStatsArraySerializer;
 import org.apache.flink.table.store.file.utils.ObjectSerializer;
 import org.apache.flink.table.types.logical.RowType;
 
-/** Serializer for {@link SstFileMeta}. */
-public class SstFileMetaSerializer extends ObjectSerializer<SstFileMeta> {
+/** Serializer for {@link DataFileMeta}. */
+public class DataFileMetaSerializer extends ObjectSerializer<DataFileMeta> {
 
     private static final long serialVersionUID = 1L;
 
@@ -35,15 +35,15 @@ public class SstFileMetaSerializer extends ObjectSerializer<SstFileMeta> {
     private final FieldStatsArraySerializer keyStatsArraySerializer;
     private final FieldStatsArraySerializer valueStatsArraySerializer;
 
-    public SstFileMetaSerializer(RowType keyType, RowType valueType) {
-        super(SstFileMeta.schema(keyType, valueType));
+    public DataFileMetaSerializer(RowType keyType, RowType valueType) {
+        super(DataFileMeta.schema(keyType, valueType));
         this.keySerializer = new RowDataSerializer(keyType);
         this.keyStatsArraySerializer = new FieldStatsArraySerializer(keyType);
         this.valueStatsArraySerializer = new FieldStatsArraySerializer(valueType);
     }
 
     @Override
-    public RowData toRow(SstFileMeta meta) {
+    public RowData toRow(DataFileMeta meta) {
         return GenericRowData.of(
                 StringData.fromString(meta.fileName()),
                 meta.fileSize(),
@@ -58,9 +58,9 @@ public class SstFileMetaSerializer extends ObjectSerializer<SstFileMeta> {
     }
 
     @Override
-    public SstFileMeta fromRow(RowData row) {
+    public DataFileMeta fromRow(RowData row) {
         int keyFieldCount = keySerializer.getArity();
-        return new SstFileMeta(
+        return new DataFileMeta(
                 row.getString(0).toString(),
                 row.getLong(1),
                 row.getLong(2),

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFilePathFactory.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFilePathFactory.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.store.file.mergetree.sst;
+package org.apache.flink.table.store.file.data;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.fs.Path;
@@ -26,16 +26,16 @@ import javax.annotation.concurrent.ThreadSafe;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
-/** Factory which produces new {@link Path}s for sst files. */
+/** Factory which produces new {@link Path}s for data files. */
 @ThreadSafe
-public class SstPathFactory {
+public class DataFilePathFactory {
 
     private final Path bucketDir;
     private final String uuid;
 
     private final AtomicInteger pathCount;
 
-    public SstPathFactory(Path root, String partition, int bucket) {
+    public DataFilePathFactory(Path root, String partition, int bucket) {
         this.bucketDir = new Path(root + "/" + partition + "/bucket-" + bucket);
         this.uuid = UUID.randomUUID().toString();
 
@@ -43,7 +43,7 @@ public class SstPathFactory {
     }
 
     public Path newPath() {
-        return new Path(bucketDir + "/sst-" + uuid + "-" + pathCount.getAndIncrement());
+        return new Path(bucketDir + "/data-" + uuid + "-" + pathCount.getAndIncrement());
     }
 
     public Path toPath(String fileName) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestCommittable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestCommittable.java
@@ -19,8 +19,8 @@
 package org.apache.flink.table.store.file.manifest;
 
 import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.mergetree.Increment;
-import org.apache.flink.table.store.file.mergetree.sst.SstFileMeta;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -33,9 +33,9 @@ public class ManifestCommittable {
 
     private final String identifier;
     private final Map<Integer, Long> logOffsets;
-    private final Map<BinaryRowData, Map<Integer, List<SstFileMeta>>> newFiles;
-    private final Map<BinaryRowData, Map<Integer, List<SstFileMeta>>> compactBefore;
-    private final Map<BinaryRowData, Map<Integer, List<SstFileMeta>>> compactAfter;
+    private final Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> newFiles;
+    private final Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> compactBefore;
+    private final Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> compactAfter;
 
     public ManifestCommittable(String identifier) {
         this.identifier = identifier;
@@ -48,9 +48,9 @@ public class ManifestCommittable {
     public ManifestCommittable(
             String identifier,
             Map<Integer, Long> logOffsets,
-            Map<BinaryRowData, Map<Integer, List<SstFileMeta>>> newFiles,
-            Map<BinaryRowData, Map<Integer, List<SstFileMeta>>> compactBefore,
-            Map<BinaryRowData, Map<Integer, List<SstFileMeta>>> compactAfter) {
+            Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> newFiles,
+            Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> compactBefore,
+            Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> compactAfter) {
         this.identifier = identifier;
         this.logOffsets = logOffsets;
         this.newFiles = newFiles;
@@ -74,10 +74,10 @@ public class ManifestCommittable {
     }
 
     private static void addFiles(
-            Map<BinaryRowData, Map<Integer, List<SstFileMeta>>> map,
+            Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> map,
             BinaryRowData partition,
             int bucket,
-            List<SstFileMeta> files) {
+            List<DataFileMeta> files) {
         map.computeIfAbsent(partition, k -> new HashMap<>())
                 .computeIfAbsent(bucket, k -> new ArrayList<>())
                 .addAll(files);
@@ -91,15 +91,15 @@ public class ManifestCommittable {
         return logOffsets;
     }
 
-    public Map<BinaryRowData, Map<Integer, List<SstFileMeta>>> newFiles() {
+    public Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> newFiles() {
         return newFiles;
     }
 
-    public Map<BinaryRowData, Map<Integer, List<SstFileMeta>>> compactBefore() {
+    public Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> compactBefore() {
         return compactBefore;
     }
 
-    public Map<BinaryRowData, Map<Integer, List<SstFileMeta>>> compactAfter() {
+    public Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> compactAfter() {
         return compactAfter;
     }
 
@@ -140,19 +140,20 @@ public class ManifestCommittable {
                 + '}';
     }
 
-    private static String filesToString(Map<BinaryRowData, Map<Integer, List<SstFileMeta>>> files) {
+    private static String filesToString(
+            Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> files) {
         StringBuilder builder = new StringBuilder();
-        for (Map.Entry<BinaryRowData, Map<Integer, List<SstFileMeta>>> entryWithPartition :
+        for (Map.Entry<BinaryRowData, Map<Integer, List<DataFileMeta>>> entryWithPartition :
                 files.entrySet()) {
-            for (Map.Entry<Integer, List<SstFileMeta>> entryWithBucket :
+            for (Map.Entry<Integer, List<DataFileMeta>> entryWithBucket :
                     entryWithPartition.getValue().entrySet()) {
-                for (SstFileMeta sst : entryWithBucket.getValue()) {
+                for (DataFileMeta dataFile : entryWithBucket.getValue()) {
                     builder.append("  * partition: ")
                             .append(entryWithPartition.getKey())
                             .append(", bucket: ")
                             .append(entryWithBucket.getKey())
                             .append(", file: ")
-                            .append(sst.fileName())
+                            .append(dataFile.fileName())
                             .append("\n");
                 }
             }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestEntry.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestEntry.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.store.file.manifest;
 
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.store.file.ValueKind;
-import org.apache.flink.table.store.file.mergetree.sst.SstFileMeta;
+import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.TinyIntType;
@@ -29,7 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-/** Entry of a manifest file, representing an addition / deletion of a SST file. */
+/** Entry of a manifest file, representing an addition / deletion of a data file. */
 public class ManifestEntry {
 
     private final ValueKind kind;
@@ -37,14 +37,14 @@ public class ManifestEntry {
     private final BinaryRowData partition;
     private final int bucket;
     private final int totalBuckets;
-    private final SstFileMeta file;
+    private final DataFileMeta file;
 
     public ManifestEntry(
             ValueKind kind,
             BinaryRowData partition,
             int bucket,
             int totalBuckets,
-            SstFileMeta file) {
+            DataFileMeta file) {
         this.kind = kind;
         this.partition = partition;
         this.bucket = bucket;
@@ -68,7 +68,7 @@ public class ManifestEntry {
         return totalBuckets;
     }
 
-    public SstFileMeta file() {
+    public DataFileMeta file() {
         return file;
     }
 
@@ -82,7 +82,7 @@ public class ManifestEntry {
         fields.add(new RowType.RowField("_PARTITION", partitionType));
         fields.add(new RowType.RowField("_BUCKET", new IntType(false)));
         fields.add(new RowType.RowField("_TOTAL_BUCKETS", new IntType(false)));
-        fields.add(new RowType.RowField("_FILE", SstFileMeta.schema(keyType, valueType)));
+        fields.add(new RowType.RowField("_FILE", DataFileMeta.schema(keyType, valueType)));
         return new RowType(fields);
     }
 
@@ -110,7 +110,7 @@ public class ManifestEntry {
     }
 
     /**
-     * The same {@link Identifier} indicates that the {@link ManifestEntry} refers to the same sst
+     * The same {@link Identifier} indicates that the {@link ManifestEntry} refers to the same data
      * file.
      */
     public static class Identifier {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestEntrySerializer.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestEntrySerializer.java
@@ -22,7 +22,7 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.store.file.ValueKind;
-import org.apache.flink.table.store.file.mergetree.sst.SstFileMetaSerializer;
+import org.apache.flink.table.store.file.data.DataFileMetaSerializer;
 import org.apache.flink.table.store.file.utils.VersionedObjectSerializer;
 import org.apache.flink.table.types.logical.RowType;
 
@@ -32,12 +32,12 @@ public class ManifestEntrySerializer extends VersionedObjectSerializer<ManifestE
     private static final long serialVersionUID = 1L;
 
     private final RowDataSerializer partitionSerializer;
-    private final SstFileMetaSerializer sstFileMetaSerializer;
+    private final DataFileMetaSerializer dataFileMetaSerializer;
 
     public ManifestEntrySerializer(RowType partitionType, RowType keyType, RowType valueType) {
         super(ManifestEntry.schema(partitionType, keyType, valueType));
         this.partitionSerializer = new RowDataSerializer(partitionType);
-        this.sstFileMetaSerializer = new SstFileMetaSerializer(keyType, valueType);
+        this.dataFileMetaSerializer = new DataFileMetaSerializer(keyType, valueType);
     }
 
     @Override
@@ -52,7 +52,7 @@ public class ManifestEntrySerializer extends VersionedObjectSerializer<ManifestE
         row.setField(1, entry.partition());
         row.setField(2, entry.bucket());
         row.setField(3, entry.totalBuckets());
-        row.setField(4, sstFileMetaSerializer.toRow(entry.file()));
+        row.setField(4, dataFileMetaSerializer.toRow(entry.file()));
         return row;
     }
 
@@ -68,6 +68,6 @@ public class ManifestEntrySerializer extends VersionedObjectSerializer<ManifestE
                         .copy(),
                 row.getInt(2),
                 row.getInt(3),
-                sstFileMetaSerializer.fromRow(row.getRow(4, sstFileMetaSerializer.numFields())));
+                dataFileMetaSerializer.fromRow(row.getRow(4, dataFileMetaSerializer.numFields())));
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestFileMeta.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestFileMeta.java
@@ -124,7 +124,7 @@ public class ManifestFileMeta {
 
     /**
      * Merge several {@link ManifestFileMeta}s. {@link ManifestEntry}s representing first adding and
-     * then deleting the same sst file will cancel each other.
+     * then deleting the same data file will cancel each other.
      *
      * <p>NOTE: This method is atomic.
      */
@@ -203,7 +203,7 @@ public class ManifestFileMeta {
                     map.put(identifier, entry);
                     break;
                 case DELETE:
-                    // each sst file will only be added once and deleted once,
+                    // each dataFile will only be added once and deleted once,
                     // if we know that it is added before then both add and delete entry can be
                     // removed because there won't be further operations on this file,
                     // otherwise we have to keep the delete entry because the add entry must be

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/Increment.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/Increment.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.store.file.mergetree;
 
-import org.apache.flink.table.store.file.mergetree.sst.SstFileMeta;
+import org.apache.flink.table.store.file.data.DataFileMeta;
 
 import java.util.Collections;
 import java.util.List;
@@ -35,30 +35,30 @@ import java.util.Objects;
  */
 public class Increment {
 
-    private final List<SstFileMeta> newFiles;
+    private final List<DataFileMeta> newFiles;
 
-    private final List<SstFileMeta> compactBefore;
+    private final List<DataFileMeta> compactBefore;
 
-    private final List<SstFileMeta> compactAfter;
+    private final List<DataFileMeta> compactAfter;
 
     public Increment(
-            List<SstFileMeta> newFiles,
-            List<SstFileMeta> beCompacted,
-            List<SstFileMeta> compacted) {
+            List<DataFileMeta> newFiles,
+            List<DataFileMeta> beCompacted,
+            List<DataFileMeta> compacted) {
         this.newFiles = Collections.unmodifiableList(newFiles);
         this.compactBefore = Collections.unmodifiableList(beCompacted);
         this.compactAfter = Collections.unmodifiableList(compacted);
     }
 
-    public List<SstFileMeta> newFiles() {
+    public List<DataFileMeta> newFiles() {
         return newFiles;
     }
 
-    public List<SstFileMeta> compactBefore() {
+    public List<DataFileMeta> compactBefore() {
         return compactBefore;
     }
 
-    public List<SstFileMeta> compactAfter() {
+    public List<DataFileMeta> compactAfter() {
         return compactAfter;
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MemTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MemTable.java
@@ -29,7 +29,7 @@ import java.util.Iterator;
 
 /**
  * Append only memory table for storing key-values. When it is full, it will be flushed to disk and
- * form an SST file.
+ * form a data file.
  */
 public interface MemTable {
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/SortedRun.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/SortedRun.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.store.file.mergetree;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.store.file.mergetree.sst.SstFileMeta;
+import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.util.Preconditions;
 
 import java.util.Collections;
@@ -35,14 +35,14 @@ import java.util.stream.Collectors;
  */
 public class SortedRun {
 
-    private final List<SstFileMeta> files;
+    private final List<DataFileMeta> files;
 
     private final long totalSize;
 
-    private SortedRun(List<SstFileMeta> files) {
+    private SortedRun(List<DataFileMeta> files) {
         this.files = Collections.unmodifiableList(files);
         long totalSize = 0L;
-        for (SstFileMeta file : files) {
+        for (DataFileMeta file : files) {
             totalSize += file.fileSize();
         }
         this.totalSize = totalSize;
@@ -52,23 +52,23 @@ public class SortedRun {
         return new SortedRun(Collections.emptyList());
     }
 
-    public static SortedRun fromSingle(SstFileMeta file) {
+    public static SortedRun fromSingle(DataFileMeta file) {
         return new SortedRun(Collections.singletonList(file));
     }
 
-    public static SortedRun fromSorted(List<SstFileMeta> sortedFiles) {
+    public static SortedRun fromSorted(List<DataFileMeta> sortedFiles) {
         return new SortedRun(sortedFiles);
     }
 
     public static SortedRun fromUnsorted(
-            List<SstFileMeta> unsortedFiles, Comparator<RowData> keyComparator) {
+            List<DataFileMeta> unsortedFiles, Comparator<RowData> keyComparator) {
         unsortedFiles.sort((o1, o2) -> keyComparator.compare(o1.minKey(), o2.minKey()));
         SortedRun run = new SortedRun(unsortedFiles);
         run.validate(keyComparator);
         return run;
     }
 
-    public List<SstFileMeta> files() {
+    public List<DataFileMeta> files() {
         return files;
     }
 
@@ -106,7 +106,7 @@ public class SortedRun {
     @Override
     public String toString() {
         return "["
-                + files.stream().map(SstFileMeta::toString).collect(Collectors.joining(", "))
+                + files.stream().map(DataFileMeta::toString).collect(Collectors.joining(", "))
                 + "]";
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/CompactUnit.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/CompactUnit.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.table.store.file.mergetree.compact;
 
+import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.mergetree.LevelSortedRun;
-import org.apache.flink.table.store.file.mergetree.sst.SstFileMeta;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,17 +29,17 @@ interface CompactUnit {
 
     int outputLevel();
 
-    List<SstFileMeta> files();
+    List<DataFileMeta> files();
 
     static CompactUnit fromLevelRuns(int outputLevel, List<LevelSortedRun> runs) {
-        List<SstFileMeta> files = new ArrayList<>();
+        List<DataFileMeta> files = new ArrayList<>();
         for (LevelSortedRun run : runs) {
             files.addAll(run.run().files());
         }
         return fromFiles(outputLevel, files);
     }
 
-    static CompactUnit fromFiles(int outputLevel, List<SstFileMeta> files) {
+    static CompactUnit fromFiles(int outputLevel, List<DataFileMeta> files) {
         return new CompactUnit() {
             @Override
             public int outputLevel() {
@@ -47,7 +47,7 @@ interface CompactUnit {
             }
 
             @Override
-            public List<SstFileMeta> files() {
+            public List<DataFileMeta> files() {
                 return files;
             }
         };

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
@@ -24,12 +24,12 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.store.file.Snapshot;
 import org.apache.flink.table.store.file.ValueKind;
+import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.manifest.ManifestCommittable;
 import org.apache.flink.table.store.file.manifest.ManifestEntry;
 import org.apache.flink.table.store.file.manifest.ManifestFile;
 import org.apache.flink.table.store.file.manifest.ManifestFileMeta;
 import org.apache.flink.table.store.file.manifest.ManifestList;
-import org.apache.flink.table.store.file.mergetree.sst.SstFileMeta;
 import org.apache.flink.table.store.file.predicate.Predicate;
 import org.apache.flink.table.store.file.predicate.PredicateConverter;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
@@ -287,11 +287,11 @@ public class FileStoreCommitImpl implements FileStoreCommit {
     }
 
     private List<ManifestEntry> collectChanges(
-            Map<BinaryRowData, Map<Integer, List<SstFileMeta>>> map, ValueKind kind) {
+            Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> map, ValueKind kind) {
         List<ManifestEntry> changes = new ArrayList<>();
-        for (Map.Entry<BinaryRowData, Map<Integer, List<SstFileMeta>>> entryWithPartition :
+        for (Map.Entry<BinaryRowData, Map<Integer, List<DataFileMeta>>> entryWithPartition :
                 map.entrySet()) {
-            for (Map.Entry<Integer, List<SstFileMeta>> entryWithBucket :
+            for (Map.Entry<Integer, List<DataFileMeta>> entryWithBucket :
                     entryWithPartition.getValue().entrySet()) {
                 changes.addAll(
                         entryWithBucket.getValue().stream()

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreRead.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreRead.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.store.file.operation;
 
 import org.apache.flink.table.data.binary.BinaryRowData;
-import org.apache.flink.table.store.file.mergetree.sst.SstFileMeta;
+import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.utils.RecordReader;
 
 import java.io.IOException;
@@ -49,6 +49,6 @@ public interface FileStoreRead {
      *       reader is guaranteed to be ordered by keys and does not contain duplicated keys.
      * </ul>
      */
-    RecordReader createReader(BinaryRowData partition, int bucket, List<SstFileMeta> files)
+    RecordReader createReader(BinaryRowData partition, int bucket, List<DataFileMeta> files)
             throws IOException;
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreScan.java
@@ -21,9 +21,9 @@ package org.apache.flink.table.store.file.operation;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.store.file.Snapshot;
 import org.apache.flink.table.store.file.ValueKind;
+import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.manifest.ManifestEntry;
 import org.apache.flink.table.store.file.manifest.ManifestFileMeta;
-import org.apache.flink.table.store.file.mergetree.sst.SstFileMeta;
 import org.apache.flink.table.store.file.predicate.Predicate;
 
 import javax.annotation.Nullable;
@@ -74,9 +74,9 @@ public interface FileStoreScan {
         List<ManifestEntry> files();
 
         /** Return a map group by partition and bucket. */
-        default Map<BinaryRowData, Map<Integer, List<SstFileMeta>>> groupByPartFiles() {
+        default Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> groupByPartFiles() {
             List<ManifestEntry> files = files();
-            Map<BinaryRowData, Map<Integer, List<SstFileMeta>>> groupBy = new HashMap<>();
+            Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> groupBy = new HashMap<>();
             for (ManifestEntry entry : files) {
                 checkArgument(entry.kind() == ValueKind.ADD);
                 groupBy.computeIfAbsent(entry.partition(), k -> new HashMap<>())

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/stats/FieldStatsArraySerializer.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/stats/FieldStatsArraySerializer.java
@@ -83,7 +83,7 @@ public class FieldStatsArraySerializer extends ObjectSerializer<FieldStats[]> {
     }
 
     private static RowType toAllFieldsNullableRowType(RowType rowType) {
-        // as stated in SstFile.RollingFile#finish, field stats are not collected currently so
+        // as stated in RollingFile.Writer#finish, field stats are not collected currently so
         // min/max values are all nulls
         return RowType.of(
                 rowType.getFields().stream()

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/FileStorePathFactory.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/FileStorePathFactory.java
@@ -23,7 +23,7 @@ import org.apache.flink.connector.file.table.FileSystemConnectorOptions;
 import org.apache.flink.connector.file.table.RowDataPartitionComputer;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.data.binary.BinaryRowData;
-import org.apache.flink.table.store.file.mergetree.sst.SstPathFactory;
+import org.apache.flink.table.store.file.data.DataFilePathFactory;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.utils.LogicalTypeDataTypeConverter;
@@ -105,8 +105,8 @@ public class FileStorePathFactory {
         return new Path(root + "/snapshot/." + SNAPSHOT_PREFIX + id + "-" + UUID.randomUUID());
     }
 
-    public SstPathFactory createSstPathFactory(BinaryRowData partition, int bucket) {
-        return new SstPathFactory(root, getPartitionString(partition), bucket);
+    public DataFilePathFactory createDataFilePathFactory(BinaryRowData partition, int bucket) {
+        return new DataFilePathFactory(root, getPartitionString(partition), bucket);
     }
 
     /** IMPORTANT: This method is NOT THREAD SAFE. */
@@ -135,24 +135,25 @@ public class FileStorePathFactory {
         return uuid;
     }
 
-    /** Cache for storing {@link SstPathFactory}s. */
-    public static class SstPathFactoryCache {
+    /** Cache for storing {@link DataFilePathFactory}s. */
+    public static class DataFilePathFactoryCache {
 
         private final FileStorePathFactory pathFactory;
-        private final Map<BinaryRowData, Map<Integer, SstPathFactory>> cache;
+        private final Map<BinaryRowData, Map<Integer, DataFilePathFactory>> cache;
 
-        public SstPathFactoryCache(FileStorePathFactory pathFactory) {
+        public DataFilePathFactoryCache(FileStorePathFactory pathFactory) {
             this.pathFactory = pathFactory;
             this.cache = new HashMap<>();
         }
 
-        public SstPathFactory getSstPathFactory(BinaryRowData partition, int bucket) {
+        public DataFilePathFactory getDataFilePathFactory(BinaryRowData partition, int bucket) {
             return cache.compute(partition, (p, m) -> m == null ? new HashMap<>() : m)
                     .compute(
                             bucket,
                             (b, f) ->
                                     f == null
-                                            ? pathFactory.createSstPathFactory(partition, bucket)
+                                            ? pathFactory.createDataFilePathFactory(
+                                                    partition, bucket)
                                             : f);
         }
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RecordWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RecordWriter.java
@@ -20,8 +20,8 @@ package org.apache.flink.table.store.file.utils;
 
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.file.ValueKind;
+import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.mergetree.Increment;
-import org.apache.flink.table.store.file.mergetree.sst.SstFileMeta;
 
 import java.util.List;
 
@@ -53,5 +53,5 @@ public interface RecordWriter {
      *
      * @return Deleted files.
      */
-    List<SstFileMeta> close() throws Exception;
+    List<DataFileMeta> close() throws Exception;
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RollingFile.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RollingFile.java
@@ -104,7 +104,7 @@ public abstract class RollingFile<R, F> {
             this.writer = newWriter(out);
 
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Create new rolling file " + path.toString());
+                LOG.debug("Create new rolling file " + path);
             }
         }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileMetaSerializerTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileMetaSerializerTest.java
@@ -16,24 +16,24 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.store.file.mergetree.sst;
+package org.apache.flink.table.store.file.data;
 
 import org.apache.flink.table.store.file.TestKeyValueGenerator;
 import org.apache.flink.table.store.file.utils.ObjectSerializerTestBase;
 
-/** Tests for {@link SstFileMetaSerializer}. */
-public class SstFileMetaSerializerTest extends ObjectSerializerTestBase<SstFileMeta> {
+/** Tests for {@link DataFileMetaSerializer}. */
+public class DataFileMetaSerializerTest extends ObjectSerializerTestBase<DataFileMeta> {
 
-    private final SstTestDataGenerator gen = SstTestDataGenerator.builder().build();
+    private final DataFileTestDataGenerator gen = DataFileTestDataGenerator.builder().build();
 
     @Override
-    protected SstFileMetaSerializer serializer() {
-        return new SstFileMetaSerializer(
+    protected DataFileMetaSerializer serializer() {
+        return new DataFileMetaSerializer(
                 TestKeyValueGenerator.KEY_TYPE, TestKeyValueGenerator.ROW_TYPE);
     }
 
     @Override
-    protected SstFileMeta object() {
+    protected DataFileMeta object() {
         return gen.next().meta;
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFilePathFactoryTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFilePathFactoryTest.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.store.file.mergetree.sst;
+package org.apache.flink.table.store.file.data;
 
 import org.apache.flink.core.fs.Path;
 
@@ -25,28 +25,29 @@ import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Tests for {@link SstPathFactory}. */
-public class SstPathFactoryTest {
+/** Tests for {@link DataFilePathFactory}. */
+public class DataFilePathFactoryTest {
 
     @TempDir java.nio.file.Path tempDir;
 
     @Test
     public void testNoPartition() {
-        SstPathFactory pathFactory = new SstPathFactory(new Path(tempDir.toString()), "", 123);
+        DataFilePathFactory pathFactory =
+                new DataFilePathFactory(new Path(tempDir.toString()), "", 123);
         String uuid = pathFactory.uuid();
 
         for (int i = 0; i < 20; i++) {
             assertThat(pathFactory.newPath())
-                    .isEqualTo(new Path(tempDir.toString() + "/bucket-123/sst-" + uuid + "-" + i));
+                    .isEqualTo(new Path(tempDir.toString() + "/bucket-123/data-" + uuid + "-" + i));
         }
-        assertThat(pathFactory.toPath("my-sst-file-name"))
-                .isEqualTo(new Path(tempDir.toString() + "/bucket-123/my-sst-file-name"));
+        assertThat(pathFactory.toPath("my-data-file-name"))
+                .isEqualTo(new Path(tempDir.toString() + "/bucket-123/my-data-file-name"));
     }
 
     @Test
     public void testWithPartition() {
-        SstPathFactory pathFactory =
-                new SstPathFactory(new Path(tempDir.toString()), "dt=20211224", 123);
+        DataFilePathFactory pathFactory =
+                new DataFilePathFactory(new Path(tempDir.toString()), "dt=20211224", 123);
         String uuid = pathFactory.uuid();
 
         for (int i = 0; i < 20; i++) {
@@ -54,13 +55,13 @@ public class SstPathFactoryTest {
                     .isEqualTo(
                             new Path(
                                     tempDir.toString()
-                                            + "/dt=20211224/bucket-123/sst-"
+                                            + "/dt=20211224/bucket-123/data-"
                                             + uuid
                                             + "-"
                                             + i));
         }
-        assertThat(pathFactory.toPath("my-sst-file-name"))
+        assertThat(pathFactory.toPath("my-data-file-name"))
                 .isEqualTo(
-                        new Path(tempDir.toString() + "/dt=20211224/bucket-123/my-sst-file-name"));
+                        new Path(tempDir.toString() + "/dt=20211224/bucket-123/my-data-file-name"));
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileTestDataGenerator.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileTestDataGenerator.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.store.file.mergetree.sst;
+package org.apache.flink.table.store.file.data;
 
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.store.file.KeyValue;
@@ -29,8 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-/** Random {@link SstFileMeta} generator. */
-public class SstTestDataGenerator {
+/** Random {@link DataFileMeta} generator. */
+public class DataFileTestDataGenerator {
 
     private final int numBuckets;
     private final int memTableCapacity;
@@ -38,7 +38,7 @@ public class SstTestDataGenerator {
     private final List<Map<BinaryRowData, List<KeyValue>>> memTables;
     private final TestKeyValueGenerator gen;
 
-    private SstTestDataGenerator(int numBuckets, int memTableCapacity) {
+    private DataFileTestDataGenerator(int numBuckets, int memTableCapacity) {
         this.numBuckets = numBuckets;
         this.memTableCapacity = memTableCapacity;
 
@@ -60,7 +60,7 @@ public class SstTestDataGenerator {
             memTable.add(kv);
 
             if (memTable.size() >= memTableCapacity) {
-                List<Data> result = createSstFiles(memTable, 0, partition, bucket);
+                List<Data> result = createDataFiles(memTable, 0, partition, bucket);
                 memTable.clear();
                 assert result.size() == 1;
                 return result.get(0);
@@ -68,7 +68,7 @@ public class SstTestDataGenerator {
         }
     }
 
-    public List<Data> createSstFiles(
+    public List<Data> createDataFiles(
             List<KeyValue> kvs, int level, BinaryRowData partition, int bucket) {
         gen.sort(kvs);
         List<KeyValue> combined = new ArrayList<>();
@@ -88,7 +88,7 @@ public class SstTestDataGenerator {
         List<Data> result = new ArrayList<>();
         for (int i = 0; i < combined.size(); i += capacity) {
             result.add(
-                    createSstFile(
+                    createDataFile(
                             combined.subList(i, Math.min(i + capacity, combined.size())),
                             level,
                             partition,
@@ -97,7 +97,8 @@ public class SstTestDataGenerator {
         return result;
     }
 
-    private Data createSstFile(List<KeyValue> kvs, int level, BinaryRowData partition, int bucket) {
+    private Data createDataFile(
+            List<KeyValue> kvs, int level, BinaryRowData partition, int bucket) {
         FieldStatsCollector keyStatsCollector =
                 new FieldStatsCollector(TestKeyValueGenerator.KEY_TYPE);
         FieldStatsCollector valueStatsCollector =
@@ -126,8 +127,8 @@ public class SstTestDataGenerator {
         return new Data(
                 partition,
                 bucket,
-                new SstFileMeta(
-                        "sst-" + UUID.randomUUID(),
+                new DataFileMeta(
+                        "data-" + UUID.randomUUID(),
                         totalSize,
                         kvs.size(),
                         minKey,
@@ -140,15 +141,15 @@ public class SstTestDataGenerator {
                 kvs);
     }
 
-    /** An in-memory SST file. */
+    /** An in-memory data file. */
     public static class Data {
         public final BinaryRowData partition;
         public final int bucket;
-        public final SstFileMeta meta;
+        public final DataFileMeta meta;
         public final List<KeyValue> content;
 
         private Data(
-                BinaryRowData partition, int bucket, SstFileMeta meta, List<KeyValue> content) {
+                BinaryRowData partition, int bucket, DataFileMeta meta, List<KeyValue> content) {
             this.partition = partition;
             this.bucket = bucket;
             this.meta = meta;
@@ -160,7 +161,7 @@ public class SstTestDataGenerator {
         return new Builder();
     }
 
-    /** Builder for {@link SstTestDataGenerator}. */
+    /** Builder for {@link DataFileTestDataGenerator}. */
     public static class Builder {
         private int numBuckets = 3;
         private int memTableCapacity = 3;
@@ -175,8 +176,8 @@ public class SstTestDataGenerator {
             return this;
         }
 
-        public SstTestDataGenerator build() {
-            return new SstTestDataGenerator(numBuckets, memTableCapacity);
+        public DataFileTestDataGenerator build() {
+            return new DataFileTestDataGenerator(numBuckets, memTableCapacity);
         }
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestCommittableSerializerTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestCommittableSerializerTest.java
@@ -19,8 +19,8 @@
 package org.apache.flink.table.store.file.manifest;
 
 import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.mergetree.Increment;
-import org.apache.flink.table.store.file.mergetree.sst.SstFileMeta;
 import org.apache.flink.table.store.file.stats.FieldStats;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
@@ -88,9 +88,9 @@ public class ManifestCommittableSerializerTest {
                 Arrays.asList(newFile(ID.incrementAndGet(), 0), newFile(ID.incrementAndGet(), 0)));
     }
 
-    public static SstFileMeta newFile(int name, int level) {
+    public static DataFileMeta newFile(int name, int level) {
         FieldStats[] stats = new FieldStats[] {new FieldStats(0, 1, 0)};
-        return new SstFileMeta(
+        return new DataFileMeta(
                 String.valueOf(name), 0, 1, row(0), row(0), stats, stats, 0, 1, level);
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestFileMetaTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestFileMetaTest.java
@@ -24,8 +24,8 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.data.writer.BinaryRowWriter;
 import org.apache.flink.table.store.file.ValueKind;
+import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.format.FileFormat;
-import org.apache.flink.table.store.file.mergetree.sst.SstFileMeta;
 import org.apache.flink.table.store.file.stats.FieldStats;
 import org.apache.flink.table.store.file.utils.FailingAtomicRenameFileSystem;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
@@ -233,7 +233,7 @@ public class ManifestFileMetaTest {
                 binaryRowData, // not used
                 0, // not used
                 0, // not used
-                new SstFileMeta(
+                new DataFileMeta(
                         fileName,
                         0, // not used
                         0, // not used

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/LevelsTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/LevelsTest.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.store.file.mergetree;
 
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.store.file.mergetree.sst.SstFileMeta;
+import org.apache.flink.table.store.file.data.DataFileMeta;
 
 import org.junit.jupiter.api.Test;
 
@@ -61,7 +61,7 @@ public class LevelsTest {
         assertThat(levels.nonEmptyHighestLevel()).isEqualTo(2);
     }
 
-    public static SstFileMeta newFile(int level) {
-        return new SstFileMeta("", 0, 1, row(0), row(0), null, null, 0, 1, level);
+    public static DataFileMeta newFile(int level) {
+        return new DataFileMeta("", 0, 1, row(0), row(0), null, null, 0, 1, level);
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/CompactManagerTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/CompactManagerTest.java
@@ -21,9 +21,9 @@ package org.apache.flink.table.store.file.mergetree.compact;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.data.writer.BinaryRowWriter;
+import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.mergetree.Levels;
 import org.apache.flink.table.store.file.mergetree.SortedRun;
-import org.apache.flink.table.store.file.mergetree.sst.SstFileMeta;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -187,7 +187,7 @@ public class CompactManagerTest {
             CompactStrategy strategy,
             boolean expectedDropDelete)
             throws ExecutionException, InterruptedException {
-        List<SstFileMeta> files = new ArrayList<>();
+        List<DataFileMeta> files = new ArrayList<>();
         for (int i = 0; i < inputs.size(); i++) {
             LevelMinMax minMax = inputs.get(i);
             files.add(minMax.toFile(i));
@@ -203,8 +203,8 @@ public class CompactManagerTest {
         assertThat(outputs).isEqualTo(expected);
     }
 
-    private static SstFileMeta newFile(int level, int minKey, int maxKey, long maxSequence) {
-        return new SstFileMeta(
+    private static DataFileMeta newFile(int level, int minKey, int maxKey, long maxSequence) {
+        return new DataFileMeta(
                 "",
                 maxKey - minKey + 1,
                 1,
@@ -237,7 +237,7 @@ public class CompactManagerTest {
             long maxSequence = 0;
             for (List<SortedRun> section : sections) {
                 for (SortedRun run : section) {
-                    for (SstFileMeta file : run.files()) {
+                    for (DataFileMeta file : run.files()) {
                         int min = file.minKey().getInt(0);
                         int max = file.maxKey().getInt(0);
                         if (min < minKey) {
@@ -262,7 +262,7 @@ public class CompactManagerTest {
         private final int min;
         private final int max;
 
-        private LevelMinMax(SstFileMeta file) {
+        private LevelMinMax(DataFileMeta file) {
             this.level = file.level();
             this.min = file.minKey().getInt(0);
             this.max = file.maxKey().getInt(0);
@@ -274,7 +274,7 @@ public class CompactManagerTest {
             this.max = max;
         }
 
-        private SstFileMeta toFile(long maxSequence) {
+        private DataFileMeta toFile(long maxSequence) {
             return newFile(level, min, max, maxSequence);
         }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/IntervalPartitionTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/IntervalPartitionTest.java
@@ -21,8 +21,8 @@ package org.apache.flink.table.store.file.mergetree.compact;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.data.writer.BinaryRowWriter;
 import org.apache.flink.table.runtime.generated.RecordComparator;
+import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.mergetree.SortedRun;
-import org.apache.flink.table.store.file.mergetree.sst.SstFileMeta;
 import org.apache.flink.table.store.file.stats.FieldStats;
 
 import org.junit.jupiter.api.RepeatedTest;
@@ -142,8 +142,8 @@ public class IntervalPartitionTest {
         return sortedRuns;
     }
 
-    private List<SstFileMeta> parseMetas(String in) {
-        List<SstFileMeta> metas = new ArrayList<>();
+    private List<DataFileMeta> parseMetas(String in) {
+        List<DataFileMeta> metas = new ArrayList<>();
         Pattern pattern = Pattern.compile("\\[(\\d+?), (\\d+?)]");
         Matcher matcher = pattern.matcher(in);
         while (matcher.find()) {
@@ -155,7 +155,7 @@ public class IntervalPartitionTest {
         return metas;
     }
 
-    private SstFileMeta makeInterval(int left, int right) {
+    private DataFileMeta makeInterval(int left, int right) {
         BinaryRowData minKey = new BinaryRowData(1);
         BinaryRowWriter minWriter = new BinaryRowWriter(minKey);
         minWriter.writeInt(0, left);
@@ -165,7 +165,7 @@ public class IntervalPartitionTest {
         maxWriter.writeInt(0, right);
         maxWriter.complete();
 
-        return new SstFileMeta(
+        return new DataFileMeta(
                 "DUMMY",
                 100,
                 25,

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/UniversalCompactionTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/UniversalCompactionTest.java
@@ -18,9 +18,9 @@
 
 package org.apache.flink.table.store.file.mergetree.compact;
 
+import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.mergetree.LevelSortedRun;
 import org.apache.flink.table.store.file.mergetree.SortedRun;
-import org.apache.flink.table.store.file.mergetree.sst.SstFileMeta;
 
 import org.junit.jupiter.api.Test;
 
@@ -51,19 +51,19 @@ public class UniversalCompactionTest {
         // by size amplification
         Optional<CompactUnit> pick = compaction.pick(3, level0(1, 2, 3, 3));
         assertThat(pick.isPresent()).isTrue();
-        long[] results = pick.get().files().stream().mapToLong(SstFileMeta::fileSize).toArray();
+        long[] results = pick.get().files().stream().mapToLong(DataFileMeta::fileSize).toArray();
         assertThat(results).isEqualTo(new long[] {1, 2, 3, 3});
 
         // by size ratio
         pick = compaction.pick(3, level0(1, 1, 1, 50));
         assertThat(pick.isPresent()).isTrue();
-        results = pick.get().files().stream().mapToLong(SstFileMeta::fileSize).toArray();
+        results = pick.get().files().stream().mapToLong(DataFileMeta::fileSize).toArray();
         assertThat(results).isEqualTo(new long[] {1, 1, 1});
 
         // by file num
         pick = compaction.pick(3, level0(1, 2, 3, 50));
         assertThat(pick.isPresent()).isTrue();
-        results = pick.get().files().stream().mapToLong(SstFileMeta::fileSize).toArray();
+        results = pick.get().files().stream().mapToLong(DataFileMeta::fileSize).toArray();
         // 3 should be in the candidate, by size ratio after picking by file num
         assertThat(results).isEqualTo(new long[] {1, 2, 3});
     }
@@ -182,7 +182,10 @@ public class UniversalCompactionTest {
         CompactUnit unit = compaction.pickForSizeAmp(3, level0(sizes));
         if (unit != null) {
             return new long[] {
-                unit.files().stream().mapToLong(SstFileMeta::fileSize).reduce(Long::sum).getAsLong()
+                unit.files().stream()
+                        .mapToLong(DataFileMeta::fileSize)
+                        .reduce(Long::sum)
+                        .getAsLong()
             };
         }
         return sizes;
@@ -196,7 +199,7 @@ public class UniversalCompactionTest {
         CompactUnit unit = compaction.pickForSizeRatio(3, level0(sizes));
         if (unit != null) {
             List<Long> compact =
-                    unit.files().stream().map(SstFileMeta::fileSize).collect(Collectors.toList());
+                    unit.files().stream().map(DataFileMeta::fileSize).collect(Collectors.toList());
             List<Long> result = new ArrayList<>();
             for (long size : sizes) {
                 result.add(size);
@@ -223,7 +226,7 @@ public class UniversalCompactionTest {
         return runs;
     }
 
-    private SstFileMeta file(long size) {
-        return new SstFileMeta("", size, 1, null, null, null, null, 0, 0, 0);
+    private DataFileMeta file(long size) {
+        return new DataFileMeta("", size, 1, null, null, null, null, 0, 0, 0);
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/stats/FieldStatsArraySerializerTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/stats/FieldStatsArraySerializerTest.java
@@ -44,7 +44,7 @@ public class FieldStatsArraySerializerTest extends ObjectSerializerTestBase<Fiel
         }
         FieldStats[] result = collector.extract();
 
-        // as stated in SstFile.RollingFile#finish, field stats are not collected currently so
+        // as stated in RollingFile.Writer#finish, field stats are not collected currently so
         // min/max values are all nulls
         ThreadLocalRandom random = ThreadLocalRandom.current();
         int numFieldsNotCollected = random.nextInt(result.length + 1);

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/FileStorePathFactoryTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/FileStorePathFactoryTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.data.writer.BinaryRowWriter;
-import org.apache.flink.table.store.file.mergetree.sst.SstPathFactory;
+import org.apache.flink.table.store.file.data.DataFilePathFactory;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
@@ -75,15 +75,16 @@ public class FileStorePathFactoryTest {
     }
 
     @Test
-    public void testCreateSstPathFactoryNoPartition() {
+    public void testCreateDataFilePathFactoryNoPartition() {
         FileStorePathFactory pathFactory = new FileStorePathFactory(new Path(tempDir.toString()));
-        SstPathFactory sstPathFactory = pathFactory.createSstPathFactory(new BinaryRowData(0), 123);
-        assertThat(sstPathFactory.toPath("my-sst-file-name"))
-                .isEqualTo(new Path(tempDir.toString() + "/bucket-123/my-sst-file-name"));
+        DataFilePathFactory dataFilePathFactory =
+                pathFactory.createDataFilePathFactory(new BinaryRowData(0), 123);
+        assertThat(dataFilePathFactory.toPath("my-data-file-name"))
+                .isEqualTo(new Path(tempDir.toString() + "/bucket-123/my-data-file-name"));
     }
 
     @Test
-    public void testCreateSstPathFactoryWithPartition() {
+    public void testCreateDataFilePathFactoryWithPartition() {
         FileStorePathFactory pathFactory =
                 new FileStorePathFactory(
                         new Path(tempDir.toString()),
@@ -113,9 +114,10 @@ public class FileStorePathFactoryTest {
             writer.setNullAt(1);
         }
         writer.complete();
-        SstPathFactory sstPathFactory = pathFactory.createSstPathFactory(partition, 123);
-        assertThat(sstPathFactory.toPath("my-sst-file-name"))
+        DataFilePathFactory dataFilePathFactory =
+                pathFactory.createDataFilePathFactory(partition, 123);
+        assertThat(dataFilePathFactory.toPath("my-data-file-name"))
                 .isEqualTo(
-                        new Path(tempDir.toString() + expected + "/bucket-123/my-sst-file-name"));
+                        new Path(tempDir.toString() + expected + "/bucket-123/my-data-file-name"));
     }
 }


### PR DESCRIPTION
If we support append only data, the records have no primary key, the file should be data file instead of sst file.

This PR do:
- Rename sst file to data file for classes and variables
- Rename `sst-{uuid}-{count}` file name to `data-{uuid}-{count}`  file name 