### PR TITLE
[FLINK-27580] Implement filter pushdown for TableStoreHiveStorageHandler

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/TableStoreSource.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/TableStoreSource.java
@@ -39,8 +39,8 @@ import org.apache.flink.table.expressions.TypeLiteralExpression;
 import org.apache.flink.table.expressions.ValueLiteralExpression;
 import org.apache.flink.table.factories.DynamicTableFactory;
 import org.apache.flink.table.store.connector.TableStore;
-import org.apache.flink.table.store.file.predicate.And;
 import org.apache.flink.table.store.file.predicate.Predicate;
+import org.apache.flink.table.store.file.predicate.PredicateBuilder;
 import org.apache.flink.table.store.file.predicate.PredicateConverter;
 import org.apache.flink.table.store.log.LogSourceProvider;
 import org.apache.flink.table.store.log.LogStoreTableFactory;
@@ -199,8 +199,9 @@ public class TableStoreSource
                 PredicateConverter.convert(filter).ifPresent(fieldPredicates::add);
             }
         }
-        partitionPredicate = partitionPredicates.stream().reduce(And::new).orElse(null);
-        fieldPredicate = fieldPredicates.stream().reduce(And::new).orElse(null);
+        partitionPredicate =
+                partitionPredicates.isEmpty() ? null : PredicateBuilder.and(partitionPredicates);
+        fieldPredicate = fieldPredicates.isEmpty() ? null : PredicateBuilder.and(fieldPredicates);
         return Result.of(
                 filters, streaming && logStoreTableFactory != null ? filters : notAcceptedFilters);
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/And.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/And.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.store.file.predicate;
 import org.apache.flink.table.store.file.stats.FieldStats;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /** A {@link Predicate} to eval and. */
 public class And implements Predicate {
@@ -43,6 +44,17 @@ public class And implements Predicate {
     @Override
     public boolean test(long rowCount, FieldStats[] fieldStats) {
         return predicate1.test(rowCount, fieldStats) && predicate2.test(rowCount, fieldStats);
+    }
+
+    @Override
+    public Optional<Predicate> negate() {
+        Optional<Predicate> negate1 = predicate1.negate();
+        Optional<Predicate> negate2 = predicate2.negate();
+        if (negate1.isPresent() && negate2.isPresent()) {
+            return Optional.of(new Or(negate1.get(), negate2.get()));
+        } else {
+            return Optional.empty();
+        }
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/Equal.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/Equal.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.store.file.predicate;
 import org.apache.flink.table.store.file.stats.FieldStats;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -52,6 +53,11 @@ public class Equal implements Predicate {
         }
         return literal.compareValueTo(stats.minValue()) >= 0
                 && literal.compareValueTo(stats.maxValue()) <= 0;
+    }
+
+    @Override
+    public Optional<Predicate> negate() {
+        return Optional.of(new NotEqual(index, literal));
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/GreaterOrEqual.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/GreaterOrEqual.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.store.file.predicate;
 import org.apache.flink.table.store.file.stats.FieldStats;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -51,6 +52,11 @@ public class GreaterOrEqual implements Predicate {
             return false;
         }
         return literal.compareValueTo(stats.maxValue()) <= 0;
+    }
+
+    @Override
+    public Optional<Predicate> negate() {
+        return Optional.of(new LessThan(index, literal));
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/GreaterThan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/GreaterThan.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.store.file.predicate;
 import org.apache.flink.table.store.file.stats.FieldStats;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -51,6 +52,11 @@ public class GreaterThan implements Predicate {
             return false;
         }
         return literal.compareValueTo(stats.maxValue()) < 0;
+    }
+
+    @Override
+    public Optional<Predicate> negate() {
+        return Optional.of(new LessOrEqual(index, literal));
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/IsNotNull.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/IsNotNull.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.store.file.predicate;
 import org.apache.flink.table.store.file.stats.FieldStats;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /** A {@link Predicate} to eval is not null. */
 public class IsNotNull implements Predicate {
@@ -41,6 +42,11 @@ public class IsNotNull implements Predicate {
     @Override
     public boolean test(long rowCount, FieldStats[] fieldStats) {
         return fieldStats[index].nullCount() < rowCount;
+    }
+
+    @Override
+    public Optional<Predicate> negate() {
+        return Optional.of(new IsNull(index));
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/IsNull.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/IsNull.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.store.file.predicate;
 import org.apache.flink.table.store.file.stats.FieldStats;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /** A {@link Predicate} to eval is null. */
 public class IsNull implements Predicate {
@@ -41,6 +42,11 @@ public class IsNull implements Predicate {
     @Override
     public boolean test(long rowCount, FieldStats[] fieldStats) {
         return fieldStats[index].nullCount() > 0;
+    }
+
+    @Override
+    public Optional<Predicate> negate() {
+        return Optional.of(new IsNotNull(index));
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/LessOrEqual.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/LessOrEqual.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.store.file.predicate;
 import org.apache.flink.table.store.file.stats.FieldStats;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -51,6 +52,11 @@ public class LessOrEqual implements Predicate {
             return false;
         }
         return literal.compareValueTo(stats.minValue()) >= 0;
+    }
+
+    @Override
+    public Optional<Predicate> negate() {
+        return Optional.of(new GreaterThan(index, literal));
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/LessThan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/LessThan.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.store.file.predicate;
 import org.apache.flink.table.store.file.stats.FieldStats;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -51,6 +52,11 @@ public class LessThan implements Predicate {
             return false;
         }
         return literal.compareValueTo(stats.minValue()) > 0;
+    }
+
+    @Override
+    public Optional<Predicate> negate() {
+        return Optional.of(new GreaterOrEqual(index, literal));
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/NotEqual.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/NotEqual.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.store.file.predicate;
 import org.apache.flink.table.store.file.stats.FieldStats;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -52,6 +53,11 @@ public class NotEqual implements Predicate {
         }
         return literal.compareValueTo(stats.minValue()) != 0
                 || literal.compareValueTo(stats.maxValue()) != 0;
+    }
+
+    @Override
+    public Optional<Predicate> negate() {
+        return Optional.of(new Equal(index, literal));
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/Or.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/Or.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.store.file.predicate;
 import org.apache.flink.table.store.file.stats.FieldStats;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /** A {@link Predicate} to eval or. */
 public class Or implements Predicate {
@@ -43,6 +44,17 @@ public class Or implements Predicate {
     @Override
     public boolean test(long rowCount, FieldStats[] fieldStats) {
         return predicate1.test(rowCount, fieldStats) || predicate2.test(rowCount, fieldStats);
+    }
+
+    @Override
+    public Optional<Predicate> negate() {
+        Optional<Predicate> negate1 = predicate1.negate();
+        Optional<Predicate> negate2 = predicate2.negate();
+        if (negate1.isPresent() && negate2.isPresent()) {
+            return Optional.of(new And(negate1.get(), negate2.get()));
+        } else {
+            return Optional.empty();
+        }
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/Predicate.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/Predicate.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.store.file.predicate;
 import org.apache.flink.table.store.file.stats.FieldStats;
 
 import java.io.Serializable;
+import java.util.Optional;
 
 /** Predicate which returns Boolean and provides testing by stats. */
 public interface Predicate extends Serializable {
@@ -39,4 +40,7 @@ public interface Predicate extends Serializable {
      *     absolutely not possible to hit.
      */
     boolean test(long rowCount, FieldStats[] fieldStats);
+
+    /** @return the negation predicate of this predicate if possible. */
+    Optional<Predicate> negate();
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/PredicateBuilder.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/PredicateBuilder.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.predicate;
+
+import org.apache.flink.util.Preconditions;
+
+import java.util.List;
+
+/** A utility class to create {@link Predicate} object for common filter conditions. */
+public class PredicateBuilder {
+
+    public static Predicate and(List<Predicate> predicates) {
+        Preconditions.checkArgument(
+                predicates.size() > 0,
+                "There must be at least 1 inner predicate to construct an AND predicate");
+        return predicates.stream().reduce(And::new).get();
+    }
+
+    public static Predicate or(List<Predicate> predicates) {
+        Preconditions.checkArgument(
+                predicates.size() > 0,
+                "There must be at least 1 inner predicate to construct an OR predicate");
+        return predicates.stream().reduce(Or::new).get();
+    }
+
+    public static Predicate in(int idx, List<Literal> literals) {
+        Preconditions.checkArgument(
+                literals.size() > 0,
+                "There must be at least 1 literal to construct an IN predicate");
+        return literals.stream().map(l -> (Predicate) new Equal(idx, l)).reduce(Or::new).get();
+    }
+
+    public static Predicate between(
+            int idx, Literal includedLowerBound, Literal includedUpperBound) {
+        return new And(
+                new GreaterOrEqual(idx, includedLowerBound),
+                new LessOrEqual(idx, includedUpperBound));
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/StartsWith.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/StartsWith.java
@@ -21,6 +21,8 @@ package org.apache.flink.table.store.file.predicate;
 import org.apache.flink.table.data.binary.BinaryStringData;
 import org.apache.flink.table.store.file.stats.FieldStats;
 
+import java.util.Optional;
+
 /** A {@link Predicate} to evaluate {@code filter like 'abc%' or filter like 'abc_'}. */
 public class StartsWith implements Predicate {
 
@@ -52,5 +54,10 @@ public class StartsWith implements Predicate {
         BinaryStringData pattern = (BinaryStringData) patternLiteral.value();
         return (min.startsWith(pattern) || min.compareTo(pattern) <= 0)
                 && (max.startsWith(pattern) || max.compareTo(pattern) >= 0);
+    }
+
+    @Override
+    public Optional<Predicate> negate() {
+        return Optional.empty();
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/predicate/PredicateTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/predicate/PredicateTest.java
@@ -80,6 +80,9 @@ public class PredicateTest {
         assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(false);
         assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
                 .isEqualTo(false);
+
+        assertThat(predicate.negate().orElse(null))
+                .isEqualTo(new NotEqual(0, new Literal(DataTypes.INT().getLogicalType(), 5)));
     }
 
     @Test
@@ -98,6 +101,9 @@ public class PredicateTest {
         assertThat(predicate.test(1, new FieldStats[] {new FieldStats(5, 5, 0)})).isEqualTo(false);
         assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
                 .isEqualTo(false);
+
+        assertThat(predicate.negate().orElse(null))
+                .isEqualTo(new Equal(0, new Literal(DataTypes.INT().getLogicalType(), 5)));
     }
 
     @Test
@@ -120,25 +126,9 @@ public class PredicateTest {
         assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(true);
         assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
                 .isEqualTo(false);
-    }
 
-    @Test
-    public void testGreaterReverse() {
-        CallExpression expression =
-                call(BuiltInFunctionDefinitions.LESS_THAN, literal(5), field(0, DataTypes.INT()));
-        Predicate predicate = expression.accept(CONVERTER);
-
-        assertThat(predicate.test(new Object[] {4})).isEqualTo(false);
-        assertThat(predicate.test(new Object[] {5})).isEqualTo(false);
-        assertThat(predicate.test(new Object[] {6})).isEqualTo(true);
-        assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
-
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 4, 0)})).isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0)})).isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 6, 0)})).isEqualTo(true);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(true);
-        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
-                .isEqualTo(false);
+        assertThat(predicate.negate().orElse(null))
+                .isEqualTo(new LessOrEqual(0, new Literal(DataTypes.INT().getLogicalType(), 5)));
     }
 
     @Test
@@ -161,6 +151,9 @@ public class PredicateTest {
         assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(true);
         assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
                 .isEqualTo(false);
+
+        assertThat(predicate.negate().orElse(null))
+                .isEqualTo(new LessThan(0, new Literal(DataTypes.INT().getLogicalType(), 5)));
     }
 
     @Test
@@ -179,6 +172,9 @@ public class PredicateTest {
         assertThat(predicate.test(3, new FieldStats[] {new FieldStats(4, 7, 0)})).isEqualTo(true);
         assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
                 .isEqualTo(false);
+
+        assertThat(predicate.negate().orElse(null))
+                .isEqualTo(new GreaterOrEqual(0, new Literal(DataTypes.INT().getLogicalType(), 5)));
     }
 
     @Test
@@ -200,6 +196,9 @@ public class PredicateTest {
         assertThat(predicate.test(3, new FieldStats[] {new FieldStats(4, 7, 0)})).isEqualTo(true);
         assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
                 .isEqualTo(false);
+
+        assertThat(predicate.negate().orElse(null))
+                .isEqualTo(new GreaterThan(0, new Literal(DataTypes.INT().getLogicalType(), 5)));
     }
 
     @Test
@@ -216,6 +215,8 @@ public class PredicateTest {
 
         assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(false);
         assertThat(predicate.test(3, new FieldStats[] {new FieldStats(5, 7, 1)})).isEqualTo(true);
+
+        assertThat(predicate.negate().orElse(null)).isEqualTo(new IsNotNull(0));
     }
 
     @Test
@@ -234,6 +235,8 @@ public class PredicateTest {
         assertThat(predicate.test(3, new FieldStats[] {new FieldStats(5, 7, 1)})).isEqualTo(true);
         assertThat(predicate.test(3, new FieldStats[] {new FieldStats(null, null, 3)}))
                 .isEqualTo(false);
+
+        assertThat(predicate.negate().orElse(null)).isEqualTo(new IsNull(0));
     }
 
     @Test
@@ -277,6 +280,12 @@ public class PredicateTest {
                                     new FieldStats(6, 7, 0), new FieldStats(4, 6, 0)
                                 }))
                 .isEqualTo(false);
+
+        assertThat(predicate.negate().orElse(null))
+                .isEqualTo(
+                        new Or(
+                                new NotEqual(0, new Literal(DataTypes.INT().getLogicalType(), 3)),
+                                new NotEqual(1, new Literal(DataTypes.INT().getLogicalType(), 5))));
     }
 
     @Test
@@ -320,6 +329,12 @@ public class PredicateTest {
                                     new FieldStats(6, 7, 0), new FieldStats(8, 10, 0)
                                 }))
                 .isEqualTo(false);
+
+        assertThat(predicate.negate().orElse(null))
+                .isEqualTo(
+                        new And(
+                                new NotEqual(0, new Literal(DataTypes.INT().getLogicalType(), 3)),
+                                new NotEqual(1, new Literal(DataTypes.INT().getLogicalType(), 5))));
     }
 
     @MethodSource("provideLikeExpressions")

