### PR TITLE
[FLINK-27528] Introduce a new configuration option 'compact.rescale-bucket' for FileStore

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreFactoryOptions.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreFactoryOptions.java
@@ -28,6 +28,17 @@ import java.util.Set;
 /** Options for {@link TableStoreFactory}. */
 public class TableStoreFactoryOptions {
 
+    public static final ConfigOption<Boolean> COMPACTION_RESCALE_BUCKET =
+            ConfigOptions.key("compaction.rescale-bucket")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Specify the behavior for compaction. Set value to true "
+                                    + "will lead compaction to reorganize data files "
+                                    + "according to the bucket number from table schema. "
+                                    + "By default, compaction does not adjust the bucket number "
+                                    + "of a partition/table.");
+
     public static final ConfigOption<String> LOG_SYSTEM =
             ConfigOptions.key("log.system")
                     .stringType()
@@ -47,6 +58,7 @@ public class TableStoreFactoryOptions {
 
     public static Set<ConfigOption<?>> allOptions() {
         Set<ConfigOption<?>> allOptions = new HashSet<>();
+        allOptions.add(COMPACTION_RESCALE_BUCKET);
         allOptions.add(LOG_SYSTEM);
         allOptions.add(SINK_PARALLELISM);
         allOptions.add(SCAN_PARALLELISM);

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreOptions.java
@@ -92,6 +92,17 @@ public class FileStoreOptions implements Serializable {
                             "The default partition name in case the dynamic partition"
                                     + " column value is null/empty string.");
 
+    public static final ConfigOption<Boolean> COMPACTION_RESCALE_BUCKET =
+            key("compact.rescale-bucket")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Specify the behavior for compaction. Set value to true "
+                                    + "will lead compaction to reorganize data files "
+                                    + "according to the bucket number read from catalog meta. "
+                                    + "By default, compaction will use the bucket number read "
+                                    + "from manifest meta.");
+
     public static final ConfigOption<Integer> SNAPSHOT_NUM_RETAINED_MIN =
             ConfigOptions.key("snapshot.num-retained.min")
                     .intType()
@@ -122,7 +133,7 @@ public class FileStoreOptions implements Serializable {
                     .defaultValue(MergeEngine.DEDUPLICATE)
                     .withDescription(
                             Description.builder()
-                                    .text("Specifies the merge engine for table with primary key.")
+                                    .text("Specify the merge engine for table with primary key.")
                                     .linebreak()
                                     .list(
                                             formatEnumOption(MergeEngine.DEDUPLICATE),
@@ -140,6 +151,7 @@ public class FileStoreOptions implements Serializable {
         allOptions.add(MANIFEST_TARGET_FILE_SIZE);
         allOptions.add(MANIFEST_MERGE_MIN_COUNT);
         allOptions.add(PARTITION_DEFAULT_NAME);
+        allOptions.add(COMPACTION_RESCALE_BUCKET);
         allOptions.add(SNAPSHOT_NUM_RETAINED_MIN);
         allOptions.add(SNAPSHOT_NUM_RETAINED_MAX);
         allOptions.add(SNAPSHOT_TIME_RETAINED);
@@ -224,6 +236,10 @@ public class FileStoreOptions implements Serializable {
 
     public int manifestMergeMinCount() {
         return options.get(MANIFEST_MERGE_MIN_COUNT);
+    }
+
+    public boolean rescaleBucket() {
+        return options.get(COMPACTION_RESCALE_BUCKET);
     }
 
     /** Specifies the merge engine for table with primary key. */

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreOptions.java
@@ -92,17 +92,6 @@ public class FileStoreOptions implements Serializable {
                             "The default partition name in case the dynamic partition"
                                     + " column value is null/empty string.");
 
-    public static final ConfigOption<Boolean> COMPACTION_RESCALE_BUCKET =
-            key("compact.rescale-bucket")
-                    .booleanType()
-                    .defaultValue(false)
-                    .withDescription(
-                            "Specify the behavior for compaction. Set value to true "
-                                    + "will lead compaction to reorganize data files "
-                                    + "according to the bucket number read from catalog meta. "
-                                    + "By default, compaction will use the bucket number read "
-                                    + "from manifest meta.");
-
     public static final ConfigOption<Integer> SNAPSHOT_NUM_RETAINED_MIN =
             ConfigOptions.key("snapshot.num-retained.min")
                     .intType()
@@ -151,7 +140,6 @@ public class FileStoreOptions implements Serializable {
         allOptions.add(MANIFEST_TARGET_FILE_SIZE);
         allOptions.add(MANIFEST_MERGE_MIN_COUNT);
         allOptions.add(PARTITION_DEFAULT_NAME);
-        allOptions.add(COMPACTION_RESCALE_BUCKET);
         allOptions.add(SNAPSHOT_NUM_RETAINED_MIN);
         allOptions.add(SNAPSHOT_NUM_RETAINED_MAX);
         allOptions.add(SNAPSHOT_TIME_RETAINED);
@@ -236,10 +224,6 @@ public class FileStoreOptions implements Serializable {
 
     public int manifestMergeMinCount() {
         return options.get(MANIFEST_MERGE_MIN_COUNT);
-    }
-
-    public boolean rescaleBucket() {
-        return options.get(COMPACTION_RESCALE_BUCKET);
     }
 
     /** Specifies the merge engine for table with primary key. */

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeOptions.java
@@ -84,17 +84,6 @@ public class MergeTreeOptions {
                             "The size amplification is defined as the amount (in percentage) of additional storage "
                                     + "needed to store a single byte of data in the merge tree.");
 
-    public static final ConfigOption<Boolean> COMPACTION_RESCALE_BUCKET =
-            ConfigOptions.key("compact.rescale-bucket")
-                    .booleanType()
-                    .defaultValue(false)
-                    .withDescription(
-                            "Specify the behavior for compaction. Set value to true "
-                                    + "will lead compaction to reorganize data files "
-                                    + "according to the bucket number from table schema. "
-                                    + "By default, compaction does not adjust the bucket number "
-                                    + "of a partition/table.");
-
     public static final ConfigOption<Integer> COMPACTION_SIZE_RATIO =
             ConfigOptions.key("compaction.size-ratio")
                     .intType()
@@ -122,8 +111,6 @@ public class MergeTreeOptions {
 
     public final int sizeRatio;
 
-    public final boolean rescaleBucket;
-
     public MergeTreeOptions(
             long writeBufferSize,
             long pageSize,
@@ -133,8 +120,7 @@ public class MergeTreeOptions {
             Integer numLevels,
             boolean commitForceCompact,
             int maxSizeAmplificationPercent,
-            int sizeRatio,
-            boolean rescaleBucket) {
+            int sizeRatio) {
         this.writeBufferSize = writeBufferSize;
         this.pageSize = pageSize;
         this.targetFileSize = targetFileSize;
@@ -147,7 +133,6 @@ public class MergeTreeOptions {
         this.commitForceCompact = commitForceCompact;
         this.maxSizeAmplificationPercent = maxSizeAmplificationPercent;
         this.sizeRatio = sizeRatio;
-        this.rescaleBucket = rescaleBucket;
     }
 
     public MergeTreeOptions(ReadableConfig config) {
@@ -160,8 +145,7 @@ public class MergeTreeOptions {
                 config.get(NUM_LEVELS),
                 config.get(COMMIT_FORCE_COMPACT),
                 config.get(COMPACTION_MAX_SIZE_AMPLIFICATION_PERCENT),
-                config.get(COMPACTION_SIZE_RATIO),
-                config.get(COMPACTION_RESCALE_BUCKET));
+                config.get(COMPACTION_SIZE_RATIO));
     }
 
     public static Set<ConfigOption<?>> allOptions() {
@@ -174,7 +158,6 @@ public class MergeTreeOptions {
         allOptions.add(NUM_LEVELS);
         allOptions.add(COMMIT_FORCE_COMPACT);
         allOptions.add(COMPACTION_MAX_SIZE_AMPLIFICATION_PERCENT);
-        allOptions.add(COMPACTION_RESCALE_BUCKET);
         allOptions.add(COMPACTION_SIZE_RATIO);
         return allOptions;
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeOptions.java
@@ -84,6 +84,17 @@ public class MergeTreeOptions {
                             "The size amplification is defined as the amount (in percentage) of additional storage "
                                     + "needed to store a single byte of data in the merge tree.");
 
+    public static final ConfigOption<Boolean> COMPACTION_RESCALE_BUCKET =
+            ConfigOptions.key("compact.rescale-bucket")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Specify the behavior for compaction. Set value to true "
+                                    + "will lead compaction to reorganize data files "
+                                    + "according to the bucket number from table schema. "
+                                    + "By default, compaction does not adjust the bucket number "
+                                    + "of a partition/table.");
+
     public static final ConfigOption<Integer> COMPACTION_SIZE_RATIO =
             ConfigOptions.key("compaction.size-ratio")
                     .intType()
@@ -111,6 +122,8 @@ public class MergeTreeOptions {
 
     public final int sizeRatio;
 
+    public final boolean rescaleBucket;
+
     public MergeTreeOptions(
             long writeBufferSize,
             long pageSize,
@@ -120,7 +133,8 @@ public class MergeTreeOptions {
             Integer numLevels,
             boolean commitForceCompact,
             int maxSizeAmplificationPercent,
-            int sizeRatio) {
+            int sizeRatio,
+            boolean rescaleBucket) {
         this.writeBufferSize = writeBufferSize;
         this.pageSize = pageSize;
         this.targetFileSize = targetFileSize;
@@ -133,6 +147,7 @@ public class MergeTreeOptions {
         this.commitForceCompact = commitForceCompact;
         this.maxSizeAmplificationPercent = maxSizeAmplificationPercent;
         this.sizeRatio = sizeRatio;
+        this.rescaleBucket = rescaleBucket;
     }
 
     public MergeTreeOptions(ReadableConfig config) {
@@ -145,7 +160,8 @@ public class MergeTreeOptions {
                 config.get(NUM_LEVELS),
                 config.get(COMMIT_FORCE_COMPACT),
                 config.get(COMPACTION_MAX_SIZE_AMPLIFICATION_PERCENT),
-                config.get(COMPACTION_SIZE_RATIO));
+                config.get(COMPACTION_SIZE_RATIO),
+                config.get(COMPACTION_RESCALE_BUCKET));
     }
 
     public static Set<ConfigOption<?>> allOptions() {
@@ -158,6 +174,7 @@ public class MergeTreeOptions {
         allOptions.add(NUM_LEVELS);
         allOptions.add(COMMIT_FORCE_COMPACT);
         allOptions.add(COMPACTION_MAX_SIZE_AMPLIFICATION_PERCENT);
+        allOptions.add(COMPACTION_RESCALE_BUCKET);
         allOptions.add(COMPACTION_SIZE_RATIO);
         return allOptions;
     }


### PR DESCRIPTION
This config key controls the behavior for `ALTER TABLE ... COMPACT`.

When `compact.rescale-bucket` is false, it indicates the compaction will rewrite data according to the bucket number, which is read from manifest meta, and the commit will only add/delete files; o.w. it suggests the compaction will read bucket number from catalog meta, and the commit will overwrite the whole partition directory.