### PR TITLE
[FLINK-27543] Hide column statistics collector inside the file format writer.

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileWriter.java
@@ -151,11 +151,11 @@ public class DataFileWriter {
             this.path = path;
 
             if (fileStatsExtractor == null) {
-                this.keyStatsCollector = new FieldStatsCollector(keyType);
-                this.valStatsCollector = new FieldStatsCollector(valueType);
+                keyStatsCollector = new FieldStatsCollector(keyType);
+                valStatsCollector = new FieldStatsCollector(valueType);
             } else {
-                this.keyStatsCollector = null;
-                this.valStatsCollector = null;
+                keyStatsCollector = null;
+                valStatsCollector = null;
             }
         }
 
@@ -187,8 +187,7 @@ public class DataFileWriter {
 
                 FieldStats[] stats = new FieldStats[keys.length + vals.length];
                 System.arraycopy(keys, 0, stats, 0, keys.length);
-                System.arraycopy(
-                        vals, 0, stats, keys.length, keys.length + vals.length - keys.length);
+                System.arraycopy(vals, 0, stats, keys.length, vals.length);
 
                 return new Metric(stats, recordCount);
             } else {
@@ -249,18 +248,15 @@ public class DataFileWriter {
 
         @Override
         protected DataFileMeta createResult(Path path, Metric metric) throws IOException {
-
-            BinaryTableStats keyStats;
-            BinaryTableStats valueStats;
             int numKeyFields = keyType.getFieldCount();
-            keyStats =
+            BinaryTableStats keyStats =
                     keyStatsConverter.toBinary(
                             Arrays.copyOfRange(metric.fieldStats(), 0, numKeyFields));
-            valueStats =
+            BinaryTableStats valueStats =
                     valueStatsConverter.toBinary(
                             Arrays.copyOfRange(
                                     metric.fieldStats(),
-                                    numKeyFields + 2,
+                                    numKeyFields,
                                     metric.fieldStats().length));
 
             return new DataFileMeta(

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileWriter.java
@@ -255,9 +255,7 @@ public class DataFileWriter {
             BinaryTableStats valueStats =
                     valueStatsConverter.toBinary(
                             Arrays.copyOfRange(
-                                    metric.fieldStats(),
-                                    numKeyFields,
-                                    metric.fieldStats().length));
+                                    metric.fieldStats(), numKeyFields, metric.fieldStats().length));
 
             return new DataFileMeta(
                     path.getName(),

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestFile.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestFile.java
@@ -133,7 +133,7 @@ public class ManifestFile {
 
         @Override
         public void update(ManifestEntry row) {
-            this.statsCollector.collect(row.partition());
+            statsCollector.collect(row.partition());
             recordCount += 1;
         }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/writer/AppendOnlyWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/writer/AppendOnlyWriter.java
@@ -138,9 +138,9 @@ public class AppendOnlyWriter implements RecordWriter {
         private RowMetricCollector(Path path) {
             this.path = path;
             if (fileStatsExtractor != null) {
-                this.fieldStatsCollector = new FieldStatsCollector(writeSchema);
-            } else {
                 this.fieldStatsCollector = null;
+            } else {
+                this.fieldStatsCollector = new FieldStatsCollector(writeSchema);
             }
         }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/writer/Metric.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/writer/Metric.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.table.store.file.writer;
+
+import org.apache.flink.table.store.file.stats.FieldStats;
+
+/** Metric information to describe the column's max-min values, record count etc. */
+public class Metric {
+
+    private final FieldStats[] fieldStats;
+    private final long recordCount;
+
+    public Metric(FieldStats[] stats, long recordCount) {
+        this.fieldStats = stats;
+        this.recordCount = recordCount;
+    }
+
+    public FieldStats[] fieldStats() {
+        return fieldStats;
+    }
+
+    public long recordCount() {
+        return recordCount;
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/writer/MetricCollector.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/writer/MetricCollector.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.table.store.file.writer;
+
+/**
+ * Collector to update the metrics for a given writer.
+ *
+ * @param <T> the record data type.
+ */
+public interface MetricCollector<T> {
+
+    /**
+     * Update the metric collector according to the input record.
+     *
+     * @param row to update.
+     */
+    void update(T row);
+
+    /** @return the record count. */
+    long recordCount();
+
+    /**
+     * Generate the collected metric.
+     *
+     * @return the generated {@link Metric}.
+     */
+    Metric get();
+}


### PR DESCRIPTION
This is another version for the FLINK-27543, which just introduce the abstracted `MetricCollector` to collect the metrics for each writer.