--- a/flink-table-store-hive/src/main/java/org/apache/flink/table/store/SearchArgumentToPredicateConverter.java
+++ b/flink-table-store-hive/src/main/java/org/apache/flink/table/store/SearchArgumentToPredicateConverter.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store;
+
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.store.file.predicate.And;
+import org.apache.flink.table.store.file.predicate.Equal;
+import org.apache.flink.table.store.file.predicate.GreaterOrEqual;
+import org.apache.flink.table.store.file.predicate.GreaterThan;
+import org.apache.flink.table.store.file.predicate.IsNotNull;
+import org.apache.flink.table.store.file.predicate.IsNull;
+import org.apache.flink.table.store.file.predicate.LessOrEqual;
+import org.apache.flink.table.store.file.predicate.LessThan;
+import org.apache.flink.table.store.file.predicate.Literal;
+import org.apache.flink.table.store.file.predicate.NotEqual;
+import org.apache.flink.table.store.file.predicate.Or;
+import org.apache.flink.table.store.file.predicate.Predicate;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.hadoop.hive.ql.io.sarg.ExpressionTree;
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+
+/** Converts {@link SearchArgument} to {@link Predicate} with best effort. */
+public class SearchArgumentToPredicateConverter {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(SearchArgumentToPredicateConverter.class);
+
+    private final ExpressionTree tree;
+    private final List<PredicateLeaf> leaves;
+    private final List<String> columnNames;
+    private final List<LogicalType> columnTypes;
+
+    public SearchArgumentToPredicateConverter(
+            SearchArgument sarg, List<String> columnNames, List<LogicalType> columnTypes) {
+        this.tree = sarg.getExpression();
+        this.leaves = sarg.getLeaves();
+        this.columnNames = columnNames;
+        this.columnTypes = columnTypes;
+    }
+
+    public Optional<Predicate> convert() {
+        try {
+            return Optional.of(convertTree(tree));
+        } catch (Throwable t) {
+            LOG.warn("Failed to convert predicate. Filter will be processed by Hive instead.", t);
+            return Optional.empty();
+        }
+    }
+
+    private Predicate convertTree(ExpressionTree tree) {
+        List<ExpressionTree> children = tree.getChildren();
+        switch (tree.getOperator()) {
+            case OR:
+                return children.stream().map(this::convertTree).reduce(Or::new).get();
+            case AND:
+                return children.stream().map(this::convertTree).reduce(And::new).get();
+            case NOT:
+                return convertNotTree(children.get(0));
+            case LEAF:
+                return convertLeaf(leaves.get(tree.getLeaf()));
+            default:
+                throw new UnsupportedOperationException(
+                        "Unsupported operator " + tree.getOperator());
+        }
+    }
+
+    private Predicate convertNotTree(ExpressionTree tree) {
+        List<ExpressionTree> children = tree.getChildren();
+        switch (tree.getOperator()) {
+            case OR:
+                return children.stream().map(this::convertNotTree).reduce(And::new).get();
+            case AND:
+                return children.stream().map(this::convertNotTree).reduce(Or::new).get();
+            case NOT:
+                return convertTree(children.get(0));
+            case LEAF:
+                return convertNotLeaf(leaves.get(tree.getLeaf()));
+            default:
+                throw new UnsupportedOperationException(
+                        "Unsupported operator " + tree.getOperator());
+        }
+    }
+
+    private Predicate convertLeaf(PredicateLeaf leaf) {
+        String columnName = leaf.getColumnName();
+        int idx = columnNames.indexOf(columnName);
+        Preconditions.checkArgument(idx >= 0, "Column " + columnName + " not found.");
+        LogicalType columnType = columnTypes.get(idx);
+        switch (leaf.getOperator()) {
+            case EQUALS:
+                return new Equal(idx, toLiteral(columnType, leaf.getLiteral()));
+            case LESS_THAN:
+                return new LessThan(idx, toLiteral(columnType, leaf.getLiteral()));
+            case LESS_THAN_EQUALS:
+                return new LessOrEqual(idx, toLiteral(columnType, leaf.getLiteral()));
+            case IN:
+                return leaf.getLiteralList().stream()
+                        .map(o -> (Predicate) new Equal(idx, toLiteral(columnType, o)))
+                        .reduce(Or::new)
+                        .get();
+            case BETWEEN:
+                List<Object> literalList = leaf.getLiteralList();
+                return new And(
+                        new GreaterOrEqual(idx, toLiteral(columnType, literalList.get(0))),
+                        new LessOrEqual(idx, toLiteral(columnType, literalList.get(1))));
+            case IS_NULL:
+                return new IsNull(idx);
+            default:
+                throw new UnsupportedOperationException(
+                        "Unsupported operator " + tree.getOperator());
+        }
+    }
+
+    private Predicate convertNotLeaf(PredicateLeaf leaf) {
+        String columnName = leaf.getColumnName();
+        int idx = columnNames.indexOf(columnName);
+        Preconditions.checkArgument(idx >= 0, "Column " + columnName + " not found.");
+        LogicalType columnType = columnTypes.get(idx);
+        switch (leaf.getOperator()) {
+            case EQUALS:
+                return new NotEqual(idx, toLiteral(columnType, leaf.getLiteral()));
+            case LESS_THAN:
+                return new GreaterOrEqual(idx, toLiteral(columnType, leaf.getLiteral()));
+            case LESS_THAN_EQUALS:
+                return new GreaterThan(idx, toLiteral(columnType, leaf.getLiteral()));
+            case IN:
+                return leaf.getLiteralList().stream()
+                        .map(o -> (Predicate) new NotEqual(idx, toLiteral(columnType, o)))
+                        .reduce(And::new)
+                        .get();
+            case BETWEEN:
+                List<Object> literalList = leaf.getLiteralList();
+                return new Or(
+                        new LessThan(idx, toLiteral(columnType, literalList.get(0))),
+                        new GreaterThan(idx, toLiteral(columnType, literalList.get(1))));
+            case IS_NULL:
+                return new IsNotNull(idx);
+            default:
+                throw new UnsupportedOperationException(
+                        "Unsupported operator " + tree.getOperator());
+        }
+    }
+
+    private Literal toLiteral(LogicalType literalType, Object o) {
+        if (o == null) {
+            throw new UnsupportedOperationException("Null literals are currently unsupported");
+        }
+        switch (literalType.getTypeRoot()) {
+            case BOOLEAN:
+            case BIGINT:
+            case DOUBLE:
+                return new Literal(literalType, o);
+            case TINYINT:
+                return new Literal(literalType, ((Long) o).byteValue());
+            case SMALLINT:
+                return new Literal(literalType, ((Long) o).shortValue());
+            case INTEGER:
+                return new Literal(literalType, ((Long) o).intValue());
+            case FLOAT:
+                return new Literal(literalType, ((Double) o).floatValue());
+            case VARCHAR:
+                return new Literal(literalType, StringData.fromString(o.toString()));
+            case DATE:
+                // Hive uses `java.sql.Date.valueOf(lit.toString());` to convert a literal to Date
+                // Which uses `java.util.Date()` internally to create the object and that uses the
+                // TimeZone.getDefaultRef()
+                // To get back the expected date we have to use the LocalDate which gets rid of the
+                // TimeZone misery as it uses the year/month/day to generate the object
+                LocalDate localDate;
+                if (o instanceof Timestamp) {
+                    localDate = ((Timestamp) o).toLocalDateTime().toLocalDate();
+                } else if (o instanceof Date) {
+                    localDate = ((Date) o).toLocalDate();
+                } else {
+                    throw new UnsupportedOperationException(
+                            "Unexpected date literal of class " + o.getClass().getName());
+                }
+                LocalDate epochDay =
+                        Instant.ofEpochSecond(0).atOffset(ZoneOffset.UTC).toLocalDate();
+                int numberOfDays = (int) ChronoUnit.DAYS.between(epochDay, localDate);
+                return new Literal(literalType, numberOfDays);
+            case DECIMAL:
+                DecimalType decimalType = (DecimalType) literalType;
+                int precision = decimalType.getPrecision();
+                int scale = decimalType.getScale();
+                return new Literal(
+                        literalType,
+                        DecimalData.fromBigDecimal(
+                                ((HiveDecimalWritable) o).getHiveDecimal().bigDecimalValue(),
+                                precision,
+                                scale));
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+                return new Literal(literalType, TimestampData.fromTimestamp((Timestamp) o));
+            default:
+                throw new UnsupportedOperationException(
+                        "Unsupported predicate leaf type " + literalType.getTypeRoot().name());
+        }
+    }
+}

