### PR TITLE
[FLINK-27542] E2e docker image should not occupy host machine ports as tests may run in parallel

### DIFF
--- a/flink-table-store-e2e-tests/src/test/java/org/apache/flink/table/store/tests/E2eTestBase.java
+++ b/flink-table-store-e2e-tests/src/test/java/org/apache/flink/table/store/tests/E2eTestBase.java
@@ -96,11 +96,7 @@ public abstract class E2eTestBase {
         }
         environment.withServices(services.toArray(new String[0]));
 
-        synchronized (E2eTestBase.class) {
-            // there are some steps which cannot be executed in parallel when starting the same
-            // docker image, so we should lock here
-            environment.start();
-        }
+        environment.start();
         jobManager = environment.getContainerByServiceName("jobmanager_1").get();
         jobManager.execInContainer("chown", "-R", "flink:flink", TEST_DATA_DIR);
 

--- a/flink-table-store-e2e-tests/src/test/resources-filtered/docker-compose.yaml
+++ b/flink-table-store-e2e-tests/src/test/resources-filtered/docker-compose.yaml
@@ -35,8 +35,8 @@ services:
       testnetwork:
         aliases:
           - jobmanager
-    ports:
-      - "8081:8081"
+    expose:
+      - "8081"
 
   taskmanager:
     image: apache/flink:${flink.version}
@@ -65,8 +65,8 @@ services:
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
-    ports:
-      - "2181:2181"
+    expose:
+      - "2181"
 
   kafka:
     image: confluentinc/cp-kafka:7.0.1
@@ -85,8 +85,8 @@ services:
       KAFKA_TRANSACTION_MAX_TIMEOUT_MS: 7200000
       # Disable log deletion to prevent records from being deleted during test run
       KAFKA_LOG_RETENTION_MS: -1
-    ports:
-      - "9092:9092"
+    expose:
+      - "9092"
     depends_on:
       - zookeeper
 


### PR DESCRIPTION
Currently e2e tests are not stable and may fail with `Container did not start correctly`. This is because docker images are occupying host machine ports now. As tests may run in parallel, docker images will fail to start if their corresponding ports are already occupied.