### PR TITLE
[FLINK-27542] Refactor E2eTestBase with docker compose

### DIFF
--- a/flink-table-store-e2e-tests/src/test/java/org/apache/flink/table/store/tests/E2eTestBase.java
+++ b/flink-table-store-e2e-tests/src/test/java/org/apache/flink/table/store/tests/E2eTestBase.java
@@ -71,7 +71,6 @@ public abstract class E2eTestBase {
     private final List<String> currentResults = new ArrayList<>();
 
     private DockerComposeContainer<?> environment;
-    private static final Object environmentStartLock = new Object();
     private ContainerState jobManager;
 
     @BeforeEach
@@ -97,9 +96,9 @@ public abstract class E2eTestBase {
         }
         environment.withServices(services.toArray(new String[0]));
 
-        synchronized (environmentStartLock) {
-            // there are some steps which cannot be executed in parallel when starting a docker
-            // image, so we should lock here
+        synchronized (E2eTestBase.class) {
+            // there are some steps which cannot be executed in parallel when starting the same
+            // docker image, so we should lock here
             environment.start();
         }
         jobManager = environment.getContainerByServiceName("jobmanager_1").get();

--- a/flink-table-store-e2e-tests/src/test/resources-filtered/docker-compose.yaml
+++ b/flink-table-store-e2e-tests/src/test/resources-filtered/docker-compose.yaml
@@ -25,8 +25,7 @@ services:
   # ----------------------------------------
 
   jobmanager:
-    # TODO change image tag to official flink image after 1.15 is released
-    image: tsreaper/flink-test:${flink.version}
+    image: apache/flink:${flink.version}
     volumes:
       - testdata:/test-data
     command: jobmanager
@@ -40,8 +39,7 @@ services:
       - "8081:8081"
 
   taskmanager:
-    # TODO change image tag to official flink image after 1.15 is released
-    image: tsreaper/flink-test:${flink.version}
+    image: apache/flink:${flink.version}
     volumes:
       - testdata:/test-data
     command: taskmanager

--- a/flink-table-store-e2e-tests/src/test/resources-filtered/docker-compose.yaml
+++ b/flink-table-store-e2e-tests/src/test/resources-filtered/docker-compose.yaml
@@ -1,0 +1,99 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+version: "3"
+
+services:
+
+  # ----------------------------------------
+  # Flink services
+  # ----------------------------------------
+
+  jobmanager:
+    # TODO change image tag to official flink image after 1.15 is released
+    image: tsreaper/flink-test:${flink.version}
+    volumes:
+      - testdata:/test-data
+    command: jobmanager
+    env_file:
+      - ./flink.env
+    networks:
+      testnetwork:
+        aliases:
+          - jobmanager
+    ports:
+      - "8081:8081"
+
+  taskmanager:
+    # TODO change image tag to official flink image after 1.15 is released
+    image: tsreaper/flink-test:${flink.version}
+    volumes:
+      - testdata:/test-data
+    command: taskmanager
+    env_file:
+      - ./flink.env
+    networks:
+      testnetwork:
+        aliases:
+          - taskmanager
+    depends_on:
+      - jobmanager
+
+  # ----------------------------------------
+  # Kafka services
+  # ----------------------------------------
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.0.1
+    networks:
+      testnetwork:
+        aliases:
+          - zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: confluentinc/cp-kafka:7.0.1
+    networks:
+      testnetwork:
+        aliases:
+          - kafka
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_INTERNAL://kafka:29092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_MAX_TIMEOUT_MS: 7200000
+      # Disable log deletion to prevent records from being deleted during test run
+      KAFKA_LOG_RETENTION_MS: -1
+    ports:
+      - "9092:9092"
+    depends_on:
+      - zookeeper
+
+volumes:
+  testdata:
+
+networks:
+  testnetwork:

--- a/flink-table-store-e2e-tests/src/test/resources/flink.env
+++ b/flink-table-store-e2e-tests/src/test/resources/flink.env
@@ -16,4 +16,4 @@
 # limitations under the License.
 ################################################################################
 
-flink.version=${flink.version}
+FLINK_PROPERTIES="jobmanager.rpc.address: jobmanager\ntaskmanager.numberOfTaskSlots: 9\nparallelism.default: 3\nsql-client.execution.result-mode: TABLEAU"

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@ under the License.
     </modules>
 
     <properties>
-        <flink.version>1.15-SNAPSHOT</flink.version>
+        <flink.version>1.15.0</flink.version>
         <hadoop.version>2.8.5</hadoop.version>
         <scala.binary.version>2.12</scala.binary.version>
         <slf4j.version>1.7.15</slf4j.version>


### PR DESCRIPTION
Currently we build test dockers with testcontainers API. However testcontainers API are only a subset of docker APIs and is not suitable for managing a large group of services (In the future we'll add end to end tests for Hive which consists of numerous services such as Hadoop namenodes, datanodes, Hive metastore, etc.). So we refactor E2eTestBase with docker compose.