### PR TITLE
[FLINK-27696] Add bin-pack strategy to split the whole bucket data files into several small splits for append-only table.

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStore.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStore.java
@@ -309,6 +309,7 @@ public class TableStore {
             return new FileStoreSource(
                     buildFileStore(),
                     writeMode,
+                    options.get(FileStoreOptions.TARGET_TASK_SPLIT_SIZE).getBytes(),
                     getValueCountMode(writeMode),
                     isContinuous,
                     discoveryIntervalMills(),

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceTest.java
@@ -89,6 +89,7 @@ public class FileStoreSourceTest {
                 new FileStoreSource(
                         fileStore,
                         WriteMode.CHANGE_LOG,
+                        FileStoreOptions.TARGET_TASK_SPLIT_SIZE.defaultValue().getBytes(),
                         !hasPk,
                         true,
                         Duration.ofSeconds(1).toMillis(),

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreOptions.java
@@ -84,6 +84,13 @@ public class FileStoreOptions implements Serializable {
                             "To avoid frequent manifest merges, this parameter specifies the minimum number "
                                     + "of ManifestFileMeta to merge.");
 
+    public static final ConfigOption<MemorySize> TARGET_TASK_SPLIT_SIZE =
+            ConfigOptions.key("target-task-split-size")
+                    .memoryType()
+                    .defaultValue(MemorySize.ofMebiBytes(256))
+                    .withDescription(
+                            "Target size of a split task when scanning a bucket in the append-only table.");
+
     public static final ConfigOption<String> PARTITION_DEFAULT_NAME =
             key("partition.default-name")
                     .stringType()

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/BinPacking.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/BinPacking.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.table.store.file.utils;
+
+import org.apache.flink.shaded.guava30.com.google.common.base.Preconditions;
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
+import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
+import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+
+/** Copied from org.apache.iceberg.util.BinPacking. */
+public class BinPacking {
+
+    /** List packer. */
+    public static class ListPacker<T> {
+        private final long targetWeight;
+        private final int lookback;
+        private final boolean largestBinFirst;
+
+        public ListPacker(long targetWeight, int lookback, boolean largestBinFirst) {
+            this.targetWeight = targetWeight;
+            this.lookback = lookback;
+            this.largestBinFirst = largestBinFirst;
+        }
+
+        public List<List<T>> packEnd(List<T> items, Function<T, Long> weightFunc) {
+            return Lists.reverse(
+                    ImmutableList.copyOf(
+                            Iterables.transform(
+                                    new PackingIterable<>(
+                                            Lists.reverse(items),
+                                            targetWeight,
+                                            lookback,
+                                            weightFunc,
+                                            largestBinFirst),
+                                    Lists::reverse)));
+        }
+
+        public List<List<T>> pack(Iterable<T> items, Function<T, Long> weightFunc) {
+            return ImmutableList.copyOf(
+                    new PackingIterable<>(
+                            items, targetWeight, lookback, weightFunc, largestBinFirst));
+        }
+    }
+
+    /** Packing iterable. */
+    public static class PackingIterable<T> implements Iterable<List<T>> {
+        private final Iterable<T> iterable;
+        private final long targetWeight;
+        private final int lookback;
+        private final Function<T, Long> weightFunc;
+        private final boolean largestBinFirst;
+
+        public PackingIterable(
+                Iterable<T> iterable,
+                long targetWeight,
+                int lookback,
+                Function<T, Long> weightFunc,
+                boolean largestBinFirst) {
+            Preconditions.checkArgument(
+                    lookback > 0, "Bin look-back size must be greater than 0: %s", lookback);
+            this.iterable = iterable;
+            this.targetWeight = targetWeight;
+            this.lookback = lookback;
+            this.weightFunc = weightFunc;
+            this.largestBinFirst = largestBinFirst;
+        }
+
+        @Override
+        public Iterator<List<T>> iterator() {
+            return new PackingIterator<>(
+                    iterable.iterator(), targetWeight, lookback, weightFunc, largestBinFirst);
+        }
+    }
+
+    private static class PackingIterator<T> implements Iterator<List<T>> {
+        private final Deque<Bin<T>> bins = Lists.newLinkedList();
+        private final Iterator<T> items;
+        private final long targetWeight;
+        private final int lookback;
+        private final Function<T, Long> weightFunc;
+        private final boolean largestBinFirst;
+
+        private PackingIterator(
+                Iterator<T> items,
+                long targetWeight,
+                int lookback,
+                Function<T, Long> weightFunc,
+                boolean largestBinFirst) {
+            this.items = items;
+            this.targetWeight = targetWeight;
+            this.lookback = lookback;
+            this.weightFunc = weightFunc;
+            this.largestBinFirst = largestBinFirst;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return items.hasNext() || !bins.isEmpty();
+        }
+
+        @Override
+        public List<T> next() {
+            while (items.hasNext()) {
+                T item = items.next();
+
+                long weight = weightFunc.apply(item);
+                Bin<T> bin = findBin(weight);
+
+                if (bin != null) {
+                    bin.add(item, weight);
+
+                } else {
+                    bin = newBin();
+                    bin.add(item, weight);
+                    bins.addLast(bin);
+
+                    if (bins.size() > lookback) {
+                        Bin<T> binToRemove;
+                        if (largestBinFirst) {
+                            binToRemove = removeLargestBin(bins);
+                        } else {
+                            binToRemove = bins.removeFirst();
+                        }
+                        return ImmutableList.copyOf(binToRemove.items());
+                    }
+                }
+            }
+
+            if (bins.isEmpty()) {
+                throw new NoSuchElementException();
+            }
+
+            return ImmutableList.copyOf(bins.removeFirst().items());
+        }
+
+        private Bin<T> findBin(long weight) {
+            for (Bin<T> bin : bins) {
+                if (bin.canAdd(weight)) {
+                    return bin;
+                }
+            }
+            return null;
+        }
+
+        private Bin<T> newBin() {
+            return new Bin<>(targetWeight);
+        }
+
+        private static <T> Bin<T> removeLargestBin(Collection<Bin<T>> bins) {
+            // Iterate through all bins looking for one with maximum weight, taking O(n) time.
+            Bin<T> maxBin = Collections.max(bins, Comparator.comparingLong(Bin::weight));
+
+            // Sanity check: we have removed maxBin from list of bins.
+            if (bins.remove(maxBin)) {
+                return maxBin;
+            } else {
+                throw new NoSuchElementException();
+            }
+        }
+    }
+
+    private static class Bin<T> {
+        private final long targetWeight;
+        private final List<T> items = Lists.newArrayList();
+        private long binWeight = 0L;
+
+        Bin(long targetWeight) {
+            this.targetWeight = targetWeight;
+        }
+
+        List<T> items() {
+            return items;
+        }
+
+        boolean canAdd(long weight) {
+            return binWeight + weight <= targetWeight;
+        }
+
+        void add(T item, long weight) {
+            this.binWeight += weight;
+            items.add(item);
+        }
+
+        long weight() {
+            return binWeight;
+        }
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/BinPackingTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/BinPackingTest.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.table.store.file.utils;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Copied from apache iceberg. Test cases for {@link BinPacking}. */
+public class BinPackingTest {
+    @Test
+    public void testBasicBinPacking() {
+        // Should pack the first 2 values
+        assertThat(list(list(1, 2), list(3), list(4), list(5)))
+                .isEqualTo(pack(list(1, 2, 3, 4, 5), 3));
+
+        // Should pack the first 2 values
+        assertThat(list(list(1, 2), list(3), list(4), list(5)))
+                .isEqualTo(pack(list(1, 2, 3, 4, 5), 5));
+
+        // Should pack the first 3 values
+        assertThat(list(list(1, 2, 3), list(4), list(5))).isEqualTo(pack(list(1, 2, 3, 4, 5), 6));
+
+        // Should pack the first 3 values
+        assertThat(list(list(1, 2, 3), list(4), list(5))).isEqualTo(pack(list(1, 2, 3, 4, 5), 8));
+
+        // Should pack the first 3 values, last 2 values
+        assertThat(list(list(1, 2, 3), list(4, 5))).isEqualTo(pack(list(1, 2, 3, 4, 5), 9));
+
+        // Should pack the first 4 values
+        assertThat(list(list(1, 2, 3, 4), list(5))).isEqualTo(pack(list(1, 2, 3, 4, 5), 10));
+
+        // Should pack the first 4 values
+        assertThat(list(list(1, 2, 3, 4), list(5))).isEqualTo(pack(list(1, 2, 3, 4, 5), 14));
+
+        // Should pack the first 5 values
+        assertThat(list(list(1, 2, 3, 4, 5))).isEqualTo(pack(list(1, 2, 3, 4, 5), 15));
+    }
+
+    @Test
+    public void testReverseBinPackingSingleLookback() {
+        // Should pack the first 2 values
+        assertThat(list(list(1, 2), list(3), list(4), list(5)))
+                .isEqualTo(packEnd(list(1, 2, 3, 4, 5), 3, 1));
+
+        // Should pack the first 2 values
+        assertThat(list(list(1, 2), list(3), list(4), list(5)))
+                .isEqualTo(packEnd(list(1, 2, 3, 4, 5), 4, 1));
+
+        // Should pack the second and third values
+        assertThat(list(list(1), list(2, 3), list(4), list(5)))
+                .isEqualTo(packEnd(list(1, 2, 3, 4, 5), 5, 1));
+
+        // Should pack the first 3 values
+        assertThat(list(list(1, 2, 3), list(4), list(5)))
+                .isEqualTo(packEnd(list(1, 2, 3, 4, 5), 6, 1));
+
+        // Should pack the first two pairs of values
+        assertThat(list(list(1, 2), list(3, 4), list(5)))
+                .isEqualTo(packEnd(list(1, 2, 3, 4, 5), 7, 1));
+
+        // Should pack the first two pairs of values
+        assertThat(list(list(1, 2), list(3, 4), list(5)))
+                .isEqualTo(packEnd(list(1, 2, 3, 4, 5), 8, 1));
+
+        // Should pack the first 3 values, last 2 values
+        assertThat(list(list(1, 2, 3), list(4, 5))).isEqualTo(packEnd(list(1, 2, 3, 4, 5), 9, 1));
+
+        // Should pack the first 3 values, last 2 values
+        assertThat(list(list(1, 2, 3), list(4, 5))).isEqualTo(packEnd(list(1, 2, 3, 4, 5), 11, 1));
+
+        // Should pack the first 3 values, last 2 values
+        assertThat(list(list(1, 2), list(3, 4, 5))).isEqualTo(packEnd(list(1, 2, 3, 4, 5), 12, 1));
+
+        // Should pack the last 4 values
+        assertThat(list(list(1), list(2, 3, 4, 5))).isEqualTo(packEnd(list(1, 2, 3, 4, 5), 14, 1));
+
+        // Should pack the first 5 values
+        assertThat(list(list(1, 2, 3, 4, 5))).isEqualTo(packEnd(list(1, 2, 3, 4, 5), 15, 1));
+    }
+
+    @Test
+    public void testReverseBinPackingUnlimitedLookback() {
+        // Should pack the first 2 values
+        assertThat(list(list(1, 2), list(3), list(4), list(5)))
+                .isEqualTo(packEnd(list(1, 2, 3, 4, 5), 3));
+
+        // Should pack 1 with 3
+        assertThat(list(list(2), list(1, 3), list(4), list(5)))
+                .isEqualTo(packEnd(list(1, 2, 3, 4, 5), 4));
+
+        // Should pack 2,3 and 1,4
+        assertThat(list(list(2, 3), list(1, 4), list(5)))
+                .isEqualTo(packEnd(list(1, 2, 3, 4, 5), 5));
+
+        // Should pack 2,4 and 1,5
+        assertThat(list(list(3), list(2, 4), list(1, 5)))
+                .isEqualTo(packEnd(list(1, 2, 3, 4, 5), 6));
+
+        // Should pack 3,4 and 2,5
+        assertThat(list(list(1), list(3, 4), list(2, 5)))
+                .isEqualTo(packEnd(list(1, 2, 3, 4, 5), 7));
+
+        // Should pack 1,2,3 and 3,5
+        assertThat(list(list(1, 2, 4), list(3, 5))).isEqualTo(packEnd(list(1, 2, 3, 4, 5), 8));
+
+        // Should pack the first 3 values, last 2 values
+        assertThat(list(list(1, 2, 3), list(4, 5))).isEqualTo(packEnd(list(1, 2, 3, 4, 5), 9));
+
+        // Should pack 2,3 and 1,4,5
+        assertThat(list(list(2, 3), list(1, 4, 5))).isEqualTo(packEnd(list(1, 2, 3, 4, 5), 10));
+
+        // Should pack 1,3 and 2,4,5
+        assertThat(list(list(1, 3), list(2, 4, 5))).isEqualTo(packEnd(list(1, 2, 3, 4, 5), 11));
+
+        // Should pack 1,2 and 3,4,5
+        assertThat(list(list(1, 2), list(3, 4, 5))).isEqualTo(packEnd(list(1, 2, 3, 4, 5), 12));
+
+        // Should pack 1,2 and 3,4,5
+        assertThat(list(list(2), list(1, 3, 4, 5))).isEqualTo(packEnd(list(1, 2, 3, 4, 5), 13));
+
+        // Should pack the last 4 values
+        assertThat(list(list(1), list(2, 3, 4, 5))).isEqualTo(packEnd(list(1, 2, 3, 4, 5), 14));
+
+        // Should pack the first 5 values
+        assertThat(list(list(1, 2, 3, 4, 5))).isEqualTo(packEnd(list(1, 2, 3, 4, 5), 15));
+    }
+
+    @Test
+    public void testBinPackingLookBack() {
+        // lookback state:
+        // 1. [5]
+        // 2. [5, 1]
+        // 3. [5, 1], [5]
+        // 4. [5, 1, 1], [5]
+        // 5. [5, 1, 1], [5], [5]
+        // 6. [5, 1, 1, 1], [5], [5]
+
+        // Unlimited look-back: should merge ones into first bin
+        assertThat(list(list(5, 1, 1, 1), list(5), list(5)))
+                .isEqualTo(pack(list(5, 1, 5, 1, 5, 1), 8));
+
+        // lookback state:
+        // 1. [5]
+        // 2. [5, 1]
+        // 3. [5, 1], [5]
+        // 4. [5, 1, 1], [5]
+        // 5. [5], [5]          ([5, 1, 1] drops out of look-back)
+        // 6. [5, 1], [5]
+
+        // 2 bin look-back: should merge two ones into first bin
+        assertThat(list(list(5, 1, 1), list(5, 1), list(5)))
+                .isEqualTo(pack(list(5, 1, 5, 1, 5, 1), 8, 2));
+
+        // lookback state:
+        // 1. [5]
+        // 2. [5, 1]
+        // 3. [5]               ([5, 1] drops out of look-back)
+        // 4. [5, 1]
+        // 5. [5]               ([5, 1] #2 drops out of look-back)
+        // 6. [5, 1]
+
+        // 1 bin look-back: should merge ones with fives
+        assertThat(list(list(5, 1), list(5, 1), list(5, 1)))
+                .isEqualTo(pack(list(5, 1, 5, 1, 5, 1), 8, 1));
+
+        // 2 bin look-back: should merge until targetWeight when largestBinFirst is enabled
+        assertThat(list(list(36, 36, 36), list(128), list(36, 65), list(65)))
+                .isEqualTo(pack(list(36, 36, 36, 36, 65, 65, 128), 128, 2, true));
+
+        // 1 bin look-back: should merge until targetWeight when largestBinFirst is enabled
+        assertThat(list(list(64, 64), list(128), list(32, 32, 32, 32)))
+                .isEqualTo(pack(list(64, 64, 128, 32, 32, 32, 32), 128, 1, true));
+    }
+
+    private List<List<Integer>> pack(List<Integer> items, long targetWeight) {
+        return pack(items, targetWeight, Integer.MAX_VALUE);
+    }
+
+    private List<List<Integer>> pack(List<Integer> items, long targetWeight, int lookback) {
+        return pack(items, targetWeight, lookback, false);
+    }
+
+    private List<List<Integer>> pack(
+            List<Integer> items, long targetWeight, int lookback, boolean largestBinFirst) {
+        BinPacking.ListPacker<Integer> packer =
+                new BinPacking.ListPacker<>(targetWeight, lookback, largestBinFirst);
+        return packer.pack(items, Integer::longValue);
+    }
+
+    private List<List<Integer>> packEnd(List<Integer> items, long targetWeight) {
+        return packEnd(items, targetWeight, Integer.MAX_VALUE);
+    }
+
+    private List<List<Integer>> packEnd(List<Integer> items, long targetWeight, int lookback) {
+        BinPacking.ListPacker<Integer> packer =
+                new BinPacking.ListPacker<>(targetWeight, lookback, false);
+        return packer.packEnd(items, Integer::longValue);
+    }
+
+    private <T> List<T> list(T... items) {
+        return Lists.newArrayList(items);
+    }
+}


### PR DESCRIPTION
Support bin-pack strategy for append-only table.  The bin-packing algorithm is ported from apache iceberg. https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/util/BinPacking.java