### PR TITLE
[FLINK-27755] Introduce a filesystem catalog for table store

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreConnectorFactory.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreConnectorFactory.java
@@ -20,11 +20,13 @@ package org.apache.flink.table.store.connector;
 
 import org.apache.flink.table.factories.DynamicTableFactory;
 
+import static org.apache.flink.table.store.file.catalog.TableStoreCatalogFactory.IDENTIFIER;
+
 /** A table store {@link DynamicTableFactory} to create source and sink. */
 public class TableStoreConnectorFactory extends AbstractTableStoreFactory {
 
     @Override
     public String factoryIdentifier() {
-        return "table-store";
+        return IDENTIFIER;
     }
 }

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreConnectorFactory.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreConnectorFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector;
+
+import org.apache.flink.table.factories.DynamicTableFactory;
+
+/** A table store {@link DynamicTableFactory} to create source and sink. */
+public class TableStoreConnectorFactory extends AbstractTableStoreFactory {
+
+    @Override
+    public String factoryIdentifier() {
+        return "table-store";
+    }
+}

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileSystemCatalogITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileSystemCatalogITCase.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector;
+
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.store.file.catalog.FileSystemCatalog;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.types.Row;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static org.apache.flink.util.CollectionUtil.iteratorToList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** ITCase for {@link FileSystemCatalog}. */
+public class FileSystemCatalogITCase extends AbstractTestBase {
+
+    private TableEnvironment tEnv;
+
+    @Before
+    public void before() throws IOException {
+        tEnv = TableEnvironment.create(EnvironmentSettings.newInstance().inBatchMode().build());
+        String path = TEMPORARY_FOLDER.newFolder().toURI().toString();
+        tEnv.executeSql(
+                String.format(
+                        "CREATE CATALOG fs WITH ('type'='table-store', 'root-path'='%s')", path));
+        tEnv.useCatalog("fs");
+    }
+
+    @Test
+    public void testWriteRead() throws ExecutionException, InterruptedException {
+        tEnv.executeSql("CREATE TABLE T (a STRING, b STRING, c STRING)");
+        tEnv.executeSql("INSERT INTO T VALUES ('1', '2', '3'), ('4', '5', '6')").await();
+        List<Row> result = iteratorToList(tEnv.from("T").execute().collect());
+        assertThat(result).containsExactlyInAnyOrder(Row.of("1", "2", "3"), Row.of("4", "5", "6"));
+    }
+}

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileSystemCatalogITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileSystemCatalogITCase.java
@@ -40,7 +40,7 @@ public class FileSystemCatalogITCase extends KafkaTableTestBase {
         String path = TEMPORARY_FOLDER.newFolder().toURI().toString();
         tEnv.executeSql(
                 String.format(
-                        "CREATE CATALOG fs WITH ('type'='table-store', 'root-path'='%s')", path));
+                        "CREATE CATALOG fs WITH ('type'='table-store', 'warehouse'='%s')", path));
         tEnv.useCatalog("fs");
         env.setParallelism(1);
     }

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileSystemCatalogITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileSystemCatalogITCase.java
@@ -18,10 +18,9 @@
 
 package org.apache.flink.table.store.connector;
 
-import org.apache.flink.table.api.EnvironmentSettings;
-import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.store.file.catalog.FileSystemCatalog;
-import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.table.store.file.utils.BlockingIterator;
+import org.apache.flink.table.store.kafka.KafkaTableTestBase;
 import org.apache.flink.types.Row;
 
 import org.junit.Before;
@@ -29,31 +28,54 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
+import java.util.UUID;
 
