### PR TITLE
[FLINK-27558] Introduce a new optional option for TableStoreFactory to represent planned manifest entries

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreFactoryOptions.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreFactoryOptions.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.store.connector;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.table.factories.FactoryUtil;
@@ -39,13 +40,16 @@ public class TableStoreFactoryOptions {
                                     + "By default, compaction does not adjust the bucket number "
                                     + "of a partition/table.");
 
+    @Internal
     public static final ConfigOption<String> COMPACTION_SCANNED_MANIFEST =
             ConfigOptions.key("compaction.scanned-manifest")
                     .stringType()
                     .noDefaultValue()
                     .withDescription(
-                            "The string representation of manifest entries which are scanned during manual compaction "
-                                    + " planning phase and injected back into enriched options.");
+                            "The serialized json string of manifest entries which are scanned during manual compaction "
+                                    + "planning phase and injected back into enriched options. The json format contains "
+                                    + "snapshot id and each partition's data file meta list (among which "
+                                    + "each data file meta is encoded by Base64 format) tagged with bucket id.");
 
     public static final ConfigOption<String> LOG_SYSTEM =
             ConfigOptions.key("log.system")

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreFactoryOptions.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreFactoryOptions.java
@@ -39,6 +39,14 @@ public class TableStoreFactoryOptions {
                                     + "By default, compaction does not adjust the bucket number "
                                     + "of a partition/table.");
 
+    public static final ConfigOption<String> COMPACTION_SCANNED_MANIFEST =
+            ConfigOptions.key("compaction.scanned-manifest")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The string representation of manifest entries which are scanned during manual compaction "
+                                    + " planning phase and injected back into enriched options.");
+
     public static final ConfigOption<String> LOG_SYSTEM =
             ConfigOptions.key("log.system")
                     .stringType()
@@ -52,13 +60,14 @@ public class TableStoreFactoryOptions {
                     .intType()
                     .noDefaultValue()
                     .withDescription(
-                            "Defines a custom parallelism for the scan source. "
+                            "Define a custom parallelism for the scan source. "
                                     + "By default, if this option is not defined, the planner will derive the parallelism "
                                     + "for each statement individually by also considering the global configuration.");
 
     public static Set<ConfigOption<?>> allOptions() {
         Set<ConfigOption<?>> allOptions = new HashSet<>();
         allOptions.add(COMPACTION_RESCALE_BUCKET);
+        allOptions.add(COMPACTION_SCANNED_MANIFEST);
         allOptions.add(LOG_SYSTEM);
         allOptions.add(SINK_PARALLELISM);
         allOptions.add(SCAN_PARALLELISM);


### PR DESCRIPTION
When `TableStoreFactory.onCompactTable`gets called, the planned manifest entries need to be injected back into the enriched options, and we need a new key to represent it.