--- a/flink-table-store-hive/src/main/java/org/apache/flink/table/store/hive/TableStoreHiveStorageHandler.java
+++ b/flink-table-store-hive/src/main/java/org/apache/flink/table/store/hive/TableStoreHiveStorageHandler.java
@@ -26,9 +26,13 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.HiveMetaHook;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.metadata.HiveStorageHandler;
+import org.apache.hadoop.hive.ql.metadata.HiveStoragePredicateHandler;
+import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
+import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
 import org.apache.hadoop.hive.ql.plan.TableDesc;
 import org.apache.hadoop.hive.ql.security.authorization.HiveAuthorizationProvider;
 import org.apache.hadoop.hive.serde2.AbstractSerDe;
+import org.apache.hadoop.hive.serde2.Deserializer;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.OutputFormat;
@@ -40,7 +44,8 @@ import java.util.Properties;
 import java.util.UUID;
 
 /** {@link HiveStorageHandler} for table store. This is the entrance class of Hive API. */
-public class TableStoreHiveStorageHandler implements HiveStorageHandler {
+public class TableStoreHiveStorageHandler
+        implements HiveStoragePredicateHandler, HiveStorageHandler {
 
     private static final Logger LOG = LoggerFactory.getLogger(TableStoreHiveStorageHandler.class);
 
@@ -97,5 +102,14 @@ public class TableStoreHiveStorageHandler implements HiveStorageHandler {
     @Override
     public Configuration getConf() {
         return conf;
+    }
+
+    @Override
+    public DecomposedPredicate decomposePredicate(
+            JobConf jobConf, Deserializer deserializer, ExprNodeDesc predicate) {
+        DecomposedPredicate decomposed = new DecomposedPredicate();
+        decomposed.residualPredicate = (ExprNodeGenericFuncDesc) predicate;
+        decomposed.pushedPredicate = (ExprNodeGenericFuncDesc) predicate;
+        return decomposed;
     }
 }

--- a/flink-table-store-hive/src/test/java/org/apache/flink/table/store/FileStoreTestHelper.java
+++ b/flink-table-store-hive/src/test/java/org/apache/flink/table/store/FileStoreTestHelper.java
@@ -103,7 +103,7 @@ public class FileStoreTestHelper {
         writer.write(kind, key, value);
     }
 
-    public void finishWrite() throws Exception {
+    public void commit() throws Exception {
         ManifestCommittable committable = new ManifestCommittable(UUID.randomUUID().toString());
         for (Map.Entry<BinaryRowData, Map<Integer, RecordWriter>> entryWithPartition :
                 writers.entrySet()) {
@@ -117,6 +117,7 @@ public class FileStoreTestHelper {
                 writer.close();
             }
         }
+        writers.clear();
         FileStoreCommitImpl commit = store.newCommit();
         commit.commit(committable, Collections.emptyMap());
     }

--- a/flink-table-store-hive/src/test/java/org/apache/flink/table/store/SearchArgumentToPredicateConverterTest.java
+++ b/flink-table-store-hive/src/test/java/org/apache/flink/table/store/SearchArgumentToPredicateConverterTest.java
@@ -1,0 +1,350 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.store.file.predicate.And;
+import org.apache.flink.table.store.file.predicate.Equal;
+import org.apache.flink.table.store.file.predicate.GreaterOrEqual;
+import org.apache.flink.table.store.file.predicate.GreaterThan;
+import org.apache.flink.table.store.file.predicate.IsNotNull;
+import org.apache.flink.table.store.file.predicate.IsNull;
+import org.apache.flink.table.store.file.predicate.LessOrEqual;
+import org.apache.flink.table.store.file.predicate.LessThan;
+import org.apache.flink.table.store.file.predicate.Literal;
+import org.apache.flink.table.store.file.predicate.NotEqual;
+import org.apache.flink.table.store.file.predicate.Or;
+import org.apache.flink.table.store.file.predicate.Predicate;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link SearchArgumentToPredicateConverter}. */
+public class SearchArgumentToPredicateConverterTest {
+
+    @Test
+    public void testLiteral() {
+        testLiteral(PredicateLeaf.Type.BOOLEAN, false, DataTypes.BOOLEAN().getLogicalType(), false);
+        testLiteral(PredicateLeaf.Type.LONG, 10L, DataTypes.TINYINT().getLogicalType(), (byte) 10);
+        testLiteral(
+                PredicateLeaf.Type.LONG, 100L, DataTypes.SMALLINT().getLogicalType(), (short) 100);
+        testLiteral(PredicateLeaf.Type.LONG, 1000L, DataTypes.INT().getLogicalType(), 1000);
+        testLiteral(PredicateLeaf.Type.LONG, 10000L, DataTypes.BIGINT().getLogicalType(), 10000L);
+        testLiteral(PredicateLeaf.Type.FLOAT, 0.2, DataTypes.FLOAT().getLogicalType(), 0.2f);
+        testLiteral(PredicateLeaf.Type.FLOAT, 0.2, DataTypes.DOUBLE().getLogicalType(), 0.2);
+        testLiteral(
+                PredicateLeaf.Type.DECIMAL,
+                new HiveDecimalWritable(HiveDecimal.create("123456.789")),
+                DataTypes.DECIMAL(9, 3).getLogicalType(),
+                DecimalData.fromBigDecimal(new BigDecimal("123456.789"), 9, 3));
+        testLiteral(
+                PredicateLeaf.Type.DECIMAL,
+                new HiveDecimalWritable(HiveDecimal.create("123456789123456789.123456789")),
+                DataTypes.DECIMAL(27, 9).getLogicalType(),
+                DecimalData.fromBigDecimal(new BigDecimal("123456789123456789.123456789"), 27, 9));
+        testLiteral(
+                PredicateLeaf.Type.STRING,
+                "Table Store",
+                DataTypes.STRING().getLogicalType(),
+                StringData.fromString("Table Store"));
+        testLiteral(
+                PredicateLeaf.Type.DATE,
+                Date.valueOf("1971-01-11"),
+                DataTypes.DATE().getLogicalType(),
+                375);
+        testLiteral(
+                PredicateLeaf.Type.TIMESTAMP,
+                Timestamp.valueOf("2022-05-17 16:25:53"),
+                DataTypes.TIMESTAMP(3).getLogicalType(),
+                TimestampData.fromTimestamp(Timestamp.valueOf("2022-05-17 16:25:53")));
+    }
+
+    private void testLiteral(
+            PredicateLeaf.Type hiveType,
+            Object hiveLiteral,
+            LogicalType flinkType,
+            Object flinkLiteral) {
+        SearchArgument.Builder builder = SearchArgumentFactory.newBuilder();
+        SearchArgument sarg = builder.equals("a", hiveType, hiveLiteral).build();
+        SearchArgumentToPredicateConverter converter =
+                new SearchArgumentToPredicateConverter(
+                        sarg, Collections.singletonList("a"), Collections.singletonList(flinkType));
+
+        Predicate expected = new Equal(0, new Literal(flinkType, flinkLiteral));
+        Predicate actual = converter.convert().orElse(null);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private static final List<String> COLUMN_NAMES = Arrays.asList("f_int", "f_bigint", "f_double");
+    private static final List<LogicalType> COLUMN_TYPES =
+            Arrays.asList(
+                    DataTypes.INT().getLogicalType(),
+                    DataTypes.BIGINT().getLogicalType(),
+                    DataTypes.DOUBLE().getLogicalType());
+    private static final LogicalType BIGINT_TYPE = DataTypes.BIGINT().getLogicalType();
+
+    @Test
+    public void testEqual() {
+        SearchArgument.Builder builder = SearchArgumentFactory.newBuilder();
+        SearchArgument sarg = builder.equals("f_bigint", PredicateLeaf.Type.LONG, 100L).build();
+        Predicate expected = new Equal(1, new Literal(BIGINT_TYPE, 100L));
+        assertExpected(sarg, expected);
+    }
+
+    @Test
+    public void testNotEqual() {
+        SearchArgument.Builder builder = SearchArgumentFactory.newBuilder();
+        SearchArgument sarg =
+                builder.startNot().equals("f_bigint", PredicateLeaf.Type.LONG, 100L).end().build();
+        Predicate expected = new NotEqual(1, new Literal(BIGINT_TYPE, 100L));
+        assertExpected(sarg, expected);
+    }
+
+    @Test
+    public void testLessThan() {
+        SearchArgument.Builder builder = SearchArgumentFactory.newBuilder();
+        SearchArgument sarg = builder.lessThan("f_bigint", PredicateLeaf.Type.LONG, 100L).build();
+        Predicate expected = new LessThan(1, new Literal(BIGINT_TYPE, 100L));
+        assertExpected(sarg, expected);
+    }
+
+    @Test
+    public void testGreaterOrEqual() {
+        SearchArgument.Builder builder = SearchArgumentFactory.newBuilder();
+        SearchArgument sarg =
+                builder.startNot()
+                        .lessThan("f_bigint", PredicateLeaf.Type.LONG, 100L)
+                        .end()
+                        .build();
+        Predicate expected = new GreaterOrEqual(1, new Literal(BIGINT_TYPE, 100L));
+        assertExpected(sarg, expected);
+    }
+
+    @Test
+    public void testLessOrEqual() {
+        SearchArgument.Builder builder = SearchArgumentFactory.newBuilder();
+        SearchArgument sarg =
+                builder.lessThanEquals("f_bigint", PredicateLeaf.Type.LONG, 100L).build();
+        Predicate expected = new LessOrEqual(1, new Literal(BIGINT_TYPE, 100L));
+        assertExpected(sarg, expected);
+    }
+
+    @Test
+    public void testGreaterThan() {
+        SearchArgument.Builder builder = SearchArgumentFactory.newBuilder();
+        SearchArgument sarg =
+                builder.startNot()
+                        .lessThanEquals("f_bigint", PredicateLeaf.Type.LONG, 100L)
+                        .end()
+                        .build();
+        Predicate expected = new GreaterThan(1, new Literal(BIGINT_TYPE, 100L));
+        assertExpected(sarg, expected);
+    }
+
+    @Test
+    public void testIn() {
+        SearchArgument.Builder builder = SearchArgumentFactory.newBuilder();
+        SearchArgument sarg =
+                builder.in("f_bigint", PredicateLeaf.Type.LONG, 100L, 200L, 300L).build();
+        Predicate expected =
+                new Or(
+                        new Or(
+                                new Equal(1, new Literal(BIGINT_TYPE, 100L)),
+                                new Equal(1, new Literal(BIGINT_TYPE, 200L))),
+                        new Equal(1, new Literal(BIGINT_TYPE, 300L)));
+        assertExpected(sarg, expected);
+    }
+
+    @Test
+    public void testNotIn() {
+        SearchArgument.Builder builder = SearchArgumentFactory.newBuilder();
+        SearchArgument sarg =
+                builder.startNot()
+                        .in("f_bigint", PredicateLeaf.Type.LONG, 100L, 200L, 300L)
+                        .end()
+                        .build();
+        Predicate expected =
+                new And(
+                        new And(
+                                new NotEqual(1, new Literal(BIGINT_TYPE, 100L)),
+                                new NotEqual(1, new Literal(BIGINT_TYPE, 200L))),
+                        new NotEqual(1, new Literal(BIGINT_TYPE, 300L)));
+        assertExpected(sarg, expected);
+    }
+
+    @Test
+    public void testBetween() {
+        SearchArgument.Builder builder = SearchArgumentFactory.newBuilder();
+        SearchArgument sarg =
+                builder.between("f_bigint", PredicateLeaf.Type.LONG, 100L, 200L).build();
+        Predicate expected =
+                new And(
+                        new GreaterOrEqual(1, new Literal(BIGINT_TYPE, 100L)),
+                        new LessOrEqual(1, new Literal(BIGINT_TYPE, 200L)));
+        assertExpected(sarg, expected);
+    }
+
+    @Test
+    public void testNotBetween() {
+        SearchArgument.Builder builder = SearchArgumentFactory.newBuilder();
+        SearchArgument sarg =
+                builder.startNot()
+                        .between("f_bigint", PredicateLeaf.Type.LONG, 100L, 200L)
+                        .end()
+                        .build();
+        Predicate expected =
+                new Or(
+                        new LessThan(1, new Literal(BIGINT_TYPE, 100L)),
+                        new GreaterThan(1, new Literal(BIGINT_TYPE, 200L)));
+        assertExpected(sarg, expected);
+    }
+
+    @Test
+    public void testIsNull() {
+        SearchArgument.Builder builder = SearchArgumentFactory.newBuilder();
+        SearchArgument sarg = builder.isNull("f_bigint", PredicateLeaf.Type.LONG).build();
+        Predicate expected = new IsNull(1);
+        assertExpected(sarg, expected);
+    }
+
+    @Test
+    public void testIsNotNull() {
+        SearchArgument.Builder builder = SearchArgumentFactory.newBuilder();
+        SearchArgument sarg =
+                builder.startNot().isNull("f_bigint", PredicateLeaf.Type.LONG).end().build();
+        Predicate expected = new IsNotNull(1);
+        assertExpected(sarg, expected);
+    }
+
+    @Test
+    public void testOr() {
+        SearchArgument.Builder builder = SearchArgumentFactory.newBuilder();
+        SearchArgument sarg =
+                builder.startOr()
+                        .equals("f_bigint", PredicateLeaf.Type.LONG, 100L)
+                        .equals("f_bigint", PredicateLeaf.Type.LONG, 200L)
+                        .equals("f_bigint", PredicateLeaf.Type.LONG, 300L)
+                        .end()
+                        .build();
+        Predicate expected =
+                new Or(
+                        new Or(
+                                new Equal(1, new Literal(BIGINT_TYPE, 100L)),
+                                new Equal(1, new Literal(BIGINT_TYPE, 200L))),
+                        new Equal(1, new Literal(BIGINT_TYPE, 300L)));
+        assertExpected(sarg, expected);
+    }
+
+    @Test
+    public void testNotOr() {
+        SearchArgument.Builder builder = SearchArgumentFactory.newBuilder();
+        SearchArgument sarg =
+                builder.startNot()
+                        .startOr()
+                        .equals("f_bigint", PredicateLeaf.Type.LONG, 100L)
+                        .equals("f_bigint", PredicateLeaf.Type.LONG, 200L)
+                        .equals("f_bigint", PredicateLeaf.Type.LONG, 300L)
+                        .end()
+                        .end()
+                        .build();
+        Predicate expected =
+                new And(
+                        new And(
+                                new NotEqual(1, new Literal(BIGINT_TYPE, 100L)),
+                                new NotEqual(1, new Literal(BIGINT_TYPE, 200L))),
+                        new NotEqual(1, new Literal(BIGINT_TYPE, 300L)));
+        assertExpected(sarg, expected);
+    }
+
+    @Test
+    public void testAnd() {
+        SearchArgument.Builder builder = SearchArgumentFactory.newBuilder();
+        SearchArgument sarg =
+                builder.startAnd()
+                        .startNot()
+                        .equals("f_bigint", PredicateLeaf.Type.LONG, 100L)
+                        .end()
+                        .startNot()
+                        .equals("f_bigint", PredicateLeaf.Type.LONG, 200L)
+                        .end()
+                        .startNot()
+                        .equals("f_bigint", PredicateLeaf.Type.LONG, 300L)
+                        .end()
+                        .end()
+                        .build();
+        Predicate expected =
+                new And(
+                        new And(
+                                new NotEqual(1, new Literal(BIGINT_TYPE, 100L)),
+                                new NotEqual(1, new Literal(BIGINT_TYPE, 200L))),
+                        new NotEqual(1, new Literal(BIGINT_TYPE, 300L)));
+        assertExpected(sarg, expected);
+    }
+
+    @Test
+    public void testNotAnd() {
+        SearchArgument.Builder builder = SearchArgumentFactory.newBuilder();
+        SearchArgument sarg =
+                builder.startNot()
+                        .startAnd()
+                        .startNot()
+                        .equals("f_bigint", PredicateLeaf.Type.LONG, 100L)
+                        .end()
+                        .startNot()
+                        .equals("f_bigint", PredicateLeaf.Type.LONG, 200L)
+                        .end()
+                        .startNot()
+                        .equals("f_bigint", PredicateLeaf.Type.LONG, 300L)
+                        .end()
+                        .end()
+                        .end()
+                        .build();
+        Predicate expected =
+                new Or(
+                        new Or(
+                                new Equal(1, new Literal(BIGINT_TYPE, 100L)),
+                                new Equal(1, new Literal(BIGINT_TYPE, 200L))),
+                        new Equal(1, new Literal(BIGINT_TYPE, 300L)));
+        assertExpected(sarg, expected);
+    }
+
+    private void assertExpected(SearchArgument sarg, Predicate expected) {
+        SearchArgumentToPredicateConverter converter =
+                new SearchArgumentToPredicateConverter(sarg, COLUMN_NAMES, COLUMN_TYPES);
+        Predicate actual = converter.convert().orElse(null);
+        assertThat(actual).isEqualTo(expected);
+    }
+}

--- a/flink-table-store-hive/src/test/java/org/apache/flink/table/store/mapred/TableStoreRecordReaderTest.java
+++ b/flink-table-store-hive/src/test/java/org/apache/flink/table/store/mapred/TableStoreRecordReaderTest.java
@@ -94,7 +94,7 @@ public class TableStoreRecordReaderTest {
                 ValueKind.DELETE,
                 GenericRowData.of(2L),
                 GenericRowData.of(2L, StringData.fromString("Hello")));
-        helper.finishWrite();
+        helper.commit();
 
         Tuple2<RecordReader, Long> tuple = helper.read(BinaryRowDataUtil.EMPTY_ROW, 0);
         TableStoreRecordReader reader = new TableStoreRecordReader(tuple.f0, false, tuple.f1);
@@ -159,7 +159,7 @@ public class TableStoreRecordReaderTest {
                 ValueKind.ADD,
                 GenericRowData.of(1, StringData.fromString("Hi")),
                 GenericRowData.of(1L));
-        helper.finishWrite();
+        helper.commit();
 
         Tuple2<RecordReader, Long> tuple = helper.read(BinaryRowDataUtil.EMPTY_ROW, 0);
         TableStoreRecordReader reader = new TableStoreRecordReader(tuple.f0, true, tuple.f1);


### PR DESCRIPTION
Filter pushdown is a critical optimization for sources as it can decrease number of records to read. Hive provides a `HiveStoragePredicateHandler` interface for this purpose. We need to implement this interface in `TableStoreHiveStorageHandler`.