-import static org.apache.flink.util.CollectionUtil.iteratorToList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** ITCase for {@link FileSystemCatalog}. */
-public class FileSystemCatalogITCase extends AbstractTestBase {
-
-    private TableEnvironment tEnv;
+public class FileSystemCatalogITCase extends KafkaTableTestBase {
 
     @Before
     public void before() throws IOException {
-        tEnv = TableEnvironment.create(EnvironmentSettings.newInstance().inBatchMode().build());
         String path = TEMPORARY_FOLDER.newFolder().toURI().toString();
         tEnv.executeSql(
                 String.format(
                         "CREATE CATALOG fs WITH ('type'='table-store', 'root-path'='%s')", path));
         tEnv.useCatalog("fs");
+        env.setParallelism(1);
     }
 
     @Test
-    public void testWriteRead() throws ExecutionException, InterruptedException {
+    public void testWriteRead() throws Exception {
         tEnv.executeSql("CREATE TABLE T (a STRING, b STRING, c STRING)");
+        innerTestWriteRead();
+    }
+
+    @Test
+    public void testLogWriteRead() throws Exception {
+        String topic = UUID.randomUUID().toString();
+        createTopicIfNotExists(topic, 1);
+
+        try {
+            tEnv.executeSql(
+                    String.format(
+                            "CREATE TABLE T (a STRING, b STRING, c STRING) WITH ("
+                                    + "'log.system'='kafka', "
+                                    + "'log.kafka.bootstrap.servers'='%s',"
+                                    + "'log.topic'='%s'"
+                                    + ")",
+                            getBootstrapServers(), topic));
+            innerTestWriteRead();
+        } finally {
+            deleteTopicIfExists(topic);
+        }
+    }
+
+    private void innerTestWriteRead() throws Exception {
+        BlockingIterator<Row, Row> iterator =
+                BlockingIterator.of(tEnv.from("T").execute().collect());
         tEnv.executeSql("INSERT INTO T VALUES ('1', '2', '3'), ('4', '5', '6')").await();
-        List<Row> result = iteratorToList(tEnv.from("T").execute().collect());
+        List<Row> result = iterator.collectAndClose(2);
         assertThat(result).containsExactlyInAnyOrder(Row.of("1", "2", "3"), Row.of("4", "5", "6"));
     }
 }

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileSystemCatalogITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileSystemCatalogITCase.java
@@ -71,14 +71,6 @@ public class FileSystemCatalogITCase extends KafkaTableTestBase {
         }
     }
 
-    private void innerTestWriteRead() throws Exception {
-        BlockingIterator<Row, Row> iterator =
-                BlockingIterator.of(tEnv.from("T").execute().collect());
-        tEnv.executeSql("INSERT INTO T VALUES ('1', '2', '3'), ('4', '5', '6')").await();
-        List<Row> result = iterator.collectAndClose(2);
-        assertThat(result).containsExactlyInAnyOrder(Row.of("1", "2", "3"), Row.of("4", "5", "6"));
-    }
-
     @Test
     public void testLogWriteReadWithVirtual() throws Exception {
         String topic = UUID.randomUUID().toString();
@@ -107,5 +99,13 @@ public class FileSystemCatalogITCase extends KafkaTableTestBase {
         } finally {
             deleteTopicIfExists(topic);
         }
+    }
+
+    private void innerTestWriteRead() throws Exception {
+        BlockingIterator<Row, Row> iterator =
+                BlockingIterator.of(tEnv.from("T").execute().collect());
+        tEnv.executeSql("INSERT INTO T VALUES ('1', '2', '3'), ('4', '5', '6')").await();
+        List<Row> result = iterator.collectAndClose(2);
+        assertThat(result).containsExactlyInAnyOrder(Row.of("1", "2", "3"), Row.of("4", "5", "6"));
     }
 }

