### PR TITLE
[FLINK-27629] Fix NullPointerException in NotEqual predicate

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/NotEqual.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/NotEqual.java
@@ -47,6 +47,9 @@ public class NotEqual implements Predicate {
     @Override
     public boolean test(long rowCount, FieldStats[] fieldStats) {
         FieldStats stats = fieldStats[index];
+        if (rowCount == stats.nullCount()) {
+            return false;
+        }
         return literal.compareValueTo(stats.minValue()) != 0
                 || literal.compareValueTo(stats.maxValue()) != 0;
     }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/predicate/PredicateTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/predicate/PredicateTest.java
@@ -96,6 +96,8 @@ public class PredicateTest {
         assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 6, 0)})).isEqualTo(true);
         assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(true);
         assertThat(predicate.test(1, new FieldStats[] {new FieldStats(5, 5, 0)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+                .isEqualTo(false);
     }
 
     @Test


### PR DESCRIPTION
`NotEqual` predicate will throw `NullPointerException` for a column consisting only of nulls.