### PR TITLE
POC for ALTER TABLE ... COMPACT

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/AbstractTableStoreFactory.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/AbstractTableStoreFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.store.connector;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
@@ -155,7 +156,8 @@ public abstract class AbstractTableStoreFactory
                                 Map.Entry::getValue));
     }
 
-    static TableStore buildTableStore(DynamicTableFactory.Context context) {
+    @VisibleForTesting
+    TableStore buildTableStore(DynamicTableFactory.Context context) {
         TableStore store =
                 new TableStore(
                         context.getObjectIdentifier(),

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreFactoryOptions.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreFactoryOptions.java
@@ -52,10 +52,25 @@ public class TableStoreFactoryOptions {
                     .stringType()
                     .noDefaultValue()
                     .withDescription(
-                            "The serialized json string of manifest entries which are scanned during manual compaction "
-                                    + "planning phase and injected back into enriched options. The json format contains "
-                                    + "snapshot id and each partition's data file meta list (among which "
-                                    + "each data file meta is encoded by Base64 format) tagged with bucket id.");
+                            "The base64 string of manifest entries which are scanned during manual compaction "
+                                    + "planning phase and injected back into enriched options. The format contains "
+                                    + "snapshot id and each partition's data file meta list tagged with bucket id.");
+
+    @Internal
+    public static final ConfigOption<Boolean> COMPACTION_MANUAL_TRIGGERED =
+            ConfigOptions.key("compaction.manual-triggered")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "An internal flag to indicate a manual triggered non-rescale bucket compaction.");
+
+    @Internal
+    public static final ConfigOption<String> COMPACTION_PARTITION_SPEC =
+            ConfigOptions.key("compaction.partition-spec")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "An internal flag to record the partition spec for the manual triggered non-rescale bucket compaction.");
 
     public static final ConfigOption<String> LOG_SYSTEM =
             ConfigOptions.key("log.system")

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSinkCompactor.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSinkCompactor.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector.sink;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.connector.file.table.FileSystemConnectorOptions;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.store.file.FileStore;
+import org.apache.flink.table.store.file.data.DataFileMeta;
+import org.apache.flink.table.store.file.mergetree.SortedRun;
+import org.apache.flink.table.store.file.mergetree.compact.CompactStrategy;
+import org.apache.flink.table.store.file.mergetree.compact.CompactUnit;
+import org.apache.flink.table.store.file.mergetree.compact.IntervalPartition;
+import org.apache.flink.table.store.file.mergetree.compact.ManualTriggeredCompaction;
+import org.apache.flink.table.store.file.operation.FileStoreScan;
+import org.apache.flink.table.store.file.predicate.PredicateConverter;
+import org.apache.flink.table.store.file.utils.FileStorePathFactory;
+import org.apache.flink.table.store.file.utils.KeyComparatorSupplier;
+import org.apache.flink.table.store.file.writer.RecordWriter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/** A dedicated {@link SinkWriter} for manual triggered compaction. */
+public class StoreSinkCompactor<WriterStateT> extends StoreSinkWriterBase<WriterStateT> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StoreSinkCompactor.class);
+
+    private final int subTaskId;
+    private final int numOfParallelInstances;
+
+    private final FileStore fileStore;
+    private final int numLevels;
+    private final long targetFileSize;
+    private final Map<BinaryRowData, Map<Integer, List<CompactUnit>>> partitionedUnits;
+    private final Map<String, String> partitionSpec;
+
+    public StoreSinkCompactor(
+            int subTaskId,
+            int numOfParallelInstances,
+            FileStore fileStore,
+            int numLevels,
+            long targetFileSize,
+            Map<String, String> partitionSpec) {
+        this.subTaskId = subTaskId;
+        this.numOfParallelInstances = numOfParallelInstances;
+        this.fileStore = fileStore;
+        this.numLevels = numLevels;
+        this.targetFileSize = targetFileSize;
+        this.partitionSpec = partitionSpec;
+        this.partitionedUnits = new HashMap<>();
+    }
+
+    @Override
+    public void flush(boolean endOfInput) {
+        if (endOfInput) {
+            FileStoreScan.Plan plan =
+                    fileStore
+                            .newScan()
+                            .withPartitionFilter(
+                                    PredicateConverter.CONVERTER.fromMap(
+                                            partitionSpec, fileStore.partitionType()))
+                            .plan();
+            Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> groupBy = new HashMap<>();
+            plan.groupByPartFiles()
+                    .forEach(
+                            (partition, bucketEntry) ->
+                                    bucketEntry.forEach(
+                                            (bucket, meta) -> {
+                                                if (select(partition, bucket)) {
+                                                    if (LOG.isDebugEnabled()) {
+                                                        LOG.info(
+                                                                "Assign partition {}, bucket {} to subtask {}",
+                                                                FileStorePathFactory
+                                                                        .getPartitionComputer(
+                                                                                fileStore
+                                                                                        .partitionType(),
+                                                                                FileSystemConnectorOptions
+                                                                                        .PARTITION_DEFAULT_NAME
+                                                                                        .defaultValue())
+                                                                        .generatePartValues(
+                                                                                partition),
+                                                                bucket,
+                                                                subTaskId);
+                                                    }
+                                                    groupBy.computeIfAbsent(
+                                                                    partition, k -> new HashMap<>())
+                                                            .computeIfAbsent(
+                                                                    bucket, k -> new ArrayList<>())
+                                                            .addAll(meta);
+                                                }
+                                            }));
+
+            pickManifest(groupBy, new KeyComparatorSupplier(fileStore.keyType()).get());
+            for (Map.Entry<BinaryRowData, Map<Integer, List<CompactUnit>>> partEntry :
+                    partitionedUnits.entrySet()) {
+                BinaryRowData partition = partEntry.getKey();
+                for (Map.Entry<Integer, List<CompactUnit>> bucketEntry :
+                        partEntry.getValue().entrySet()) {
+                    int bucket = bucketEntry.getKey();
+                    RecordWriter writer = getWriter(partition, bucket);
+                    try {
+                        writer.flush();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    protected RecordWriter createWriter(BinaryRowData partition, int bucket) {
+        BinaryRowData copied = partition.copy();
+        return fileStore
+                .newWrite()
+                .createCompactWriter(copied, bucket, partitionedUnits.get(copied).get(bucket));
+    }
+
+    @Override
+    public void write(RowData element, Context context) throws IOException, InterruptedException {
+        // nothing to write
+    }
+
+    @Override
+    public void close() throws Exception {
+        partitionedUnits.clear();
+        super.close();
+    }
+
+    @VisibleForTesting
+    boolean select(BinaryRowData partition, int bucket) {
+        return subTaskId == Math.abs(Objects.hash(partition, bucket) % numOfParallelInstances);
+    }
+
+    @VisibleForTesting
+    void pickManifest(
+            Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> groupBy,
+            Comparator<RowData> keyComparator) {
+        CompactStrategy<SortedRun> strategy = new ManualTriggeredCompaction(targetFileSize);
+        for (Map.Entry<BinaryRowData, Map<Integer, List<DataFileMeta>>> partEntry :
+                groupBy.entrySet()) {
+            Map<Integer, List<CompactUnit>> partUnit = new HashMap<>();
+            for (Map.Entry<Integer, List<DataFileMeta>> bucketEntry :
+                    partEntry.getValue().entrySet()) {
+                List<List<SortedRun>> sections =
+                        new IntervalPartition(bucketEntry.getValue(), keyComparator).partition();
+                List<CompactUnit> bucketUnit = new ArrayList<>();
+                sections.forEach(
+                        section -> strategy.pick(numLevels, section).ifPresent(bucketUnit::add));
+                if (bucketUnit.size() > 0) {
+                    partUnit.put(bucketEntry.getKey(), bucketUnit);
+                }
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(
+                            "Pick these files (name, level, size) for partition {}, bucket {} to compact: {}",
+                            FileStorePathFactory.getPartitionComputer(
+                                    fileStore.partitionType(),
+                                    FileSystemConnectorOptions.PARTITION_DEFAULT_NAME
+                                            .defaultValue()),
+                            bucketEntry.getKey(),
+                            bucketUnit.stream()
+                                    .map(CompactUnit::files)
+                                    .flatMap(Collection::stream)
+                                    .map(
+                                            file ->
+                                                    String.join(
+                                                            ",",
+                                                            file.fileName(),
+                                                            String.valueOf(file.level()),
+                                                            String.valueOf(file.fileSize())))
+                                    .collect(Collectors.joining(";")));
+                }
+            }
+            if (partUnit.size() > 0) {
+                partitionedUnits.put(partEntry.getKey(), partUnit);
+            }
+        }
+    }
+
+    @VisibleForTesting
+    Map<BinaryRowData, Map<Integer, List<CompactUnit>>> getPartitionedUnits() {
+        return partitionedUnits;
+    }
+}

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSinkWriter.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSinkWriter.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.store.connector.sink;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.flink.api.connector.sink2.StatefulSink.StatefulSinkWriter;
 import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink.PrecommittingSinkWriter;
@@ -40,21 +39,14 @@ import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 /** A {@link SinkWriter} for dynamic store. */
-public class StoreSinkWriter<WriterStateT>
-        implements StatefulSinkWriter<RowData, WriterStateT>,
-                PrecommittingSinkWriter<RowData, Committable> {
+public class StoreSinkWriter<WriterStateT> extends StoreSinkWriterBase<WriterStateT> {
 
     private static final BinaryRowData DUMMY_KEY = BinaryRowDataUtil.EMPTY_ROW;
 
@@ -70,8 +62,6 @@ public class StoreSinkWriter<WriterStateT>
     @Nullable private final LogWriteCallback logCallback;
 
     private final ExecutorService compactExecutor;
-
-    private final Map<BinaryRowData, Map<Integer, RecordWriter>> writers;
 
     public StoreSinkWriter(
             FileStoreWrite fileStoreWrite,
@@ -89,23 +79,13 @@ public class StoreSinkWriter<WriterStateT>
         this.compactExecutor =
                 Executors.newSingleThreadScheduledExecutor(
                         new ExecutorThreadFactory("compaction-thread"));
-        this.writers = new HashMap<>();
     }
 
-    private RecordWriter getWriter(BinaryRowData partition, int bucket) {
-        Map<Integer, RecordWriter> buckets = writers.get(partition);
-        if (buckets == null) {
-            buckets = new HashMap<>();
-            writers.put(partition.copy(), buckets);
-        }
-        return buckets.computeIfAbsent(
-                bucket,
-                k ->
-                        overwrite
-                                ? fileStoreWrite.createEmptyWriter(
-                                        partition.copy(), bucket, compactExecutor)
-                                : fileStoreWrite.createWriter(
-                                        partition.copy(), bucket, compactExecutor));
+    @Override
+    protected RecordWriter createWriter(BinaryRowData partition, int bucket) {
+        return overwrite
+                ? fileStoreWrite.createEmptyWriter(partition.copy(), bucket, compactExecutor)
+                : fileStoreWrite.createWriter(partition.copy(), bucket, compactExecutor);
     }
 
     @Override
@@ -167,45 +147,12 @@ public class StoreSinkWriter<WriterStateT>
         if (logWriter != null && logWriter instanceof StatefulSinkWriter) {
             return ((StatefulSinkWriter<?, WriterStateT>) logWriter).snapshotState(checkpointId);
         }
-        return Collections.emptyList();
+        return super.snapshotState(checkpointId);
     }
 
     @Override
     public List<Committable> prepareCommit() throws IOException, InterruptedException {
-        List<Committable> committables = new ArrayList<>();
-        Iterator<Map.Entry<BinaryRowData, Map<Integer, RecordWriter>>> partIter =
-                writers.entrySet().iterator();
-        while (partIter.hasNext()) {
-            Map.Entry<BinaryRowData, Map<Integer, RecordWriter>> partEntry = partIter.next();
-            BinaryRowData partition = partEntry.getKey();
-            Iterator<Map.Entry<Integer, RecordWriter>> bucketIter =
-                    partEntry.getValue().entrySet().iterator();
-            while (bucketIter.hasNext()) {
-                Map.Entry<Integer, RecordWriter> entry = bucketIter.next();
-                int bucket = entry.getKey();
-                RecordWriter writer = entry.getValue();
-                FileCommittable committable;
-                try {
-                    committable = new FileCommittable(partition, bucket, writer.prepareCommit());
-                } catch (Exception e) {
-                    throw new IOException(e);
-                }
-                committables.add(new Committable(Committable.Kind.FILE, committable));
-
-                // clear if no update
-                // we need a mechanism to clear writers, otherwise there will be more and more
-                // such as yesterday's partition that no longer needs to be written.
-                if (committable.increment().newFiles().isEmpty()) {
-                    closeWriter(writer);
-                    bucketIter.remove();
-                }
-            }
-
-            if (partEntry.getValue().isEmpty()) {
-                partIter.remove();
-            }
-        }
-
+        List<Committable> committables = super.prepareCommit();
         if (logWriter != null) {
             if (logWriter instanceof PrecommittingSinkWriter) {
                 Collection<?> logCommittables =
@@ -228,32 +175,12 @@ public class StoreSinkWriter<WriterStateT>
         return committables;
     }
 
-    private void closeWriter(RecordWriter writer) throws IOException {
-        try {
-            writer.sync();
-            writer.close();
-        } catch (Exception e) {
-            throw new IOException(e);
-        }
-    }
-
     @Override
     public void close() throws Exception {
         this.compactExecutor.shutdownNow();
-        for (Map<Integer, RecordWriter> bucketWriters : writers.values()) {
-            for (RecordWriter writer : bucketWriters.values()) {
-                closeWriter(writer);
-            }
-        }
-        writers.clear();
-
         if (logWriter != null) {
             logWriter.close();
         }
-    }
-
-    @VisibleForTesting
-    Map<BinaryRowData, Map<Integer, RecordWriter>> writers() {
-        return writers;
+        super.close();
     }
 }

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSinkWriterBase.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSinkWriterBase.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector.sink;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.connector.sink2.StatefulSink;
+import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.store.file.writer.RecordWriter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The base class for file store sink writers.
+ *
+ * @param <WriterStateT> The type of the writer's state.
+ */
+public abstract class StoreSinkWriterBase<WriterStateT>
+        implements StatefulSink.StatefulSinkWriter<RowData, WriterStateT>,
+                TwoPhaseCommittingSink.PrecommittingSinkWriter<RowData, Committable> {
+
+    protected final Map<BinaryRowData, Map<Integer, RecordWriter>> writers;
+
+    protected StoreSinkWriterBase() {
+        writers = new HashMap<>();
+    }
+
+    @Override
+    public List<Committable> prepareCommit() throws IOException, InterruptedException {
+        List<Committable> committables = new ArrayList<>();
+        Iterator<Map.Entry<BinaryRowData, Map<Integer, RecordWriter>>> partIter =
+                writers.entrySet().iterator();
+        while (partIter.hasNext()) {
+            Map.Entry<BinaryRowData, Map<Integer, RecordWriter>> partEntry = partIter.next();
+            BinaryRowData partition = partEntry.getKey();
+            Iterator<Map.Entry<Integer, RecordWriter>> bucketIter =
+                    partEntry.getValue().entrySet().iterator();
+            while (bucketIter.hasNext()) {
+                Map.Entry<Integer, RecordWriter> entry = bucketIter.next();
+                int bucket = entry.getKey();
+                RecordWriter writer = entry.getValue();
+                FileCommittable committable;
+                try {
+                    committable = new FileCommittable(partition, bucket, writer.prepareCommit());
+                } catch (Exception e) {
+                    throw new IOException(e);
+                }
+                committables.add(new Committable(Committable.Kind.FILE, committable));
+
+                // clear if no update
+                // we need a mechanism to clear writers, otherwise there will be more and more
+                // such as yesterday's partition that no longer needs to be written.
+                if (committable.increment().newFiles().isEmpty()) {
+                    closeWriter(writer);
+                    bucketIter.remove();
+                }
+            }
+
+            if (partEntry.getValue().isEmpty()) {
+                partIter.remove();
+            }
+        }
+        return committables;
+    }
+
+    @Override
+    public List<WriterStateT> snapshotState(long checkpointId) throws IOException {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void close() throws Exception {
+        for (Map<Integer, RecordWriter> bucketWriters : writers.values()) {
+            for (RecordWriter writer : bucketWriters.values()) {
+                closeWriter(writer);
+            }
+        }
+        writers.clear();
+    }
+
+    protected RecordWriter getWriter(BinaryRowData partition, int bucket) {
+        Map<Integer, RecordWriter> buckets = writers.get(partition);
+        if (buckets == null) {
+            buckets = new HashMap<>();
+            writers.put(partition.copy(), buckets);
+        }
+        return buckets.computeIfAbsent(bucket, k -> createWriter(partition, bucket));
+    }
+
+    protected abstract RecordWriter createWriter(BinaryRowData partition, int bucket);
+
+    private void closeWriter(RecordWriter writer) throws IOException {
+        try {
+            writer.sync();
+            writer.close();
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+
+    @VisibleForTesting
+    Map<BinaryRowData, Map<Integer, RecordWriter>> writers() {
+        return writers;
+    }
+}

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/TableStoreSink.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/TableStoreSink.java
@@ -127,7 +127,8 @@ public class TableStoreSink
                             });
         }
         // Do not sink to log store when overwrite mode
-        final LogSinkProvider finalLogSinkProvider = overwrite ? null : logSinkProvider;
+        final LogSinkProvider finalLogSinkProvider =
+                overwrite || tableStore.isCompactionTask() ? null : logSinkProvider;
         return (DataStreamSinkProvider)
                 (providerContext, dataStream) ->
                         tableStore

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSource.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSource.java
@@ -38,6 +38,7 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 
 import static org.apache.flink.table.store.connector.source.PendingSplitsCheckpoint.INVALID_SNAPSHOT;
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -60,6 +61,8 @@ public class FileStoreSource
 
     private final boolean latestContinuous;
 
+    private final boolean nonRescaleCompact;
+
     @Nullable private final int[][] projectedFields;
 
     @Nullable private final Predicate partitionPredicate;
@@ -67,7 +70,7 @@ public class FileStoreSource
     @Nullable private final Predicate fieldPredicate;
 
     /**
-     * The partitioned manifest meta collected at planning phase when manual compaction is
+     * The partitioned manifest meta collected at planning phase when rescale-bucket compaction is
      * triggered.
      */
     @Nullable private final PartitionedManifestMeta specifiedPartManifests;
@@ -79,6 +82,7 @@ public class FileStoreSource
             boolean isContinuous,
             long discoveryInterval,
             boolean latestContinuous,
+            boolean nonRescaleCompact,
             @Nullable int[][] projectedFields,
             @Nullable Predicate partitionPredicate,
             @Nullable Predicate fieldPredicate,
@@ -89,6 +93,7 @@ public class FileStoreSource
         this.isContinuous = isContinuous;
         this.discoveryInterval = discoveryInterval;
         this.latestContinuous = latestContinuous;
+        this.nonRescaleCompact = nonRescaleCompact;
         this.projectedFields = projectedFields;
         this.partitionPredicate = partitionPredicate;
         this.fieldPredicate = fieldPredicate;
@@ -138,12 +143,17 @@ public class FileStoreSource
             PendingSplitsCheckpoint checkpoint) {
         FileStoreScan scan = fileStore.newScan();
 
+        // let rescale compaction read pre-planned manifests
         if (specifiedPartManifests != null) {
             return new StaticFileStoreSplitEnumerator(
                     context,
                     scan.snapshot(specifiedPartManifests.getSnapshotId()),
                     new FileStoreSourceSplitGenerator()
                             .createSplits(specifiedPartManifests.getManifestEntries()));
+        }
+
+        if (nonRescaleCompact) {
+            return new StaticFileStoreSplitEnumerator(context, null, Collections.emptyList());
         }
 
         if (partitionPredicate != null) {

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/StaticFileStoreSplitEnumerator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/StaticFileStoreSplitEnumerator.java
@@ -44,7 +44,7 @@ public class StaticFileStoreSplitEnumerator
 
     public StaticFileStoreSplitEnumerator(
             SplitEnumeratorContext<FileStoreSourceSplit> context,
-            Snapshot snapshot,
+            @Nullable Snapshot snapshot,
             Collection<FileStoreSourceSplit> splits) {
         this.context = context;
         this.snapshot = snapshot;

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/AlterTableCompactITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/AlterTableCompactITCase.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector;
+
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.store.file.utils.SnapshotFinder;
+import org.apache.flink.types.Row;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.flink.table.store.file.FileStoreOptions.relativeTablePath;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** ITCase for 'ALTER TABLE ... COMPACT'. */
+public class AlterTableCompactITCase extends FileStoreTableITCase {
+
+    @Override
+    protected List<String> ddl() {
+        return Arrays.asList(
+                "CREATE TABLE IF NOT EXISTS T0 (f0 INT, f1 STRING, f2 DOUBLE)",
+                "CREATE TABLE IF NOT EXISTS T1 ("
+                        + "f0 INT, f1 STRING, f2 STRING) PARTITIONED BY (f1)",
+                "CREATE TABLE IF NOT EXISTS T2 ("
+                        + "f0 INT, f1 STRING, f2 STRING) PARTITIONED BY (f1, f0)");
+    }
+
+    @Test
+    public void testNonPartitioned() throws Exception {
+        batchSql("INSERT INTO T0 VALUES (1, 'Pride and Prejudice', 9.0), (2, 'Emma', 8.5)");
+        batchSql(
+                "INSERT INTO T0 VALUES (3, 'The Mansfield Park', 7.0), (4, 'Sense and Sensibility', 9.0)");
+        batchSql("INSERT INTO T0 VALUES (5, 'Northanger Abby', 8.6)");
+        batchSql(
+                "INSERT INTO T0 VALUES (6, 'Jane Eyre', 9.9), (1, 'Pride and Prejudice', 9.0), (2, 'Emma', 8.5)");
+
+        Long snapshot = findLatestSnapshotId("T0");
+        List<Row> expected = batchSql("SELECT * FROM T0", 6);
+
+        batchSql("ALTER TABLE T0 SET ('num-sorted-run.compaction-trigger' = '2')");
+        batchSql("ALTER TABLE T0 COMPACT");
+
+        assertThat(batchSql("SELECT * FROM T0", 6)).containsExactlyInAnyOrderElementsOf(expected);
+        assertThat(findLatestSnapshotId("T0")).isEqualTo(snapshot + 2);
+    }
+
+    @Test
+    public void testSinglePartitioned() throws Exception {
+        batchSql("ALTER TABLE T1 SET ('num-levels' = '3')");
+
+        // increase trigger to avoid compaction
+        batchSql("ALTER TABLE T1 SET ('num-sorted-run.compaction-trigger' = '20')");
+        batchSql("ALTER TABLE T1 SET ('num-sorted-run.stop-trigger' = '20')");
+        batchSql(
+                "INSERT INTO T1 VALUES (1, 'Winter', 'Winter is Coming'),"
+                        + " (2, 'Winter', 'The First Snowflake'),"
+                        + " (2, 'Spring', 'The First Rose in Spring'),"
+                        + " (7, 'Summer', 'Summertime Sadness')");
+        batchSql("INSERT INTO T1 VALUES (12, 'Winter', 'Last Christmas')");
+        batchSql("INSERT INTO T1 VALUES (11, 'Winter', 'Winter is Coming')");
+        batchSql("INSERT INTO T1 VALUES (10, 'Autumn', 'Refrain')");
+        batchSql(
+                "INSERT INTO T1 VALUES (6, 'Summer', 'Watermelon Sugar'),"
+                        + " (4, 'Spring', 'Spring Water')");
+        batchSql(
+                "INSERT INTO T1 VALUES (66, 'Summer', 'Summer Vibe'),"
+                        + " (9, 'Autumn', 'Wake Me Up When September Ends')");
+        batchSql(
+                "INSERT INTO T1 VALUES (666, 'Summer', 'Summer Vibe'),"
+                        + " (9, 'Autumn', 'Wake Me Up When September Ends')");
+        batchSql(
+                "INSERT INTO T1 VALUES (6666, 'Summer', 'Summer Vibe'),"
+                        + " (9, 'Autumn', 'Wake Me Up When September Ends')");
+        batchSql(
+                "INSERT INTO T1 VALUES (66666, 'Summer', 'Summer Vibe'),"
+                        + " (7, 'Summer', 'Summertime Sadness')");
+        batchSql(
+                "INSERT INTO T1 VALUES (66666, 'Summer', 'Summer Vibe'),"
+                        + " (9, 'Autumn', 'Wake Me Up When September Ends')");
+        batchSql(
+                "INSERT INTO T1 VALUES (66666, 'Summer', 'Summer Vibe'),"
+                        + " (7, 'Summer', 'Summertime Sadness')");
+
+        Long snapshot1 = findLatestSnapshotId("T1");
+        List<Row> expectedSummer = batchSql("SELECT * FROM T1 WHERE f1 = 'Summer'", 8);
+        List<Row> expectedFourSeasons = batchSql("SELECT * FROM T1", 21);
+
+        // compact a single partition
+        batchSql("ALTER TABLE T1 PARTITION (f1 = 'Summer') COMPACT");
+        assertThat(batchSql("SELECT * FROM T1 WHERE f1 = 'Summer'", 8))
+                .containsExactlyElementsOf(expectedSummer);
+        Long snapshot2 = findLatestSnapshotId("T1");
+        assertThat(snapshot2).isEqualTo(snapshot1 + 2);
+
+        // compact whole table
+        batchSql("ALTER TABLE T1 SET ('num-sorted-run.compaction-trigger' = '1')");
+        batchSql("ALTER TABLE T1 COMPACT");
+        assertThat(batchSql("SELECT * FROM T1", 21))
+                .containsExactlyInAnyOrderElementsOf(expectedFourSeasons);
+        Long snapshot3 = findLatestSnapshotId("T1");
+        assertThat(snapshot3).isEqualTo(snapshot2 + 2);
+
+        batchSql("ALTER TABLE T1 COMPACT");
+        assertThat(findLatestSnapshotId("T1")).isEqualTo(snapshot3);
+    }
+
+    @Test
+    public void testMultiPartitioned() throws Exception {
+        batchSql("ALTER TABLE T2 SET ('num-levels' = '3')");
+        // increase trigger to avoid compaction
+        batchSql("ALTER TABLE T2 SET ('num-sorted-run.compaction-trigger' = '20')");
+        batchSql("ALTER TABLE T2 SET ('num-sorted-run.stop-trigger' = '20')");
+
+        batchSql(
+                "INSERT INTO T2 VALUES (1, '2022-05-19', 'Hello'),"
+                        + " (2, '2022-05-19', 'Bye'),"
+                        + " (3, '2022-05-19', 'Meow')");
+
+        batchSql(
+                "INSERT INTO T2 VALUES (1, '2022-05-19', 'Bonjour'),"
+                        + " (2, '2022-05-19', 'Ciao'),"
+                        + " (3, '2022-05-19', 'Bark')");
+
+        batchSql(
+                "INSERT INTO T2 VALUES (1, '2022-05-20', 'Hasta la vista'),"
+                        + " (1, '2022-05-19', 'Bonjour'),"
+                        + " (2, '2022-05-19', 'Ciao'),"
+                        + " (3, '2022-05-19', 'Bark')");
+
+        Long snapshot1 = findLatestSnapshotId("T2");
+        List<Row> theSecond = batchSql("SELECT * FROM T2 WHERE f0 = 2", 3);
+
+        batchSql("ALTER TABLE T2 PARTITION (f0 = 2) COMPACT");
+        assertThat(batchSql("SELECT * FROM T2 WHERE f0 = 2", 3))
+                .containsExactlyInAnyOrderElementsOf(theSecond);
+        assertThat(findLatestSnapshotId("T2")).isEqualTo(snapshot1 + 2);
+    }
+
+    private Long findLatestSnapshotId(String tableName) throws IOException {
+        return SnapshotFinder.findLatest(
+                Path.fromLocalFile(
+                        new File(
+                                URI.create(
+                                        path
+                                                + relativeTablePath(
+                                                        ObjectIdentifier.of(
+                                                                bEnv.getCurrentCatalog(),
+                                                                bEnv.getCurrentDatabase(),
+                                                                tableName))
+                                                + "/snapshot"))));
+    }
+}

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileStoreTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileStoreTableITCase.java
@@ -44,13 +44,14 @@ public abstract class FileStoreTableITCase extends AbstractTestBase {
 
     protected TableEnvironment bEnv;
     protected TableEnvironment sEnv;
+    protected String path;
 
     @Before
     public void before() throws IOException {
         bEnv = TableEnvironment.create(EnvironmentSettings.newInstance().inBatchMode().build());
         sEnv = TableEnvironment.create(EnvironmentSettings.newInstance().inStreamingMode().build());
         sEnv.getConfig().getConfiguration().set(CHECKPOINTING_INTERVAL, Duration.ofMillis(100));
-        String path = TEMPORARY_FOLDER.newFolder().toURI().toString();
+        path = TEMPORARY_FOLDER.newFolder().toURI().toString();
         prepareEnv(bEnv, path);
         prepareEnv(sEnv, path);
     }

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/MockTableStoreManagedFactory.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/MockTableStoreManagedFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.types.logical.RowType;
+
+import static org.apache.flink.table.store.file.TestKeyValueGenerator.DEFAULT_PART_TYPE;
+import static org.apache.flink.table.store.file.TestKeyValueGenerator.DEFAULT_ROW_TYPE;
+import static org.apache.flink.table.store.file.TestKeyValueGenerator.KEY_TYPE;
+
+/** Mock {@link TableStoreManagedFactory} to create {@link TestTableStore} for tests. */
+public class MockTableStoreManagedFactory extends TableStoreManagedFactory {
+
+    private final RowType partitionType;
+    private final RowType rowType;
+
+    public MockTableStoreManagedFactory() {
+        partitionType = DEFAULT_PART_TYPE;
+        rowType = DEFAULT_ROW_TYPE;
+    }
+
+    public MockTableStoreManagedFactory(RowType partitionType, RowType rowType) {
+        this.partitionType = partitionType;
+        this.rowType = rowType;
+    }
+
+    @Override
+    TableStore buildTableStore(Context context) {
+        return new TestTableStore(
+                context.getObjectIdentifier(),
+                Configuration.fromMap(context.getCatalogTable().getOptions()),
+                partitionType,
+                KEY_TYPE,
+                rowType);
+    }
+}

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreManagedFactoryTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreManagedFactoryTest.java
@@ -19,44 +19,83 @@
 package org.apache.flink.table.store.connector;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.file.table.RowDataPartitionComputer;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.catalog.CatalogPartitionSpec;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.factories.DynamicTableFactory;
 import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.store.file.FileStore;
+import org.apache.flink.table.store.file.KeyValue;
+import org.apache.flink.table.store.file.Snapshot;
+import org.apache.flink.table.store.file.TestFileStore;
 import org.apache.flink.table.store.file.TestKeyValueGenerator;
+import org.apache.flink.table.store.file.mergetree.MergeTreeOptions;
+import org.apache.flink.table.store.file.mergetree.compact.DeduplicateMergeFunction;
+import org.apache.flink.table.store.file.operation.FileStoreScan;
+import org.apache.flink.table.store.file.predicate.PredicateConverter;
+import org.apache.flink.table.store.file.utils.JsonSerdeUtil;
+import org.apache.flink.table.store.file.utils.PartitionedManifestMeta;
 import org.apache.flink.table.store.log.LogOptions;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.InstantiationUtil;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.UUID;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static org.apache.flink.table.store.connector.TableStoreFactoryOptions.COMPACTION_MANUAL_TRIGGERED;
+import static org.apache.flink.table.store.connector.TableStoreFactoryOptions.COMPACTION_PARTITION_SPEC;
+import static org.apache.flink.table.store.connector.TableStoreFactoryOptions.COMPACTION_RESCALE_BUCKET;
+import static org.apache.flink.table.store.connector.TableStoreFactoryOptions.COMPACTION_SCANNED_MANIFEST;
 import static org.apache.flink.table.store.connector.TableStoreFactoryOptions.ROOT_PATH;
 import static org.apache.flink.table.store.connector.TableStoreTestBase.createResolvedTable;
 import static org.apache.flink.table.store.file.FileStoreOptions.BUCKET;
+import static org.apache.flink.table.store.file.FileStoreOptions.PARTITION_DEFAULT_NAME;
 import static org.apache.flink.table.store.file.FileStoreOptions.PATH;
 import static org.apache.flink.table.store.file.FileStoreOptions.TABLE_STORE_PREFIX;
+import static org.apache.flink.table.store.file.FileStoreOptions.path;
 import static org.apache.flink.table.store.file.FileStoreOptions.relativeTablePath;
+import static org.apache.flink.table.store.file.TestKeyValueGenerator.DEFAULT_PART_TYPE;
+import static org.apache.flink.table.store.file.TestKeyValueGenerator.DEFAULT_ROW_TYPE;
+import static org.apache.flink.table.store.file.TestKeyValueGenerator.GeneratorMode.MULTI_PARTITIONED;
+import static org.apache.flink.table.store.file.TestKeyValueGenerator.GeneratorMode.NON_PARTITIONED;
+import static org.apache.flink.table.store.file.TestKeyValueGenerator.GeneratorMode.SINGLE_PARTITIONED;
+import static org.apache.flink.table.store.file.TestKeyValueGenerator.KEY_TYPE;
+import static org.apache.flink.table.store.file.TestKeyValueGenerator.NON_PARTITIONED_ROW_TYPE;
+import static org.apache.flink.table.store.file.TestKeyValueGenerator.SINGLE_PARTITIONED_PART_TYPE;
+import static org.apache.flink.table.store.file.TestKeyValueGenerator.SINGLE_PARTITIONED_ROW_TYPE;
+import static org.apache.flink.table.store.file.TestKeyValueGenerator.getPrimaryKeys;
+import static org.apache.flink.table.store.file.mergetree.MergeTreeOptions.NUM_SORTED_RUNS_COMPACTION_TRIGGER;
+import static org.apache.flink.table.store.file.mergetree.MergeTreeOptions.NUM_SORTED_RUNS_STOP_TRIGGER;
+import static org.apache.flink.table.store.file.utils.FileStorePathFactory.getPartitionComputer;
 import static org.apache.flink.table.store.kafka.KafkaLogOptions.BOOTSTRAP_SERVERS;
 import static org.apache.flink.table.store.log.LogOptions.CONSISTENCY;
 import static org.apache.flink.table.store.log.LogOptions.LOG_PREFIX;
@@ -66,8 +105,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /** Test cases for {@link TableStoreManagedFactory}. */
 public class TableStoreManagedFactoryTest {
 
+    private static final String CATALOG = "catalog";
+    private static final String DATABASE = "database";
+    private static final String TABLE = "table";
     private static final ObjectIdentifier TABLE_IDENTIFIER =
-            ObjectIdentifier.of("catalog", "database", "table");
+            ObjectIdentifier.of(CATALOG, DATABASE, TABLE);
+    private static final int NUM_OF_BUCKETS = 2;
 
     private final TableStoreManagedFactory tableStoreManagedFactory =
             new TableStoreManagedFactory();
@@ -76,12 +119,12 @@ public class TableStoreManagedFactoryTest {
     private DynamicTableFactory.Context context;
 
     @ParameterizedTest
-    @MethodSource("providingOptions")
+    @MethodSource("provideOptionsToEnrich")
     public void testEnrichOptions(
             Map<String, String> sessionOptions,
             Map<String, String> tableOptions,
             Map<String, String> expectedEnrichedOptions) {
-        context = createTableContext(sessionOptions, tableOptions);
+        context = createNonEnrichedContext(sessionOptions, tableOptions);
         Map<String, String> actualEnrichedOptions = tableStoreManagedFactory.enrichOptions(context);
         assertThat(actualEnrichedOptions)
                 .containsExactlyInAnyOrderEntriesOf(expectedEnrichedOptions);
@@ -92,12 +135,12 @@ public class TableStoreManagedFactoryTest {
         Map<String, String> sessionMap = new HashMap<>();
         sessionMap.put("table-store.root-path", "my_path");
         sessionMap.put("table-store.path", "another_path");
-        context = createTableContext(sessionMap, emptyMap());
+        context = createNonEnrichedContext(sessionMap, emptyMap());
         assertThatThrownBy(() -> tableStoreManagedFactory.enrichOptions(context))
                 .hasMessage(
                         "Managed table can not contain table path. You need to remove path in table options or session config.");
 
-        context = createTableContext(emptyMap(), emptyMap());
+        context = createNonEnrichedContext(emptyMap(), emptyMap());
         assertThatThrownBy(() -> tableStoreManagedFactory.enrichOptions(context))
                 .hasMessage(
                         "Please specify a root path by setting session level configuration as `SET 'table-store.root-path' = '...'`.");
@@ -109,13 +152,13 @@ public class TableStoreManagedFactoryTest {
         sessionMap.put("table-store.root-path", "my_path");
         sessionMap.put("table-store.log.system", "kafka");
         sessionMap.put("table-store.log.topic", "my_topic");
-        context = createTableContext(sessionMap, emptyMap());
+        context = createNonEnrichedContext(sessionMap, emptyMap());
         assertThatThrownBy(() -> tableStoreManagedFactory.enrichOptions(context))
                 .hasMessage(
                         "Managed table can not contain custom topic. You need to remove topic in table options or session config.");
 
         sessionMap.remove("table-store.log.topic");
-        context = createTableContext(sessionMap, emptyMap());
+        context = createNonEnrichedContext(sessionMap, emptyMap());
         Map<String, String> enriched = tableStoreManagedFactory.enrichOptions(context);
 
         Map<String, String> expected = new HashMap<>();
@@ -126,13 +169,10 @@ public class TableStoreManagedFactoryTest {
     }
 
     @ParameterizedTest
-    @MethodSource("providingEnrichedOptionsForCreation")
+    @MethodSource("provideOptionsToCreate")
     public void testOnCreateTable(Map<String, String> enrichedOptions, boolean ignoreIfExists) {
-        context = enrichContext(createTableContext(emptyMap(), enrichedOptions));
-        Path expectedPath =
-                Paths.get(
-                        sharedTempDir.toAbsolutePath().toString(),
-                        relativeTablePath(TABLE_IDENTIFIER));
+        context = createEnrichedContext(enrichedOptions);
+        Path expectedPath = Paths.get(path(enrichedOptions).getPath());
         boolean exist = expectedPath.toFile().exists();
         if (ignoreIfExists || !exist) {
             tableStoreManagedFactory.onCreateTable(context, ignoreIfExists);
@@ -156,26 +196,11 @@ public class TableStoreManagedFactoryTest {
         }
     }
 
-    private DynamicTableFactory.Context enrichContext(DynamicTableFactory.Context context) {
-        Map<String, String> newOptions = tableStoreManagedFactory.enrichOptions(context);
-        ResolvedCatalogTable table = context.getCatalogTable().copy(newOptions);
-        return new FactoryUtil.DefaultDynamicTableContext(
-                context.getObjectIdentifier(),
-                table,
-                emptyMap(),
-                context.getConfiguration(),
-                context.getClassLoader(),
-                context.isTemporary());
-    }
-
     @ParameterizedTest
-    @MethodSource("providingEnrichedOptionsForDrop")
+    @MethodSource("provideOptionsToDrop")
     public void testOnDropTable(Map<String, String> enrichedOptions, boolean ignoreIfNotExists) {
-        context = enrichContext(createTableContext(emptyMap(), enrichedOptions));
-        Path expectedPath =
-                Paths.get(
-                        sharedTempDir.toAbsolutePath().toString(),
-                        relativeTablePath(TABLE_IDENTIFIER));
+        context = createEnrichedContext(enrichedOptions);
+        Path expectedPath = Paths.get(path(enrichedOptions).getPath());
         boolean exist = expectedPath.toFile().exists();
         if (exist || ignoreIfNotExists) {
             tableStoreManagedFactory.onDropTable(context, ignoreIfNotExists);
@@ -214,7 +239,7 @@ public class TableStoreManagedFactoryTest {
     }
 
     @ParameterizedTest
-    @MethodSource("providingResolvedTable")
+    @MethodSource("provideResolvedTable")
     public void testCreateAndCheckTableStore(
             RowType rowType,
             List<String> partitions,
@@ -223,21 +248,15 @@ public class TableStoreManagedFactoryTest {
         ResolvedCatalogTable catalogTable =
                 createResolvedTable(
                         singletonMap(
-                                "path", sharedTempDir.toAbsolutePath() + "/" + UUID.randomUUID()),
+                                PATH.key(),
+                                sharedTempDir.toAbsolutePath() + "/" + UUID.randomUUID()),
                         rowType,
                         partitions,
                         primaryKeys);
-        context =
-                new FactoryUtil.DefaultDynamicTableContext(
-                        TABLE_IDENTIFIER,
-                        catalogTable,
-                        emptyMap(),
-                        Configuration.fromMap(emptyMap()),
-                        Thread.currentThread().getContextClassLoader(),
-                        false);
+        context = createEnrichedContext(TABLE_IDENTIFIER, catalogTable);
         if (expectedResult.success) {
             tableStoreManagedFactory.onCreateTable(context, false);
-            TableStore tableStore = AbstractTableStoreFactory.buildTableStore(context);
+            TableStore tableStore = tableStoreManagedFactory.buildTableStore(context);
             assertThat(tableStore.partitioned()).isEqualTo(catalogTable.isPartitioned());
             assertThat(tableStore.valueCountMode())
                     .isEqualTo(catalogTable.getResolvedSchema().getPrimaryKeyIndexes().length == 0);
@@ -256,9 +275,272 @@ public class TableStoreManagedFactoryTest {
         }
     }
 
+    @Test
+    public void testOnCompactTableForNoSnapshot() {
+        RowType partType = RowType.of();
+        MockTableStoreManagedFactory mockTableStoreManagedFactory =
+                new MockTableStoreManagedFactory(partType, NON_PARTITIONED_ROW_TYPE);
+        prepare(
+                TABLE + "_" + UUID.randomUUID(),
+                partType,
+                NON_PARTITIONED_ROW_TYPE,
+                NON_PARTITIONED,
+                true);
+        assertThatThrownBy(
+                        () ->
+                                mockTableStoreManagedFactory.onCompactTable(
+                                        context, new CatalogPartitionSpec(emptyMap())))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("The specified table to rescale does not exist any snapshot");
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testOnCompactTableForNonPartitioned(boolean rescaleBucket) throws Exception {
+        RowType partType = RowType.of();
+        runTest(
+                new MockTableStoreManagedFactory(partType, NON_PARTITIONED_ROW_TYPE),
+                TABLE + "_" + UUID.randomUUID(),
+                partType,
+                NON_PARTITIONED_ROW_TYPE,
+                NON_PARTITIONED,
+                rescaleBucket);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testOnCompactTableForSinglePartitioned(boolean rescaleBucket) throws Exception {
+        runTest(
+                new MockTableStoreManagedFactory(
+                        SINGLE_PARTITIONED_PART_TYPE, SINGLE_PARTITIONED_ROW_TYPE),
+                TABLE + "_" + UUID.randomUUID(),
+                SINGLE_PARTITIONED_PART_TYPE,
+                SINGLE_PARTITIONED_ROW_TYPE,
+                SINGLE_PARTITIONED,
+                rescaleBucket);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testOnCompactTableForMultiPartitioned(boolean rescaleBucket) throws Exception {
+        runTest(
+                new MockTableStoreManagedFactory(),
+                TABLE + "_" + UUID.randomUUID(),
+                DEFAULT_PART_TYPE,
+                DEFAULT_ROW_TYPE,
+                MULTI_PARTITIONED,
+                rescaleBucket);
+    }
+
     // ~ Tools ------------------------------------------------------------------
 
-    private static Stream<Arguments> providingOptions() {
+    private void runTest(
+            MockTableStoreManagedFactory mockFactory,
+            String tableName,
+            RowType partitionType,
+            RowType rowType,
+            TestKeyValueGenerator.GeneratorMode mode,
+            boolean rescaleBucket)
+            throws Exception {
+        String path = prepare(tableName, partitionType, rowType, mode, rescaleBucket);
+
+        TestFileStore fileStore =
+                TestFileStore.create(
+                        "avro",
+                        path,
+                        NUM_OF_BUCKETS,
+                        partitionType,
+                        KEY_TYPE,
+                        rowType,
+                        new DeduplicateMergeFunction());
+
+        TestKeyValueGenerator generator = new TestKeyValueGenerator(mode);
+        int commitCount =
+                MergeTreeOptions.NUM_SORTED_RUNS_COMPACTION_TRIGGER.defaultValue()
+                        + new Random().nextInt(5);
+        List<KeyValue> committedData = new ArrayList<>();
+        Snapshot snapshot = null;
+        for (int i = 0; i < commitCount; i++) {
+            List<KeyValue> data = generateData(generator, new Random().nextInt(1000));
+            snapshot = commitData(fileStore, generator, data);
+            committedData.addAll(data);
+        }
+        List<BinaryRowData> partitions =
+                committedData.stream()
+                        .map(generator::getPartition)
+                        .distinct()
+                        .collect(Collectors.toList());
+        Map<String, String> partSpec;
+        if (mode != NON_PARTITIONED) {
+            RowDataPartitionComputer partitionComputer =
+                    getPartitionComputer(partitionType, PARTITION_DEFAULT_NAME.defaultValue());
+
+            List<Map<String, String>> partKvs =
+                    partitions.stream()
+                            .map(partitionComputer::generatePartValues)
+                            .collect(Collectors.toList());
+            partSpec = pickPartition(partKvs);
+        } else {
+            partSpec = emptyMap();
+        }
+        assertManifestTobeCompacted(
+                mockFactory,
+                rescaleBucket,
+                fileStore,
+                snapshot.id(),
+                new CatalogPartitionSpec(partSpec));
+    }
+
+    private String prepare(
+            String tableName,
+            RowType partitionType,
+            RowType rowType,
+            TestKeyValueGenerator.GeneratorMode mode,
+            boolean rescaleBucket) {
+        int compactionTrigger = 20;
+        ObjectIdentifier tableIdentifier = ObjectIdentifier.of(CATALOG, DATABASE, tableName);
+        String path =
+                Paths.get(
+                                sharedTempDir.toAbsolutePath().toString(),
+                                relativeTablePath(tableIdentifier))
+                        .toString();
+        Map<String, String> options =
+                of(
+                        BUCKET.key(),
+                        NUM_OF_BUCKETS + "",
+                        PATH.key(),
+                        path,
+                        NUM_SORTED_RUNS_COMPACTION_TRIGGER.key(),
+                        String.valueOf(compactionTrigger),
+                        NUM_SORTED_RUNS_STOP_TRIGGER.key(),
+                        String.valueOf(compactionTrigger));
+        if (rescaleBucket) {
+            options.put(COMPACTION_RESCALE_BUCKET.key(), "true");
+        }
+        ResolvedCatalogTable catalogTable =
+                createResolvedTable(
+                        options, rowType, partitionType.getFieldNames(), getPrimaryKeys(mode));
+        context = createEnrichedContext(tableIdentifier, catalogTable);
+        tableStoreManagedFactory.onCreateTable(context, false);
+        return path;
+    }
+
+    private List<KeyValue> generateData(TestKeyValueGenerator generator, int numRecords) {
+        List<KeyValue> data = new ArrayList<>();
+        for (int i = 0; i < numRecords; i++) {
+            data.add(generator.next());
+        }
+        return data;
+    }
+
+    private Snapshot commitData(
+            TestFileStore fileStore, TestKeyValueGenerator generator, List<KeyValue> data)
+            throws Exception {
+        List<Snapshot> snapshots =
+                fileStore.commitData(data, generator::getPartition, this::getBucket);
+        return snapshots.get(snapshots.size() - 1);
+    }
+
+    private Integer getBucket(KeyValue kv) {
+        return (kv.key().hashCode() % NUM_OF_BUCKETS + NUM_OF_BUCKETS) % NUM_OF_BUCKETS;
+    }
+
+    private void assertManifestTobeCompacted(
+            MockTableStoreManagedFactory mockFactory,
+            boolean rescaleBucket,
+            FileStore fileStore,
+            long snapshotId,
+            CatalogPartitionSpec partitionSpec)
+            throws IOException {
+        Map<String, String> actual = mockFactory.onCompactTable(context, partitionSpec);
+        if (rescaleBucket) {
+            org.apache.flink.table.store.file.predicate.Predicate partFilter;
+            if (partitionSpec.getPartitionSpec().isEmpty()) {
+                partFilter = null;
+            } else {
+                partFilter =
+                        PredicateConverter.CONVERTER.fromMap(
+                                partitionSpec.getPartitionSpec(), fileStore.partitionType());
+            }
+            FileStoreScan.Plan expectedPlan =
+                    fileStore
+                            .newScan()
+                            .withSnapshot(snapshotId)
+                            .withPartitionFilter(partFilter)
+                            .plan();
+            assertThat(actual)
+                    .containsEntry(
+                            COMPACTION_SCANNED_MANIFEST.key(),
+                            Base64.getEncoder()
+                                    .encodeToString(
+                                            InstantiationUtil.serializeObject(
+                                                    new PartitionedManifestMeta(
+                                                            expectedPlan.snapshotId(),
+                                                            expectedPlan.groupByPartFiles()))));
+            assertThat(actual).containsEntry(COMPACTION_RESCALE_BUCKET.key(), "true");
+        } else {
+            assertThat(actual).containsEntry(COMPACTION_MANUAL_TRIGGERED.key(), "true");
+            assertThat(actual)
+                    .containsEntry(
+                            COMPACTION_PARTITION_SPEC.key(),
+                            JsonSerdeUtil.toJson(partitionSpec.getPartitionSpec()));
+        }
+    }
+
+    private static Map<String, String> pickPartition(List<Map<String, String>> partitions) {
+        // pick a resolved partition spec
+        Map<String, String> partition =
+                new HashMap<>(partitions.get(new Random().nextInt(partitions.size())));
+        // remove some partition keys to test partition resolution
+        List<String> keys = new ArrayList<>(partition.keySet());
+        int count = new Random().nextInt(keys.size());
+        for (int i = 0; i < count; i++) {
+            partition.remove(pickKey(keys));
+        }
+        return partition;
+    }
+
+    private static String pickKey(List<String> keys) {
+        int idx = new Random().nextInt(keys.size());
+        String key = keys.get(idx);
+        keys.set(idx, keys.get(keys.size() - 1));
+        keys.remove(keys.size() - 1);
+        return key;
+    }
+
+    private static ResolvedCatalogTable getDummyTable(Map<String, String> tableOptions) {
+        return new ResolvedCatalogTable(
+                CatalogTable.of(Schema.derived(), "a comment", emptyList(), tableOptions),
+                ResolvedSchema.of(emptyList()));
+    }
+
+    private static DynamicTableFactory.Context createNonEnrichedContext(
+            Map<String, String> sessionOptions, Map<String, String> tableOptions) {
+        return new FactoryUtil.DefaultDynamicTableContext(
+                TABLE_IDENTIFIER,
+                getDummyTable(tableOptions),
+                emptyMap(),
+                Configuration.fromMap(sessionOptions),
+                Thread.currentThread().getContextClassLoader(),
+                false);
+    }
+
+    private static DynamicTableFactory.Context createEnrichedContext(Map<String, String> options) {
+        return createEnrichedContext(TABLE_IDENTIFIER, getDummyTable(options));
+    }
+
+    private static DynamicTableFactory.Context createEnrichedContext(
+            ObjectIdentifier tableIdentifier, ResolvedCatalogTable catalogTable) {
+        return new FactoryUtil.DefaultDynamicTableContext(
+                tableIdentifier,
+                catalogTable,
+                emptyMap(),
+                Configuration.fromMap(emptyMap()),
+                Thread.currentThread().getContextClassLoader(),
+                false);
+    }
+
+    private static Stream<Arguments> provideOptionsToEnrich() {
         Map<String, String> enrichedOptions =
                 of(
                         BUCKET.key(),
@@ -315,16 +597,17 @@ public class TableStoreManagedFactoryTest {
         return expected;
     }
 
-    private static Stream<Arguments> providingEnrichedOptionsForCreation() {
-        Map<String, String> enrichedOptions = new HashMap<>();
-        enrichedOptions.put(ROOT_PATH.key(), sharedTempDir.toAbsolutePath().toString());
+    private static Stream<Arguments> provideOptionsToCreate() {
+        Map<String, String> enrichedOptions =
+                of(ROOT_PATH.key(), sharedTempDir.toAbsolutePath().toString());
+        enrichedOptions = generateTablePath(enrichedOptions);
         return Stream.of(
                 Arguments.of(enrichedOptions, false),
                 Arguments.of(enrichedOptions, true),
                 Arguments.of(enrichedOptions, false));
     }
 
-    private static Stream<Arguments> providingEnrichedOptionsForDrop() {
+    private static Stream<Arguments> provideOptionsToDrop() {
         File tablePath =
                 Paths.get(
                                 sharedTempDir.toAbsolutePath().toString(),
@@ -333,30 +616,31 @@ public class TableStoreManagedFactoryTest {
         if (!tablePath.exists()) {
             tablePath.mkdirs();
         }
-        Map<String, String> enrichedOptions = new HashMap<>();
-        enrichedOptions.put(ROOT_PATH.key(), sharedTempDir.toAbsolutePath().toString());
+        Map<String, String> enrichedOptions =
+                of(ROOT_PATH.key(), sharedTempDir.toAbsolutePath().toString());
+        enrichedOptions = generateTablePath(enrichedOptions);
         return Stream.of(
                 Arguments.of(enrichedOptions, false),
                 Arguments.of(enrichedOptions, true),
                 Arguments.of(enrichedOptions, false));
     }
 
-    private static Stream<Arguments> providingResolvedTable() {
-        RowType rowType = TestKeyValueGenerator.ROW_TYPE;
+    private static Stream<Arguments> provideResolvedTable() {
+        RowType rowType = DEFAULT_ROW_TYPE;
         // success case
         Arguments arg0 =
                 Arguments.of(
                         rowType,
-                        Arrays.asList("dt", "hr"),
-                        Arrays.asList("dt", "hr", "shopId"), // pk is [dt, hr, shopId]
+                        DEFAULT_PART_TYPE.getFieldNames(), // partition is [dt, hr]
+                        getPrimaryKeys(MULTI_PARTITIONED), // pk is [dt, hr, shopId]
                         new TableStoreTestBase.ExpectedResult().success(true));
 
         // failed case: pk doesn't contain partition key
         Arguments arg1 =
                 Arguments.of(
                         rowType,
-                        Arrays.asList("dt", "hr"),
-                        Collections.singletonList("shopId"), // pk is [shopId]
+                        DEFAULT_PART_TYPE.getFieldNames(), // partition is [dt, hr]
+                        singletonList("shopId"), // pk is [shopId]
                         new TableStoreTestBase.ExpectedResult()
                                 .success(false)
                                 .expectedType(IllegalStateException.class)
@@ -367,13 +651,13 @@ public class TableStoreManagedFactoryTest {
         Arguments arg2 =
                 Arguments.of(
                         rowType,
-                        Arrays.asList("dt", "hr", "shopId"),
-                        Arrays.asList("dt", "hr", "shopId"), // pk is [dt, hr, shopId]
+                        DEFAULT_PART_TYPE.getFieldNames(), // partition is [dt, hr]
+                        DEFAULT_PART_TYPE.getFieldNames(), // pk is [dt, hr]
                         new TableStoreTestBase.ExpectedResult()
                                 .success(false)
                                 .expectedType(IllegalStateException.class)
                                 .expectedMessage(
-                                        "Primary key constraint [dt, hr, shopId] should not be same with partition fields [dt, hr, shopId],"
+                                        "Primary key constraint [dt, hr] should not be same with partition fields [dt, hr],"
                                                 + " this will result in only one record in a partition"));
 
         return Stream.of(arg0, arg1, arg2);
@@ -389,25 +673,6 @@ public class TableStoreManagedFactoryTest {
                     }
                 });
         return newOptions;
-    }
-
-    private static DynamicTableFactory.Context createTableContext(
-            Map<String, String> sessionOptions, Map<String, String> tableOptions) {
-        ResolvedCatalogTable resolvedCatalogTable =
-                new ResolvedCatalogTable(
-                        CatalogTable.of(
-                                Schema.derived(),
-                                "a comment",
-                                Collections.emptyList(),
-                                tableOptions),
-                        ResolvedSchema.of(Collections.emptyList()));
-        return new FactoryUtil.DefaultDynamicTableContext(
-                TABLE_IDENTIFIER,
-                resolvedCatalogTable,
-                emptyMap(),
-                Configuration.fromMap(sessionOptions),
-                Thread.currentThread().getContextClassLoader(),
-                false);
     }
 
     private static Map<String, String> of(String... kvs) {

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TestTableStore.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TestTableStore.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.store.file.FileStore;
+import org.apache.flink.table.store.file.FileStoreOptions;
+import org.apache.flink.table.store.file.TestFileStore;
+import org.apache.flink.table.store.file.mergetree.compact.DeduplicateMergeFunction;
+import org.apache.flink.table.types.logical.RowType;
+
+/** {@link TableStore} for tests. */
+public class TestTableStore extends TableStore {
+
+    private final Configuration options;
+    private final RowType partitionType;
+    private final RowType keyType;
+    private final RowType rowType;
+
+    public TestTableStore(
+            ObjectIdentifier tableIdentifier,
+            Configuration options,
+            RowType partitionType,
+            RowType keyType,
+            RowType rowType) {
+        super(tableIdentifier, options);
+        this.options = options;
+        this.partitionType = partitionType;
+        this.keyType = keyType;
+        this.rowType = rowType;
+    }
+
+    @Override
+    FileStore buildFileStore() {
+        return TestFileStore.create(
+                "avro",
+                options.getString(FileStoreOptions.PATH),
+                options.getInteger(FileStoreOptions.BUCKET),
+                partitionType,
+                keyType,
+                rowType,
+                new DeduplicateMergeFunction());
+    }
+}

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/StoreSinkTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/StoreSinkTest.java
@@ -126,6 +126,10 @@ public class StoreSinkTest {
                         primaryKeys,
                         primaryKeys,
                         2,
+                        false,
+                        0,
+                        0,
+                        null,
                         () -> lock,
                         new HashMap<>(),
                         null);
@@ -207,7 +211,7 @@ public class StoreSinkTest {
     }
 
     private List<Committable> write(StoreSink<?, ?> sink, RowData... rows) throws Exception {
-        StoreSinkWriter<?> writer = sink.createWriter(null);
+        StoreSinkWriterBase<?> writer = sink.createWriter(null);
         for (RowData row : rows) {
             writer.write(row, null);
         }
@@ -258,6 +262,10 @@ public class StoreSinkTest {
                 primaryKeys,
                 primaryKeys,
                 2,
+                false,
+                0,
+                0,
+                null,
                 () -> lock,
                 overwritePartition,
                 null);

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/TestFileStore.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/TestFileStore.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.store.file.ValueKind;
 import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.manifest.ManifestCommittable;
 import org.apache.flink.table.store.file.mergetree.Increment;
+import org.apache.flink.table.store.file.mergetree.compact.CompactUnit;
 import org.apache.flink.table.store.file.operation.FileStoreCommit;
 import org.apache.flink.table.store.file.operation.FileStoreExpire;
 import org.apache.flink.table.store.file.operation.FileStoreRead;
@@ -32,6 +33,7 @@ import org.apache.flink.table.store.file.operation.FileStoreScan;
 import org.apache.flink.table.store.file.operation.FileStoreWrite;
 import org.apache.flink.table.store.file.operation.Lock;
 import org.apache.flink.table.store.file.stats.StatsTestUtils;
+import org.apache.flink.table.store.file.writer.CompactWriter;
 import org.apache.flink.table.store.file.writer.RecordWriter;
 import org.apache.flink.table.types.logical.RowType;
 
@@ -88,6 +90,12 @@ public class TestFileStore implements FileStore {
             public RecordWriter createEmptyWriter(
                     BinaryRowData partition, int bucket, ExecutorService compactExecutor) {
                 return new TestRecordWriter(hasPk);
+            }
+
+            @Override
+            public CompactWriter createCompactWriter(
+                    BinaryRowData partition, int bucket, List<CompactUnit> units) {
+                throw new UnsupportedOperationException();
             }
         };
     }
@@ -208,6 +216,9 @@ public class TestFileStore implements FileStore {
         public void sync() {
             synced = true;
         }
+
+        @Override
+        public void flush() throws Exception {}
 
         @Override
         public List<DataFileMeta> close() {

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceTest.java
@@ -77,14 +77,14 @@ public class FileStoreSourceTest {
     @ParameterizedTest
     public void testSerDe(boolean hasPk, boolean partitioned, boolean specified)
             throws ClassNotFoundException, IOException {
-        FileStore fileStore = buildFileStore(hasPk, partitioned);
-        Long specifiedSnapshotId = specified ? 1L : null;
         Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> specifiedManifestEntries =
                 specified ? buildManifestEntries(hasPk, partitioned) : null;
+        Long specifiedSnapshotId = specified ? 1L : null;
         PartitionedManifestMeta partitionedManifestMeta =
                 specified
                         ? new PartitionedManifestMeta(specifiedSnapshotId, specifiedManifestEntries)
                         : null;
+        FileStore fileStore = buildFileStore(hasPk, partitioned);
         FileStoreSource source =
                 new FileStoreSource(
                         fileStore,
@@ -93,6 +93,7 @@ public class FileStoreSourceTest {
                         true,
                         Duration.ofSeconds(1).toMillis(),
                         true,
+                        false,
                         null,
                         null,
                         null,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreImpl.java
@@ -21,9 +21,6 @@ package org.apache.flink.table.store.file;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
-import org.apache.flink.table.runtime.generated.RecordComparator;
-import org.apache.flink.table.store.codegen.CodeGenUtils;
 import org.apache.flink.table.store.file.manifest.ManifestFile;
 import org.apache.flink.table.store.file.manifest.ManifestList;
 import org.apache.flink.table.store.file.mergetree.compact.DeduplicateMergeFunction;
@@ -36,13 +33,16 @@ import org.apache.flink.table.store.file.operation.FileStoreReadImpl;
 import org.apache.flink.table.store.file.operation.FileStoreScanImpl;
 import org.apache.flink.table.store.file.operation.FileStoreWriteImpl;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
+import org.apache.flink.table.store.file.utils.KeyComparatorSupplier;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 
 import javax.annotation.Nullable;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /** File store implementation. */
@@ -55,8 +55,8 @@ public class FileStoreImpl implements FileStore {
     private final RowType partitionType;
     private final RowType keyType;
     private final RowType valueType;
+    private final Supplier<Comparator<RowData>> keyComparatorSupplier;
     @Nullable private final MergeFunction mergeFunction;
-    private final GeneratedRecordComparator genRecordComparator;
 
     public FileStoreImpl(
             long schemaId,
@@ -75,9 +75,7 @@ public class FileStoreImpl implements FileStore {
         this.keyType = keyType;
         this.valueType = valueType;
         this.mergeFunction = mergeFunction;
-        this.genRecordComparator =
-                CodeGenUtils.generateRecordComparator(
-                        new TableConfig(), keyType.getChildren(), "KeyComparator");
+        this.keyComparatorSupplier = new KeyComparatorSupplier(keyType);
     }
 
     public FileStorePathFactory pathFactory() {
@@ -99,17 +97,13 @@ public class FileStoreImpl implements FileStore {
         return new ManifestList.Factory(partitionType, options.manifestFormat(), pathFactory());
     }
 
-    private RecordComparator newKeyComparator() {
-        return genRecordComparator.newInstance(Thread.currentThread().getContextClassLoader());
-    }
-
     @Override
     public FileStoreWriteImpl newWrite() {
         return new FileStoreWriteImpl(
                 writeMode,
                 keyType,
                 valueType,
-                this::newKeyComparator,
+                keyComparatorSupplier,
                 mergeFunction,
                 options.fileFormat(),
                 pathFactory(),
@@ -123,7 +117,7 @@ public class FileStoreImpl implements FileStore {
                 writeMode,
                 keyType,
                 valueType,
-                newKeyComparator(),
+                keyComparatorSupplier.get(),
                 mergeFunction,
                 options.fileFormat(),
                 pathFactory());

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreImpl.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.store.file;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.file.manifest.ManifestFile;
 import org.apache.flink.table.store.file.manifest.ManifestList;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/Increment.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/Increment.java
@@ -35,6 +35,7 @@ import java.util.Objects;
  */
 public class Increment {
 
+    private static final List<DataFileMeta> EMPTY_NEW_FILES = Collections.emptyList();
     private static final List<DataFileMeta> EMPTY_COMPACT_BEFORE = Collections.emptyList();
     private static final List<DataFileMeta> EMPTY_COMPACT_AFTER = Collections.emptyList();
 
@@ -46,6 +47,11 @@ public class Increment {
 
     public static Increment forAppend(List<DataFileMeta> newFiles) {
         return new Increment(newFiles, EMPTY_COMPACT_BEFORE, EMPTY_COMPACT_AFTER);
+    }
+
+    public static Increment forCompact(
+            List<DataFileMeta> compactBefore, List<DataFileMeta> compactAfter) {
+        return new Increment(EMPTY_NEW_FILES, compactBefore, compactAfter);
     }
 
     public Increment(

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeWriter.java
@@ -112,7 +112,8 @@ public class MergeTreeWriter implements RecordWriter {
         }
     }
 
-    private void flush() throws Exception {
+    @Override
+    public void flush() throws Exception {
         if (memTable.size() > 0) {
             if (levels.numberOfSortedRuns() > numSortedRunStopTrigger) {
                 // stop writing, wait for compaction finished

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/CompactStrategy.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/CompactStrategy.java
@@ -18,13 +18,11 @@
 
 package org.apache.flink.table.store.file.mergetree.compact;
 
-import org.apache.flink.table.store.file.mergetree.LevelSortedRun;
-
 import java.util.List;
 import java.util.Optional;
 
 /** Compact strategy to decide which files to select for compaction. */
-public interface CompactStrategy {
+public interface CompactStrategy<T> {
 
     /**
      * Pick compaction unit from runs.
@@ -35,5 +33,5 @@ public interface CompactStrategy {
      *   <li>compaction is sequential from small level to large level.
      * </ul>
      */
-    Optional<CompactUnit> pick(int numLevels, List<LevelSortedRun> runs);
+    Optional<CompactUnit> pick(int numLevels, List<T> runs);
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/CompactUnit.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/CompactUnit.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /** A files unit for compaction. */
-interface CompactUnit {
+public interface CompactUnit {
 
     int outputLevel();
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/ManualTriggeredCompaction.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/ManualTriggeredCompaction.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.mergetree.compact;
+
+import org.apache.flink.table.store.file.data.DataFileMeta;
+import org.apache.flink.table.store.file.mergetree.SortedRun;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * This strategy aims to eliminate the intersected key range in different sorted runs, and merge
+ * small files with the best effort. The pick candidate based on sorted runs which have been
+ * partitioned by {@link IntervalPartition} algorithm.
+ */
+public class ManualTriggeredCompaction implements CompactStrategy<SortedRun> {
+
+    private final long targetFileSize;
+
+    public ManualTriggeredCompaction(long targetFileSize) {
+        this.targetFileSize = targetFileSize;
+    }
+
+    @Override
+    public Optional<CompactUnit> pick(int numLevels, List<SortedRun> runs) {
+        if (runs.size() == 1) {
+            // for section which does not contain overlapped keys, try to merge small files
+            List<DataFileMeta> files = runs.get(0).files();
+            long ctr = files.stream().filter(file -> file.fileSize() < targetFileSize).count();
+            if (ctr > 1) {
+                return Optional.of(CompactUnit.fromFiles(numLevels - 1, files));
+            }
+        } else if (runs.size() > 1) {
+            // for section which contains overlapped keys, pick them all
+            return Optional.of(
+                    CompactUnit.fromFiles(
+                            numLevels - 1,
+                            runs.stream()
+                                    .map(SortedRun::files)
+                                    .flatMap(Collection::stream)
+                                    .collect(Collectors.toList())));
+        }
+
+        return Optional.empty();
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/UniversalCompaction.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/UniversalCompaction.java
@@ -35,7 +35,7 @@ import java.util.Optional;
  * <p>See RocksDb Universal-Compaction:
  * https://github.com/facebook/rocksdb/wiki/Universal-Compaction.
  */
-public class UniversalCompaction implements CompactStrategy {
+public class UniversalCompaction implements CompactStrategy<LevelSortedRun> {
 
     private static final Logger LOG = LoggerFactory.getLogger(UniversalCompaction.class);
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreWrite.java
@@ -19,8 +19,10 @@
 package org.apache.flink.table.store.file.operation;
 
 import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.store.file.mergetree.compact.CompactUnit;
 import org.apache.flink.table.store.file.writer.RecordWriter;
 
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 
 /** Write operation which provides {@link RecordWriter} creation. */
@@ -32,4 +34,7 @@ public interface FileStoreWrite {
     /** Create an empty {@link RecordWriter} from partition and bucket. */
     RecordWriter createEmptyWriter(
             BinaryRowData partition, int bucket, ExecutorService compactExecutor);
+
+    /** Create a compact {@link RecordWriter} from partition, bucket and compact units. */
+    RecordWriter createCompactWriter(BinaryRowData partition, int bucket, List<CompactUnit> units);
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/FileStorePathFactory.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/FileStorePathFactory.java
@@ -61,18 +61,23 @@ public class FileStorePathFactory {
         this.root = root;
         this.uuid = UUID.randomUUID().toString();
 
-        String[] partitionColumns = partitionType.getFieldNames().toArray(new String[0]);
-        this.partitionComputer =
-                new RowDataPartitionComputer(
-                        defaultPartValue,
-                        partitionColumns,
-                        partitionType.getFields().stream()
-                                .map(f -> LogicalTypeDataTypeConverter.toDataType(f.getType()))
-                                .toArray(DataType[]::new),
-                        partitionColumns);
+        this.partitionComputer = getPartitionComputer(partitionType, defaultPartValue);
 
         this.manifestFileCount = new AtomicInteger(0);
         this.manifestListCount = new AtomicInteger(0);
+    }
+
+    @VisibleForTesting
+    public static RowDataPartitionComputer getPartitionComputer(
+            RowType partitionType, String defaultPartValue) {
+        String[] partitionColumns = partitionType.getFieldNames().toArray(new String[0]);
+        return new RowDataPartitionComputer(
+                defaultPartValue,
+                partitionColumns,
+                partitionType.getFields().stream()
+                        .map(f -> LogicalTypeDataTypeConverter.toDataType(f.getType()))
+                        .toArray(DataType[]::new),
+                partitionColumns);
     }
 
     public Path newManifestFile() {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/KeyComparatorSupplier.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/KeyComparatorSupplier.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.utils;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
+import org.apache.flink.table.runtime.generated.RecordComparator;
+import org.apache.flink.table.store.codegen.CodeGenUtils;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.function.SerializableSupplier;
+
+import java.util.Comparator;
+import java.util.function.Supplier;
+
+/** A {@link Supplier} that returns the comparator for the file store key. */
+public class KeyComparatorSupplier implements SerializableSupplier<Comparator<RowData>> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final GeneratedRecordComparator genRecordComparator;
+
+    public KeyComparatorSupplier(RowType keyType) {
+        genRecordComparator =
+                CodeGenUtils.generateRecordComparator(
+                        new TableConfig(), keyType.getChildren(), "KeyComparator");
+    }
+
+    @Override
+    public RecordComparator get() {
+        return genRecordComparator.newInstance(Thread.currentThread().getContextClassLoader());
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/writer/AppendOnlyWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/writer/AppendOnlyWriter.java
@@ -106,6 +106,9 @@ public class AppendOnlyWriter implements RecordWriter {
     }
 
     @Override
+    public void flush() throws Exception {}
+
+    @Override
     public List<DataFileMeta> close() throws Exception {
         sync();
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/writer/CompactWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/writer/CompactWriter.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.writer;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.file.ValueKind;
+import org.apache.flink.table.store.file.data.DataFileMeta;
+import org.apache.flink.table.store.file.data.DataFileWriter;
+import org.apache.flink.table.store.file.mergetree.Increment;
+import org.apache.flink.table.store.file.mergetree.compact.CompactManager;
+import org.apache.flink.table.store.file.mergetree.compact.CompactUnit;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * A {@link RecordWriter} implementation that only perform compaction on existing records and does
+ * not generate new records.
+ */
+public class CompactWriter implements RecordWriter {
+
+    private final List<CompactUnit> units;
+    private final ExecutorService compactExecutor;
+    private final CompactManager compactor;
+    private final DataFileWriter dataFileWriter;
+
+    public CompactWriter(
+            List<CompactUnit> units,
+            Comparator<RowData> keyComparator,
+            long targetFileSize,
+            CompactManager.Rewriter rewriter,
+            DataFileWriter dataFileWriter) {
+        this.units = new ArrayList<>(units);
+        this.compactExecutor =
+                Executors.newSingleThreadScheduledExecutor(
+                        new ExecutorThreadFactory("compaction-thread"));
+        this.compactor =
+                new CompactManager(compactExecutor, keyComparator, targetFileSize, rewriter);
+        this.dataFileWriter = dataFileWriter;
+    }
+
+    @Override
+    public void flush() {
+        units.forEach(unit -> compactor.submitCompaction(unit, true));
+    }
+
+    @Override
+    public Increment prepareCommit() throws IOException, InterruptedException {
+        List<DataFileMeta> compactBefore = new ArrayList<>();
+        List<DataFileMeta> compactAfter = new ArrayList<>();
+        while (!compactor.isCompactionFinished()) {
+            try {
+                compactor
+                        .finishCompaction()
+                        .ifPresent(
+                                results ->
+                                        results.forEach(
+                                                result -> {
+                                                    compactBefore.addAll(result.before());
+                                                    compactAfter.addAll(result.after());
+                                                }));
+            } catch (ExecutionException e) {
+                throw new IOException(e.getCause());
+            }
+        }
+        return Increment.forCompact(compactBefore, compactAfter);
+    }
+
+    @Override
+    public List<DataFileMeta> close() throws Exception {
+        compactExecutor.shutdownNow();
+        List<DataFileMeta> delete = new ArrayList<>();
+        try {
+            compactor
+                    .finishCompaction()
+                    .ifPresent(results -> results.forEach(result -> delete.addAll(result.after())));
+        } catch (ExecutionException e) {
+            throw new IOException(e.getCause());
+        }
+        // delete generated compact-after files which have no chance to be committed
+        for (DataFileMeta file : delete) {
+            dataFileWriter.delete(file);
+        }
+        return delete;
+    }
+
+    @Override
+    public void write(ValueKind valueKind, RowData key, RowData value) throws Exception {}
+
+    @Override
+    public void sync() throws Exception {}
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/writer/RecordWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/writer/RecordWriter.java
@@ -48,6 +48,9 @@ public interface RecordWriter {
      */
     void sync() throws Exception;
 
+    /** Called when mem table is full or end of input to flush all pending data to disk. */
+    void flush() throws Exception;
+
     /**
      * Close this writer, the call will delete newly generated but not committed files.
      *

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/KeyValueSerializerTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/KeyValueSerializerTest.java
@@ -32,7 +32,7 @@ public class KeyValueSerializerTest extends ObjectSerializerTestBase<KeyValue> {
     @Override
     protected ObjectSerializer<KeyValue> serializer() {
         return new KeyValueSerializer(
-                TestKeyValueGenerator.KEY_TYPE, TestKeyValueGenerator.ROW_TYPE);
+                TestKeyValueGenerator.KEY_TYPE, TestKeyValueGenerator.DEFAULT_ROW_TYPE);
     }
 
     @Override
@@ -47,7 +47,7 @@ public class KeyValueSerializerTest extends ObjectSerializerTestBase<KeyValue> {
                                 expected,
                                 actual,
                                 TestKeyValueGenerator.KEY_SERIALIZER,
-                                TestKeyValueGenerator.ROW_SERIALIZER))
+                                TestKeyValueGenerator.DEFAULT_ROW_SERIALIZER))
                 .isTrue();
     }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestKeyValueGenerator.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestKeyValueGenerator.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.store.file;
 
 import org.apache.flink.table.data.GenericArrayData;
 import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.runtime.generated.RecordComparator;
@@ -34,10 +35,16 @@ import org.apache.flink.table.types.logical.VarCharType;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.table.store.file.TestKeyValueGenerator.GeneratorMode.MULTI_PARTITIONED;
+import static org.apache.flink.table.store.file.TestKeyValueGenerator.GeneratorMode.NON_PARTITIONED;
+import static org.apache.flink.table.store.file.TestKeyValueGenerator.GeneratorMode.SINGLE_PARTITIONED;
 
 /** Random {@link KeyValue} generator. */
 public class TestKeyValueGenerator {
@@ -53,7 +60,7 @@ public class TestKeyValueGenerator {
     // * itemId: long, any value
     // * price & amount: int[], [1 ~ 100, 1 ~ 10]
     // * comment: string, length from 10 to 1000
-    public static final RowType ROW_TYPE =
+    public static final RowType DEFAULT_ROW_TYPE =
             RowType.of(
                     new LogicalType[] {
                         new VarCharType(false, 8),
@@ -67,18 +74,22 @@ public class TestKeyValueGenerator {
                     new String[] {
                         "dt", "hr", "shopId", "orderId", "itemId", "priceAmount", "comment"
                     });
-    public static final RowType PARTITION_TYPE =
+    public static final RowType DEFAULT_PART_TYPE =
             RowType.of(
                     new LogicalType[] {new VarCharType(false, 8), new IntType(false)},
                     new String[] {"dt", "hr"});
+    public static final RowType SINGLE_PARTITIONED_ROW_TYPE = singlePartType(DEFAULT_ROW_TYPE);
+    public static final RowType SINGLE_PARTITIONED_PART_TYPE = singlePartType(DEFAULT_PART_TYPE);
+    public static final RowType NON_PARTITIONED_ROW_TYPE =
+            nonPartType(DEFAULT_PART_TYPE.getFieldCount());
+    public static final RowType NON_PARTITIONED_PART_TYPE = RowType.of();
     public static final RowType KEY_TYPE =
             RowType.of(
                     new LogicalType[] {new IntType(false), new BigIntType(false)},
                     new String[] {"key_shopId", "key_orderId"});
 
-    public static final RowDataSerializer ROW_SERIALIZER = new RowDataSerializer(ROW_TYPE);
-    private static final RowDataSerializer PARTITION_SERIALIZER =
-            new RowDataSerializer(PARTITION_TYPE);
+    public static final RowDataSerializer DEFAULT_ROW_SERIALIZER =
+            new RowDataSerializer(DEFAULT_ROW_TYPE);
     public static final RowDataSerializer KEY_SERIALIZER = new RowDataSerializer(KEY_TYPE);
     public static final RecordComparator KEY_COMPARATOR =
             (a, b) -> {
@@ -89,6 +100,7 @@ public class TestKeyValueGenerator {
                 return Long.compare(a.getLong(1), b.getLong(1));
             };
 
+    private final GeneratorMode mode;
     private final Random random;
 
     private final List<Order> addedOrders;
@@ -96,13 +108,42 @@ public class TestKeyValueGenerator {
 
     private long sequenceNumber;
 
+    private final RowDataSerializer rowSerializer;
+    private final RowDataSerializer partitionSerializer;
+
     public TestKeyValueGenerator() {
+        this(MULTI_PARTITIONED);
+    }
+
+    public TestKeyValueGenerator(GeneratorMode mode) {
+        this.mode = mode;
         this.random = new Random();
 
         this.addedOrders = new ArrayList<>();
         this.deletedOrders = new ArrayList<>();
 
         this.sequenceNumber = 0;
+
+        RowType rowType;
+        RowType partitionType;
+        switch (mode) {
+            case NON_PARTITIONED:
+                rowType = NON_PARTITIONED_ROW_TYPE;
+                partitionType = NON_PARTITIONED_PART_TYPE;
+                break;
+            case SINGLE_PARTITIONED:
+                rowType = SINGLE_PARTITIONED_ROW_TYPE;
+                partitionType = SINGLE_PARTITIONED_PART_TYPE;
+                break;
+            case MULTI_PARTITIONED:
+                rowType = DEFAULT_ROW_TYPE;
+                partitionType = DEFAULT_PART_TYPE;
+                break;
+            default:
+                throw new UnsupportedOperationException("Unsupported generator mode: " + mode);
+        }
+        rowSerializer = new RowDataSerializer(rowType);
+        partitionSerializer = new RowDataSerializer(partitionType);
     }
 
     public KeyValue next() {
@@ -140,31 +181,65 @@ public class TestKeyValueGenerator {
                                 .copy(),
                         sequenceNumber++,
                         kind,
-                        ROW_SERIALIZER
-                                .toBinaryRow(
-                                        GenericRowData.of(
-                                                StringData.fromString(order.dt),
-                                                order.hr,
-                                                order.shopId,
-                                                order.orderId,
-                                                order.itemId,
-                                                order.priceAmount == null
-                                                        ? null
-                                                        : new GenericArrayData(order.priceAmount),
-                                                StringData.fromString(order.comment)))
-                                .copy());
+                        rowSerializer.toBinaryRow(convertToRow(order)).copy());
+    }
+
+    private RowData convertToRow(Order order) {
+        List<Object> values =
+                new ArrayList<>(
+                        Arrays.asList(
+                                order.shopId,
+                                order.orderId,
+                                order.itemId,
+                                order.priceAmount == null
+                                        ? null
+                                        : new GenericArrayData(order.priceAmount),
+                                StringData.fromString(order.comment)));
+
+        if (mode == MULTI_PARTITIONED) {
+            values.add(0, StringData.fromString(order.dt));
+            values.add(1, order.hr);
+        } else if (mode == SINGLE_PARTITIONED) {
+            values.add(0, StringData.fromString(order.dt));
+        }
+        return GenericRowData.of(values.toArray(new Object[0]));
     }
 
     public BinaryRowData getPartition(KeyValue kv) {
-        return PARTITION_SERIALIZER
-                .toBinaryRow(GenericRowData.of(kv.value().getString(0), kv.value().getInt(1)))
-                .copy();
+        Object[] values;
+        if (mode == MULTI_PARTITIONED) {
+            values = new Object[] {kv.value().getString(0), kv.value().getInt(1)};
+        } else if (mode == SINGLE_PARTITIONED) {
+            values = new Object[] {kv.value().getString(0)};
+        } else {
+            values = new Object[0];
+        }
+        return partitionSerializer.toBinaryRow(GenericRowData.of(values)).copy();
     }
 
-    public static Map<String, String> toPartitionMap(BinaryRowData partition) {
+    public static List<String> getPrimaryKeys(GeneratorMode mode) {
+        List<String> trimmedPk =
+                KEY_TYPE.getFieldNames().stream()
+                        .map(f -> f.replaceFirst("key_", ""))
+                        .collect(Collectors.toList());
+        if (mode != NON_PARTITIONED) {
+            trimmedPk = new ArrayList<>(trimmedPk);
+            trimmedPk.addAll(
+                    mode == MULTI_PARTITIONED
+                            ? DEFAULT_PART_TYPE.getFieldNames()
+                            : SINGLE_PARTITIONED_PART_TYPE.getFieldNames());
+        }
+        return trimmedPk;
+    }
+
+    public static Map<String, String> toPartitionMap(BinaryRowData partition, GeneratorMode mode) {
         Map<String, String> map = new HashMap<>();
-        map.put("dt", partition.getString(0).toString());
-        map.put("hr", String.valueOf(partition.getInt(1)));
+        if (mode == MULTI_PARTITIONED) {
+            map.put("dt", partition.getString(0).toString());
+            map.put("hr", String.valueOf(partition.getInt(1)));
+        } else if (mode == SINGLE_PARTITIONED) {
+            map.put("dt", partition.getString(0).toString());
+        }
         return map;
     }
 
@@ -184,6 +259,17 @@ public class TestKeyValueGenerator {
         list.set(idx, list.get(list.size() - 1));
         list.remove(list.size() - 1);
         return tmp;
+    }
+
+    private static RowType nonPartType(int to) {
+        List<RowType.RowField> fields = TestKeyValueGenerator.DEFAULT_PART_TYPE.getFields();
+        return new RowType(fields.subList(2, to));
+    }
+
+    private static RowType singlePartType(RowType type) {
+        List<RowType.RowField> fields = new ArrayList<>(type.getFields());
+        fields.remove(1);
+        return new RowType(fields);
     }
 
     private class Order {
@@ -219,5 +305,12 @@ public class TestKeyValueGenerator {
                             : new int[] {random.nextInt(100) + 1, random.nextInt(100) + 1};
             comment = random.nextInt(10) == 0 ? null : randomString(random.nextInt(1001 - 10) + 10);
         }
+    }
+
+    /** Generator mode for {@link TestKeyValueGenerator}. */
+    public enum GeneratorMode {
+        NON_PARTITIONED,
+        SINGLE_PARTITIONED,
+        MULTI_PARTITIONED
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileTest.java
@@ -80,7 +80,7 @@ public class DataFileTest {
 
         checkRollingFiles(
                 TestKeyValueGenerator.KEY_TYPE,
-                TestKeyValueGenerator.ROW_TYPE,
+                TestKeyValueGenerator.DEFAULT_ROW_TYPE,
                 data.meta,
                 actualMetas,
                 writer.suggestedFileSize());
@@ -90,7 +90,7 @@ public class DataFileTest {
                 data,
                 actualMetas,
                 TestKeyValueGenerator.KEY_SERIALIZER,
-                TestKeyValueGenerator.ROW_SERIALIZER,
+                TestKeyValueGenerator.DEFAULT_ROW_SERIALIZER,
                 serializer,
                 reader,
                 kv -> kv);
@@ -136,7 +136,7 @@ public class DataFileTest {
                 data,
                 actualMetas,
                 projectedKeySerializer,
-                TestKeyValueGenerator.ROW_SERIALIZER,
+                TestKeyValueGenerator.DEFAULT_ROW_SERIALIZER,
                 serializer,
                 fileReader,
                 kv ->
@@ -202,7 +202,7 @@ public class DataFileTest {
         int suggestedFileSize = ThreadLocalRandom.current().nextInt(8192) + 1024;
         return new DataFileWriter.Factory(
                         TestKeyValueGenerator.KEY_TYPE,
-                        TestKeyValueGenerator.ROW_TYPE,
+                        TestKeyValueGenerator.DEFAULT_ROW_TYPE,
                         // normal format will buffer changes in memory and we can't determine
                         // if the written file size is really larger than suggested, so we use a
                         // special format which flushes for every added element
@@ -218,7 +218,7 @@ public class DataFileTest {
         DataFileReader.Factory factory =
                 new DataFileReader.Factory(
                         TestKeyValueGenerator.KEY_TYPE,
-                        TestKeyValueGenerator.ROW_TYPE,
+                        TestKeyValueGenerator.DEFAULT_ROW_TYPE,
                         new FlushingFileFormat(format),
                         pathFactory);
         if (keyProjection != null) {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileTestDataGenerator.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileTestDataGenerator.java
@@ -102,7 +102,7 @@ public class DataFileTestDataGenerator {
         FieldStatsCollector keyStatsCollector =
                 new FieldStatsCollector(TestKeyValueGenerator.KEY_TYPE);
         FieldStatsCollector valueStatsCollector =
-                new FieldStatsCollector(TestKeyValueGenerator.ROW_TYPE);
+                new FieldStatsCollector(TestKeyValueGenerator.DEFAULT_ROW_TYPE);
         long totalSize = 0;
         BinaryRowData minKey = null;
         BinaryRowData maxKey = null;

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestFileTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestFileTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.store.file.manifest;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.table.store.file.TestKeyValueGenerator;
 import org.apache.flink.table.store.file.format.FileFormat;
 import org.apache.flink.table.store.file.stats.StatsTestUtils;
 import org.apache.flink.table.store.file.utils.FailingAtomicRenameFileSystem;
@@ -36,6 +35,7 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.table.store.file.TestKeyValueGenerator.DEFAULT_PART_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link ManifestFile}. */
@@ -93,11 +93,9 @@ public class ManifestFileTest {
 
     private ManifestFile createManifestFile(String path) {
         FileStorePathFactory pathFactory =
-                new FileStorePathFactory(
-                        new Path(path), TestKeyValueGenerator.PARTITION_TYPE, "default");
+                new FileStorePathFactory(new Path(path), DEFAULT_PART_TYPE, "default");
         int suggestedFileSize = ThreadLocalRandom.current().nextInt(8192) + 1024;
-        return new ManifestFile.Factory(
-                        TestKeyValueGenerator.PARTITION_TYPE, avro, pathFactory, suggestedFileSize)
+        return new ManifestFile.Factory(DEFAULT_PART_TYPE, avro, pathFactory, suggestedFileSize)
                 .create();
     }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestListTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestListTest.java
@@ -92,8 +92,8 @@ public class ManifestListTest {
     private ManifestList createManifestList(String path) {
         FileStorePathFactory pathFactory =
                 new FileStorePathFactory(
-                        new Path(path), TestKeyValueGenerator.PARTITION_TYPE, "default");
-        return new ManifestList.Factory(TestKeyValueGenerator.PARTITION_TYPE, avro, pathFactory)
+                        new Path(path), TestKeyValueGenerator.DEFAULT_PART_TYPE, "default");
+        return new ManifestList.Factory(TestKeyValueGenerator.DEFAULT_PART_TYPE, avro, pathFactory)
                 .create();
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestTestDataGenerator.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestTestDataGenerator.java
@@ -83,7 +83,7 @@ public class ManifestTestDataGenerator {
                 !entries.isEmpty(), "Manifest entries are empty. Invalid test data.");
 
         FieldStatsCollector collector =
-                new FieldStatsCollector(TestKeyValueGenerator.PARTITION_TYPE);
+                new FieldStatsCollector(TestKeyValueGenerator.DEFAULT_PART_TYPE);
 
         long numAddedFiles = 0;
         long numDeletedFiles = 0;

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/CompactManagerTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/CompactManagerTest.java
@@ -203,7 +203,7 @@ public class CompactManagerTest {
         assertThat(outputs).isEqualTo(expected);
     }
 
-    private static DataFileMeta newFile(int level, int minKey, int maxKey, long maxSequence) {
+    public static DataFileMeta newFile(int level, int minKey, int maxKey, long maxSequence) {
         return new DataFileMeta(
                 "",
                 maxKey - minKey + 1,

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/ManualTriggeredCompactionTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/ManualTriggeredCompactionTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.mergetree.compact;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.file.data.DataFileMeta;
+import org.apache.flink.table.store.file.mergetree.SortedRun;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.table.store.file.mergetree.compact.CompactManagerTest.newFile;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link ManualTriggeredCompaction}. */
+public class ManualTriggeredCompactionTest {
+
+    private final Comparator<RowData> comparator = Comparator.comparingInt(o -> o.getInt(0));
+    private final ManualTriggeredCompaction strategy = new ManualTriggeredCompaction(10);
+    private final int numLevels = 3;
+
+    @Test
+    public void testPickSmall() {
+        assertThat(
+                        strategy.pick(
+                                numLevels,
+                                generateNoOverlap(new int[] {0}, new int[] {1}, new int[] {2})))
+                .isEmpty();
+
+        assertThat(
+                        strategy.pick(
+                                numLevels,
+                                generateNoOverlap(
+                                        new int[] {0, 0}, new int[] {1, 5}, new int[] {2, 30})))
+                .isEmpty();
+
+        List<SortedRun> section =
+                generateNoOverlap(new int[] {0, 0, 1}, new int[] {1, 5, 32}, new int[] {2, 30, 36});
+        assertCompact(section);
+    }
+
+    @Test
+    public void testPickOverlapped() {
+        List<SortedRun> section =
+                generateOverlap(
+                        new int[][] {new int[] {0, 1, 20}, new int[] {0, 30, 50}},
+                        new int[][] {new int[] {0, 16, 27}},
+                        new int[][] {new int[] {1, 45, 47}, new int[] {2, 52, 60}});
+        assertCompact(section);
+    }
+
+    private void assertCompact(List<SortedRun> section) {
+        Optional<CompactUnit> actual = strategy.pick(numLevels, section);
+        assertThat(actual).isPresent();
+        assertThat(actual.get().outputLevel()).isEqualTo(numLevels - 1);
+        assertThat(actual.get().files())
+                .containsExactlyInAnyOrderElementsOf(
+                        section.stream()
+                                .map(SortedRun::files)
+                                .flatMap(Collection::stream)
+                                .collect(Collectors.toList()));
+    }
+
+    private List<SortedRun> generateNoOverlap(int[] levels, int[] min, int[] max) {
+        if (levels.length == 1) {
+            return Collections.singletonList(
+                    SortedRun.fromSingle(newFile(levels[0], min[0], max[0], max[0])));
+        }
+        List<DataFileMeta> files = new ArrayList<>();
+        for (int i = 0; i < levels.length; i++) {
+            files.add(newFile(levels[i], min[i], max[i], max[i]));
+        }
+        return Collections.singletonList(SortedRun.fromUnsorted(files, comparator));
+    }
+
+    private List<SortedRun> generateOverlap(int[][]... sequences) {
+        List<SortedRun> runs = new ArrayList<>();
+        for (int[][] sequence : sequences) {
+            List<DataFileMeta> files = new ArrayList<>();
+            for (int[] tuple : sequence) {
+                files.add(newFile(tuple[0], tuple[1], tuple[2], tuple[2]));
+            }
+            runs.add(SortedRun.fromUnsorted(files, comparator));
+        }
+        return runs;
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreCommitTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreCommitTest.java
@@ -276,9 +276,9 @@ public class FileStoreCommitTest {
                 "avro",
                 root,
                 numBucket,
-                TestKeyValueGenerator.PARTITION_TYPE,
+                TestKeyValueGenerator.DEFAULT_PART_TYPE,
                 TestKeyValueGenerator.KEY_TYPE,
-                TestKeyValueGenerator.ROW_TYPE,
+                TestKeyValueGenerator.DEFAULT_ROW_TYPE,
                 new DeduplicateMergeFunction());
     }
 
@@ -310,7 +310,10 @@ public class FileStoreCommitTest {
 
         LOG.debug("========== Beginning of " + name + " ==========");
         for (KeyValue kv : supplier.get()) {
-            LOG.debug(kv.toString(TestKeyValueGenerator.KEY_TYPE, TestKeyValueGenerator.ROW_TYPE));
+            LOG.debug(
+                    kv.toString(
+                            TestKeyValueGenerator.KEY_TYPE,
+                            TestKeyValueGenerator.DEFAULT_ROW_TYPE));
         }
         LOG.debug("========== End of " + name + " ==========");
     }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreExpireTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreExpireTest.java
@@ -58,9 +58,9 @@ public class FileStoreExpireTest {
                         "avro",
                         tempDir.toString(),
                         1,
-                        TestKeyValueGenerator.PARTITION_TYPE,
+                        TestKeyValueGenerator.DEFAULT_PART_TYPE,
                         TestKeyValueGenerator.KEY_TYPE,
-                        TestKeyValueGenerator.ROW_TYPE,
+                        TestKeyValueGenerator.DEFAULT_ROW_TYPE,
                         new DeduplicateMergeFunction());
         pathFactory = store.pathFactory();
     }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreReadTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreReadTest.java
@@ -133,9 +133,9 @@ public class FileStoreReadTest {
         }
         TestFileStore store =
                 createStore(
-                        TestKeyValueGenerator.PARTITION_TYPE,
+                        TestKeyValueGenerator.DEFAULT_PART_TYPE,
                         TestKeyValueGenerator.KEY_TYPE,
-                        TestKeyValueGenerator.ROW_TYPE,
+                        TestKeyValueGenerator.DEFAULT_ROW_TYPE,
                         new DeduplicateMergeFunction());
 
         RowDataSerializer projectedValueSerializer =

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreScanTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreScanTest.java
@@ -65,9 +65,9 @@ public class FileStoreScanTest {
                         "avro",
                         tempDir.toString(),
                         NUM_BUCKETS,
-                        TestKeyValueGenerator.PARTITION_TYPE,
+                        TestKeyValueGenerator.DEFAULT_PART_TYPE,
                         TestKeyValueGenerator.KEY_TYPE,
-                        TestKeyValueGenerator.ROW_TYPE,
+                        TestKeyValueGenerator.DEFAULT_ROW_TYPE,
                         new DeduplicateMergeFunction());
         pathFactory = store.pathFactory();
     }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
@@ -38,6 +38,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
 
+import static org.apache.flink.table.store.file.TestKeyValueGenerator.GeneratorMode.MULTI_PARTITIONED;
+
 /** Testing {@link Thread}s to perform concurrent commits. */
 public class TestCommitThread extends Thread {
 
@@ -114,7 +116,7 @@ public class TestCommitThread extends Thread {
                 committable,
                 () ->
                         commit.overwrite(
-                                TestKeyValueGenerator.toPartitionMap(partition),
+                                TestKeyValueGenerator.toPartitionMap(partition, MULTI_PARTITIONED),
                                 committable,
                                 Collections.emptyMap()));
     }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/PartitionedManifestMetaSerializationTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/PartitionedManifestMetaSerializationTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.utils;
+
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.store.file.data.DataFileMeta;
+import org.apache.flink.table.store.file.data.DataFileTestDataGenerator;
+import org.apache.flink.util.InstantiationUtil;
+
+import org.junit.jupiter.api.RepeatedTest;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Serialization test for {@link PartitionedManifestMeta}. */
+public class PartitionedManifestMetaSerializationTest {
+
+    @RepeatedTest(10)
+    public void testJsonSerDe() throws IOException, ClassNotFoundException {
+        PartitionedManifestMeta partitionedMeta =
+                new PartitionedManifestMeta(new Random().nextLong(), genManifestEntries());
+        String serialized =
+                Base64.getEncoder()
+                        .encodeToString(InstantiationUtil.serializeObject(partitionedMeta));
+        Object deserialized =
+                InstantiationUtil.deserializeObject(
+                        Base64.getDecoder().decode(serialized),
+                        Thread.currentThread().getContextClassLoader());
+        assertThat(deserialized).isEqualTo(partitionedMeta);
+    }
+
+    private static Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> genManifestEntries() {
+        Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> manifestEntries = new HashMap<>();
+        DataFileTestDataGenerator gen =
+                DataFileTestDataGenerator.builder()
+                        .numBuckets(new Random().nextInt(16) + 1)
+                        .build();
+        IntStream.range(0, new Random().nextInt(1000))
+                .boxed()
+                .map(i -> gen.next())
+                .forEach(
+                        data ->
+                                manifestEntries
+                                        .computeIfAbsent(data.partition, entry -> new HashMap<>())
+                                        .computeIfAbsent(data.bucket, entry -> new ArrayList<>())
+                                        .add(data.meta));
+        return manifestEntries;
+    }
+}


### PR DESCRIPTION
This draft is rebased on FLINK-27558 to show how `ALTER TABLE ... COMPACT` works. After reaching a consensus, it should be closed instead of merged.