--- a/flink-table-store-core/pom.xml
+++ b/flink-table-store-core/pom.xml
@@ -89,6 +89,41 @@ under the License.
             <version>${flink.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-common</artifactId>
+            <version>${flink.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-api-java</artifactId>
+            <version>${flink.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit4.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/FileSystemCatalog.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/FileSystemCatalog.java
@@ -1,0 +1,317 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.catalog;
+
+import org.apache.flink.core.fs.FileStatus;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.CatalogDatabase;
+import org.apache.flink.table.catalog.CatalogDatabaseImpl;
+import org.apache.flink.table.catalog.CatalogTableImpl;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
+import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.TableNotExistException;
+import org.apache.flink.table.factories.DynamicTableFactory;
+import org.apache.flink.table.factories.Factory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.store.file.schema.Schema;
+import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.file.schema.UpdateSchema;
+import org.apache.flink.util.function.RunnableWithException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+
+import static org.apache.flink.table.catalog.GenericInMemoryCatalogFactoryOptions.DEFAULT_DATABASE;
+import static org.apache.flink.table.store.file.FileStoreOptions.PATH;
+
+/** A catalog implementation for {@link FileSystem}. */
+public class FileSystemCatalog extends TableStoreCatalog {
+
+    public static final String DB_SUFFIX = ".db";
+
+    public static final CatalogDatabaseImpl DUMMY_DATABASE =
+            new CatalogDatabaseImpl(Collections.emptyMap(), null);
+
+    private final FileSystem fs;
+    private final Path root;
+
+    public FileSystemCatalog(String name, Path root) {
+        this(name, root, DEFAULT_DATABASE.defaultValue());
+    }
+
+    public FileSystemCatalog(String name, Path root, String defaultDatabase) {
+        super(name, defaultDatabase);
+        this.root = root;
+        this.fs = uncheck(root::getFileSystem);
+        uncheck(() -> createDatabase(defaultDatabase, DUMMY_DATABASE, true));
+    }
+
+    @Override
+    public Optional<Factory> getFactory() {
+        return Optional.of(
+                FactoryUtil.discoverFactory(
+                        classLoader(), DynamicTableFactory.class, "table-store"));
+    }
+
+    @Override
+    public List<String> listDatabases() throws CatalogException {
+        List<String> databases = new ArrayList<>();
+        for (FileStatus status : uncheck(() -> fs.listStatus(root))) {
+            Path path = status.getPath();
+            if (status.isDir() && isDatabase(path)) {
+                databases.add(database(path));
+            }
+        }
+        return databases;
+    }
+
+    @Override
+    public CatalogDatabase getDatabase(String databaseName)
+            throws DatabaseNotExistException, CatalogException {
+        if (!databaseExists(databaseName)) {
+            throw new DatabaseNotExistException(getName(), databaseName);
+        }
+        return new CatalogDatabaseImpl(Collections.emptyMap(), "");
+    }
+
+    @Override
+    public boolean databaseExists(String databaseName) throws CatalogException {
+        return uncheck(() -> fs.exists(databasePath(databaseName)));
+    }
+
+    @Override
+    public void createDatabase(String name, CatalogDatabase database, boolean ignoreIfExists)
+            throws DatabaseAlreadyExistException, CatalogException {
+        if (database.getProperties().size() > 0) {
+            throw new UnsupportedOperationException(
+                    "Create database with properties is unsupported.");
+        }
+
+        if (database.getDescription().isPresent() && !database.getDescription().get().equals("")) {
+            throw new UnsupportedOperationException(
+                    "Create database with description is unsupported.");
+        }
+
+        if (!ignoreIfExists && databaseExists(name)) {
+            throw new DatabaseAlreadyExistException(getName(), name);
+        }
+
+        uncheck(() -> fs.mkdirs(databasePath(name)));
+    }
+
+    @Override
+    public void dropDatabase(String name, boolean ignoreIfNotExists, boolean cascade)
+            throws DatabaseNotExistException, DatabaseNotEmptyException, CatalogException {
+        if (!databaseExists(name)) {
+            if (ignoreIfNotExists) {
+                return;
+            }
+
+            throw new DatabaseNotExistException(getName(), name);
+        }
+
+        if (listTables(name).size() > 0) {
+            throw new DatabaseNotEmptyException(getName(), name);
+        }
+
+        uncheck(() -> fs.delete(databasePath(name), true));
+    }
+
+    @Override
+    public List<String> listTables(String databaseName)
+            throws DatabaseNotExistException, CatalogException {
+        if (!databaseExists(databaseName)) {
+            throw new DatabaseNotExistException(getName(), databaseName);
+        }
+
+        List<String> tables = new ArrayList<>();
+        for (FileStatus status : uncheck(() -> fs.listStatus(databasePath(databaseName)))) {
+            if (status.isDir() && isTable(status.getPath())) {
+                tables.add(status.getPath().getName());
+            }
+        }
+        return tables;
+    }
+
+    @Override
+    public CatalogBaseTable getTable(ObjectPath tablePath)
+            throws TableNotExistException, CatalogException {
+        Path path = tablePath(tablePath);
+        Schema schema =
+                new SchemaManager(path)
+                        .latest()
+                        .orElseThrow(() -> new TableNotExistException(getName(), tablePath));
+
+        Map<String, String> options = new HashMap<>(schema.options());
+        options.put(PATH.key(), path.toString());
+
+        //noinspection deprecation
+        return new CatalogTableImpl(
+                schema.getTableSchema(), schema.partitionKeys(), options, schema.comment());
+    }
+
+    @Override
+    public boolean tableExists(ObjectPath tablePath) throws CatalogException {
+        return isTable(tablePath(tablePath));
+    }
+
+    @Override
+    public void dropTable(ObjectPath tablePath, boolean ignoreIfNotExists)
+            throws TableNotExistException, CatalogException {
+        Path path = tablePath(tablePath);
+        if (!uncheck(() -> fs.exists(path))) {
+            if (ignoreIfNotExists) {
+                return;
+            }
+
+            throw new TableNotExistException(getName(), tablePath);
+        }
+
+        uncheck(() -> fs.delete(path, true));
+    }
+
+    @Override
+    public void createTable(ObjectPath tablePath, CatalogBaseTable table, boolean ignoreIfExists)
+            throws TableAlreadyExistException, DatabaseNotExistException, CatalogException {
+        if (!databaseExists(tablePath.getDatabaseName())) {
+            throw new DatabaseNotExistException(getName(), tablePath.getDatabaseName());
+        }
+
+        Path path = tablePath(tablePath);
+        if (uncheck(() -> fs.exists(path))) {
+            if (ignoreIfExists) {
+                return;
+            }
+
+            throw new TableAlreadyExistException(getName(), tablePath);
+        }
+
+        commitTableChange(path, table);
+    }
+
+    @Override
+    public void alterTable(
+            ObjectPath tablePath, CatalogBaseTable newTable, boolean ignoreIfNotExists)
+            throws TableNotExistException, CatalogException {
+        Path path = tablePath(tablePath);
+        if (uncheck(() -> !fs.exists(path))) {
+            if (ignoreIfNotExists) {
+                return;
+            }
+
+            throw new TableNotExistException(getName(), tablePath);
+        }
+
+        commitTableChange(path, newTable);
+    }
+
+    private static <T> T uncheck(Callable<T> callable) {
+        try {
+            return callable.call();
+        } catch (Exception e) {
+            throw new CatalogException(e);
+        }
+    }
+
+    private static void uncheck(RunnableWithException runnable) {
+        try {
+            runnable.run();
+        } catch (Exception e) {
+            throw new CatalogException(e);
+        }
+    }
+
+    private static ClassLoader classLoader() {
+        return FileSystemCatalog.class.getClassLoader();
+    }
+
+    private static boolean isDatabase(Path path) {
+        return path.getName().endsWith(DB_SUFFIX);
+    }
+
+    private static String database(Path path) {
+        String name = path.getName();
+        return name.substring(0, name.length() - DB_SUFFIX.length());
+    }
+
+    private Path databasePath(String database) {
+        return new Path(root, database + DB_SUFFIX);
+    }
+
+    private static boolean isTable(Path path) {
+        return new SchemaManager(path).listAllIds().size() > 0;
+    }
+
+    private Path tablePath(ObjectPath objectPath) {
+        return new Path(databasePath(objectPath.getDatabaseName()), objectPath.getObjectName());
+    }
+
+    private void commitTableChange(Path tablePath, CatalogBaseTable table) {
+        SchemaManager schemaManager = new SchemaManager(tablePath);
+        UpdateSchema updateSchema = createUpdateSchema(table, tablePath);
+        uncheck(() -> schemaManager.commitNewVersion(updateSchema));
+    }
+
+    private ResolvedCatalogTable castToResolved(CatalogBaseTable table) {
+        if (!(table instanceof ResolvedCatalogTable)) {
+            throw new UnsupportedOperationException(
+                    "Only support ResolvedCatalogTable, but is: " + table.getClass());
+        }
+
+        return (ResolvedCatalogTable) table;
+    }
+
+    private UpdateSchema createUpdateSchema(CatalogBaseTable table, Path tablePath) {
+        ResolvedCatalogTable resolvedTable = castToResolved(table);
+        ResolvedSchema resolvedSchema = resolvedTable.getResolvedSchema();
+        if (resolvedSchema.getColumns().stream().anyMatch(column -> !column.isPhysical())) {
+            throw new UnsupportedOperationException("TODO: Non physical column is unsupported.");
+        }
+
+        if (resolvedSchema.getWatermarkSpecs().size() > 0) {
+            throw new UnsupportedOperationException("TODO: Watermark is unsupported.");
+        }
+
+        // remove table path
+        Map<String, String> options = resolvedTable.getOptions();
+        String specific = options.remove(PATH.key());
+        if (specific != null) {
+            if (!tablePath.equals(new Path(specific))) {
+                throw new IllegalArgumentException(
+                        "Illegal table path in table options: " + specific);
+            }
+            resolvedTable = resolvedTable.copy(options);
+        }
+
+        return UpdateSchema.fromCatalogTable(resolvedTable);
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/TableStoreCatalog.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/TableStoreCatalog.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.catalog;
+
+import org.apache.flink.table.catalog.AbstractCatalog;
+import org.apache.flink.table.catalog.CatalogDatabase;
+import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.catalog.CatalogPartition;
+import org.apache.flink.table.catalog.CatalogPartitionSpec;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.catalog.exceptions.FunctionNotExistException;
+import org.apache.flink.table.catalog.exceptions.PartitionNotExistException;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
+import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
+import org.apache.flink.table.expressions.Expression;
+
+import java.util.Collections;
+import java.util.List;
+
+/** Catalog for table store. */
+public abstract class TableStoreCatalog extends AbstractCatalog {
+
+    public TableStoreCatalog(String name, String defaultDatabase) {
+        super(name, defaultDatabase);
+    }
+
+    // --------------------- unsupported methods ----------------------------
+
+    @Override
+    public final void open() throws CatalogException {}
+
+    @Override
+    public final void close() throws CatalogException {}
+
+    @Override
+    public final void alterDatabase(
+            String name, CatalogDatabase newDatabase, boolean ignoreIfNotExists)
+            throws CatalogException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public final void renameTable(
+            ObjectPath tablePath, String newTableName, boolean ignoreIfNotExists)
+            throws CatalogException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public final List<String> listViews(String databaseName) throws CatalogException {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public final List<CatalogPartitionSpec> listPartitions(ObjectPath tablePath)
+            throws CatalogException {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public final List<CatalogPartitionSpec> listPartitions(
+            ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws CatalogException {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public final List<CatalogPartitionSpec> listPartitionsByFilter(
+            ObjectPath tablePath, List<Expression> filters) throws CatalogException {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public final CatalogPartition getPartition(
+            ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
+            throws PartitionNotExistException, CatalogException {
+        throw new PartitionNotExistException(getName(), tablePath, partitionSpec);
+    }
+
+    @Override
+    public final boolean partitionExists(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
+            throws CatalogException {
+        return false;
+    }
+
+    @Override
+    public final void createPartition(
+            ObjectPath tablePath,
+            CatalogPartitionSpec partitionSpec,
+            CatalogPartition partition,
+            boolean ignoreIfExists)
+            throws CatalogException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public final void dropPartition(
+            ObjectPath tablePath, CatalogPartitionSpec partitionSpec, boolean ignoreIfNotExists)
+            throws CatalogException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public final void alterPartition(
+            ObjectPath tablePath,
+            CatalogPartitionSpec partitionSpec,
+            CatalogPartition newPartition,
+            boolean ignoreIfNotExists)
+            throws CatalogException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public final List<String> listFunctions(String dbName) throws CatalogException {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public final CatalogFunction getFunction(ObjectPath functionPath)
+            throws FunctionNotExistException, CatalogException {
+        throw new FunctionNotExistException(getName(), functionPath);
+    }
+
+    @Override
+    public final boolean functionExists(ObjectPath functionPath) throws CatalogException {
+        return false;
+    }
+
+    @Override
+    public final void createFunction(
+            ObjectPath functionPath, CatalogFunction function, boolean ignoreIfExists)
+            throws CatalogException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public final void alterFunction(
+            ObjectPath functionPath, CatalogFunction newFunction, boolean ignoreIfNotExists)
+            throws CatalogException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public final void dropFunction(ObjectPath functionPath, boolean ignoreIfNotExists)
+            throws CatalogException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public final CatalogTableStatistics getTableStatistics(ObjectPath tablePath)
+            throws CatalogException {
+        return CatalogTableStatistics.UNKNOWN;
+    }
+
+    @Override
+    public final CatalogColumnStatistics getTableColumnStatistics(ObjectPath tablePath)
+            throws CatalogException {
+        return CatalogColumnStatistics.UNKNOWN;
+    }
+
+    @Override
+    public final CatalogTableStatistics getPartitionStatistics(
+            ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws CatalogException {
+        return CatalogTableStatistics.UNKNOWN;
+    }
+
+    @Override
+    public final CatalogColumnStatistics getPartitionColumnStatistics(
+            ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws CatalogException {
+        return CatalogColumnStatistics.UNKNOWN;
+    }
+
+    @Override
+    public final void alterTableStatistics(
+            ObjectPath tablePath, CatalogTableStatistics tableStatistics, boolean ignoreIfNotExists)
+            throws CatalogException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public final void alterTableColumnStatistics(
+            ObjectPath tablePath,
+            CatalogColumnStatistics columnStatistics,
+            boolean ignoreIfNotExists)
+            throws CatalogException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public final void alterPartitionStatistics(
+            ObjectPath tablePath,
+            CatalogPartitionSpec partitionSpec,
+            CatalogTableStatistics partitionStatistics,
+            boolean ignoreIfNotExists)
+            throws CatalogException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public final void alterPartitionColumnStatistics(
+            ObjectPath tablePath,
+            CatalogPartitionSpec partitionSpec,
+            CatalogColumnStatistics columnStatistics,
+            boolean ignoreIfNotExists)
+            throws CatalogException {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/TableStoreCatalogFactory.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/TableStoreCatalogFactory.java
@@ -33,24 +33,26 @@ import static org.apache.flink.table.factories.FactoryUtil.PROPERTY_VERSION;
 /** Factory for {@link TableStoreCatalog}. */
 public class TableStoreCatalogFactory implements CatalogFactory {
 
+    public static final String IDENTIFIER = "table-store";
+
     public static final ConfigOption<String> DEFAULT_DATABASE =
             ConfigOptions.key("default-database").stringType().defaultValue("default");
 
-    public static final ConfigOption<String> ROOT_PATH =
-            ConfigOptions.key("root-path")
+    public static final ConfigOption<String> WAREHOUSE =
+            ConfigOptions.key("warehouse")
                     .stringType()
                     .noDefaultValue()
-                    .withDescription("The root path of catalog.");
+                    .withDescription("The warehouse root path of catalog.");
 
     @Override
     public String factoryIdentifier() {
-        return "table-store";
+        return IDENTIFIER;
     }
 
     @Override
     public Set<ConfigOption<?>> requiredOptions() {
         Set<ConfigOption<?>> options = new HashSet<>();
-        options.add(ROOT_PATH);
+        options.add(WAREHOUSE);
         return options;
     }
 
@@ -69,6 +71,6 @@ public class TableStoreCatalogFactory implements CatalogFactory {
         helper.validate();
         ReadableConfig options = helper.getOptions();
         return new FileSystemCatalog(
-                context.getName(), new Path(options.get(ROOT_PATH)), options.get(DEFAULT_DATABASE));
+                context.getName(), new Path(options.get(WAREHOUSE)), options.get(DEFAULT_DATABASE));
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/TableStoreCatalogFactory.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/TableStoreCatalogFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.catalog;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.factories.CatalogFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.apache.flink.table.factories.FactoryUtil.PROPERTY_VERSION;
+
+/** Factory for {@link TableStoreCatalog}. */
+public class TableStoreCatalogFactory implements CatalogFactory {
+
+    public static final ConfigOption<String> DEFAULT_DATABASE =
+            ConfigOptions.key("default-database").stringType().defaultValue("default");
+
+    public static final ConfigOption<String> ROOT_PATH =
+            ConfigOptions.key("root-path")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The root path of catalog.");
+
+    @Override
+    public String factoryIdentifier() {
+        return "table-store";
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(ROOT_PATH);
+        return options;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(DEFAULT_DATABASE);
+        options.add(PROPERTY_VERSION);
+        return options;
+    }
+
+    @Override
+    public TableStoreCatalog createCatalog(Context context) {
+        FactoryUtil.CatalogFactoryHelper helper =
+                FactoryUtil.createCatalogFactoryHelper(this, context);
+        helper.validate();
+        ReadableConfig options = helper.getOptions();
+        return new FileSystemCatalog(
+                context.getName(), new Path(options.get(ROOT_PATH)), options.get(DEFAULT_DATABASE));
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/Schema.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/Schema.java
@@ -18,14 +18,12 @@
 
 package org.apache.flink.table.store.file.schema;
 
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.store.file.utils.JsonSerdeUtil;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.util.Preconditions;
 
 import java.io.Serializable;
@@ -188,16 +186,8 @@ public class Schema implements Serializable {
         return Objects.hash(fields, partitionKeys, primaryKeys, options, comment);
     }
 
-    public TableSchema getTableSchema() {
-        TableSchema.Builder builder = TableSchema.builder();
-        for (DataField field : fields) {
-            builder.field(
-                    field.name(), TypeConversions.fromLogicalToDataType(field.type().logicalType));
-        }
-        if (primaryKeys.size() > 0) {
-            builder.primaryKey(primaryKeys.toArray(new String[0]));
-        }
-        return builder.build();
+    public UpdateSchema toUpdateSchema() {
+        return new UpdateSchema(logicalRowType(), partitionKeys, primaryKeys, options, comment);
     }
 
     public static List<DataField> newFields(RowType rowType) {

--- a/flink-table-store-core/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-table-store-core/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -13,5 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.apache.flink.table.store.connector.TableStoreManagedFactory
-org.apache.flink.table.store.connector.TableStoreConnectorFactory
+org.apache.flink.table.store.file.catalog.TableStoreCatalogFactory

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/catalog/FileSystemCatalogTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/catalog/FileSystemCatalogTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.catalog;
+
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.catalog.CatalogTest;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+
+/** Test for {@link FileSystemCatalog}. */
+public class FileSystemCatalogTest extends TableStoreCatalogTest {
+
+    @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+    @BeforeClass
+    public static void beforeEach() throws IOException {
+        String path = TEMPORARY_FOLDER.newFolder().toURI().toString();
+        catalog = new FileSystemCatalog(CatalogTest.TEST_CATALOG_NAME, new Path(path));
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/catalog/TableStoreCatalogTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/catalog/TableStoreCatalogTest.java
@@ -1,0 +1,320 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.catalog;
+
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.catalog.CatalogDatabase;
+import org.apache.flink.table.catalog.CatalogDatabaseImpl;
+import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.CatalogTestBase;
+import org.apache.flink.table.catalog.CatalogTestUtil;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+/** Test for {@link TableStoreCatalog}. */
+public abstract class TableStoreCatalogTest extends CatalogTestBase {
+
+    @Override
+    protected boolean isGeneric() {
+        return false;
+    }
+
+    @Override
+    public CatalogDatabase createDb() {
+        return new CatalogDatabaseImpl(Collections.emptyMap(), "");
+    }
+
+    @Override
+    public CatalogTable createAnotherTable() {
+        // TODO support change schema, modify it to createAnotherSchema
+        ResolvedSchema resolvedSchema = this.createSchema();
+        CatalogTable origin =
+                CatalogTable.of(
+                        Schema.newBuilder().fromResolvedSchema(resolvedSchema).build(),
+                        "test comment",
+                        Collections.emptyList(),
+                        this.getBatchTableProperties());
+        return new ResolvedCatalogTable(origin, resolvedSchema);
+    }
+
+    @Override
+    public CatalogTable createAnotherPartitionedTable() {
+        // TODO support change schema, modify it to createAnotherSchema
+        ResolvedSchema resolvedSchema = this.createSchema();
+        CatalogTable origin =
+                CatalogTable.of(
+                        Schema.newBuilder().fromResolvedSchema(resolvedSchema).build(),
+                        "test comment",
+                        this.createPartitionKeys(),
+                        this.getBatchTableProperties());
+        return new ResolvedCatalogTable(origin, resolvedSchema);
+    }
+
+    @Override
+    public CatalogDatabase createAnotherDb() {
+        // Not support database with properties or comment
+        return new CatalogDatabaseImpl(new HashMap<String, String>() {}, null);
+    }
+
+    @Override
+    public void testAlterTable() throws Exception {
+        catalog.createDatabase("db1", this.createDb(), false);
+        CatalogTable table = this.createTable();
+        catalog.createTable(this.path1, table, false);
+        CatalogTestUtil.checkEquals(table, (CatalogTable) catalog.getTable(this.path1));
+        CatalogTable newTable = this.createAnotherTable();
+        catalog.alterTable(this.path1, newTable, false);
+        Assert.assertNotEquals(table, catalog.getTable(this.path1));
+        CatalogTestUtil.checkEquals(newTable, (CatalogTable) catalog.getTable(this.path1));
+        catalog.dropTable(this.path1, false);
+
+        // Not support views
+    }
+
+    @Test
+    public void testListTables() throws Exception {
+        catalog.createDatabase("db1", this.createDb(), false);
+        catalog.createTable(this.path1, this.createTable(), false);
+        catalog.createTable(this.path3, this.createTable(), false);
+        Assert.assertEquals(2L, catalog.listTables("db1").size());
+
+        // Not support views
+    }
+
+    @Override
+    public void testAlterTable_differentTypedTable() {
+        // TODO support this
+    }
+
+    // --------------------- unsupported methods ----------------------------
+
+    @Override
+    protected CatalogFunction createFunction() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected CatalogFunction createPythonFunction() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected CatalogFunction createAnotherFunction() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void testCreateView() {}
+
+    @Override
+    public void testAlterDb() {}
+
+    @Override
+    public void testAlterDb_DatabaseNotExistException() {}
+
+    @Override
+    public void testAlterDb_DatabaseNotExist_ignored() {}
+
+    @Override
+    public void testRenameTable_nonPartitionedTable() {}
+
+    @Override
+    public void testRenameTable_TableNotExistException_ignored() {}
+
+    @Override
+    public void testRenameTable_TableNotExistException() {}
+
+    @Override
+    public void testRenameTable_TableAlreadyExistException() {}
+
+    @Override
+    public void testCreateView_DatabaseNotExistException() {}
+
+    @Override
+    public void testCreateView_TableAlreadyExistException() {}
+
+    @Override
+    public void testCreateView_TableAlreadyExist_ignored() {}
+
+    @Override
+    public void testDropView() {}
+
+    @Override
+    public void testAlterView() {}
+
+    @Override
+    public void testAlterView_TableNotExistException() {}
+
+    @Override
+    public void testAlterView_TableNotExist_ignored() {}
+
+    @Override
+    public void testListView() {}
+
+    @Override
+    public void testRenameView() {}
+
+    @Override
+    public void testCreateFunction() {}
+
+    @Override
+    public void testCreatePythonFunction() {}
+
+    @Override
+    public void testCreateFunction_DatabaseNotExistException() {}
+
+    @Override
+    public void testCreateFunction_FunctionAlreadyExistException() {}
+
+    @Override
+    public void testAlterFunction() {}
+
+    @Override
+    public void testAlterPythonFunction() {}
+
+    @Override
+    public void testAlterFunction_FunctionNotExistException() {}
+
+    @Override
+    public void testAlterFunction_FunctionNotExist_ignored() {}
+
+    @Override
+    public void testListFunctions() {}
+
+    @Override
+    public void testListFunctions_DatabaseNotExistException() {}
+
+    @Override
+    public void testGetFunction_FunctionNotExistException() {}
+
+    @Override
+    public void testGetFunction_FunctionNotExistException_NoDb() {}
+
+    @Override
+    public void testDropFunction() {}
+
+    @Override
+    public void testDropFunction_FunctionNotExistException() {}
+
+    @Override
+    public void testDropFunction_FunctionNotExist_ignored() {}
+
+    @Override
+    public void testCreatePartition() {}
+
+    @Override
+    public void testCreatePartition_TableNotExistException() {}
+
+    @Override
+    public void testCreatePartition_TableNotPartitionedException() {}
+
+    @Override
+    public void testCreatePartition_PartitionSpecInvalidException() {}
+
+    @Override
+    public void testCreatePartition_PartitionAlreadyExistsException() {}
+
+    @Override
+    public void testCreatePartition_PartitionAlreadyExists_ignored() {}
+
+    @Override
+    public void testDropPartition() {}
+
+    @Override
+    public void testDropPartition_TableNotExist() {}
+
+    @Override
+    public void testDropPartition_TableNotPartitioned() {}
+
+    @Override
+    public void testDropPartition_PartitionSpecInvalid() {}
+
+    @Override
+    public void testDropPartition_PartitionNotExist() {}
+
+    @Override
+    public void testDropPartition_PartitionNotExist_ignored() {}
+
+    @Override
+    public void testAlterPartition() {}
+
+    @Override
+    public void testAlterPartition_TableNotExist() {}
+
+    @Override
+    public void testAlterPartition_TableNotPartitioned() {}
+
+    @Override
+    public void testAlterPartition_PartitionSpecInvalid() {}
+
+    @Override
+    public void testAlterPartition_PartitionNotExist() {}
+
+    @Override
+    public void testAlterPartition_PartitionNotExist_ignored() {}
+
+    @Override
+    public void testGetPartition_TableNotExist() {}
+
+    @Override
+    public void testGetPartition_TableNotPartitioned() {}
+
+    @Override
+    public void testGetPartition_PartitionSpecInvalid_invalidPartitionSpec() {}
+
+    @Override
+    public void testGetPartition_PartitionSpecInvalid_sizeNotEqual() {}
+
+    @Override
+    public void testGetPartition_PartitionNotExist() {}
+
+    @Override
+    public void testPartitionExists() {}
+
+    @Override
+    public void testListPartitionPartialSpec() {}
+
+    @Override
+    public void testGetTableStats_TableNotExistException() {}
+
+    @Override
+    public void testGetPartitionStats() {}
+
+    @Override
+    public void testAlterTableStats() {}
+
+    @Override
+    public void testAlterTableStats_partitionedTable() {}
+
+    @Override
+    public void testAlterPartitionTableStats() {}
+
+    @Override
+    public void testAlterTableStats_TableNotExistException() {}
+
+    @Override
+    public void testAlterTableStats_TableNotExistException_ignore() {}
+}


### PR DESCRIPTION
The Table Store has store the schema and other information on the file system so that it can actually provide a FileSystemCatalog for users to use.

This catalog is provided in JIRA:
- It supports database related management
- It supports the creation and deletion of tables
- It supports table changes, but currently can only modify the options and other information, the underlying does not yet support the schema column information modification

The use case for filesystem catalog:

```
CREATE CATALOG table_store WITH (
   'type' = 'table-store',
   'root-path' = '/root-path/'
);

USE CATALOG table_store;
```

### File Table
```
— create table dir: path '${db_name}.db/${table_name}'
— create schema file in table dir
CREATE TABLE T1 (
    a INT,
    b INT
);

— delete table dir
DROP TABLE T1;
```
### File Table with Kafka Log
```
— create table dir and schema file
— with kafka existing topic
CREATE TABLE T2 (
    a INT,
    b INT
) WITH (
    'log.system' = 'kafka',
    'log.kafka.bootstrap.servers' = '...',
    'log.topic' = 'my_topic'
);

— delete table dir
DROP TABLE T2;
……
```