### PR TITLE
[FLINK-27557] Submit compaction when prepareCommit is triggered

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/AbstractTableStoreFactory.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/AbstractTableStoreFactory.java
@@ -155,7 +155,7 @@ public abstract class AbstractTableStoreFactory
                                 Map.Entry::getValue));
     }
 
-    static TableStore buildTableStore(DynamicTableFactory.Context context) {
+    TableStore buildTableStore(DynamicTableFactory.Context context) {
         TableStore store =
                 new TableStore(
                         context.getObjectIdentifier(),

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStore.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStore.java
@@ -214,7 +214,7 @@ public class TableStore {
         }
     }
 
-    private FileStore buildFileStore() {
+    FileStore buildFileStore() {
         WriteMode writeMode = options.get(TableStoreFactoryOptions.WRITE_MODE);
 
         switch (writeMode) {

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/TableStoreSink.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/TableStoreSink.java
@@ -127,7 +127,8 @@ public class TableStoreSink
                             });
         }
         // Do not sink to log store when overwrite mode
-        final LogSinkProvider finalLogSinkProvider = overwrite ? null : logSinkProvider;
+        final LogSinkProvider finalLogSinkProvider =
+                overwrite || tableStore.isCompactionTask() ? null : logSinkProvider;
         return (DataStreamSinkProvider)
                 (providerContext, dataStream) ->
                         tableStore

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/StaticFileStoreSplitEnumerator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/StaticFileStoreSplitEnumerator.java
@@ -44,7 +44,7 @@ public class StaticFileStoreSplitEnumerator
 
     public StaticFileStoreSplitEnumerator(
             SplitEnumeratorContext<FileStoreSourceSplit> context,
-            Snapshot snapshot,
+            @Nullable Snapshot snapshot,
             Collection<FileStoreSourceSplit> splits) {
         this.context = context;
         this.snapshot = snapshot;

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/AlterTableCompactITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/AlterTableCompactITCase.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector;
+
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.store.file.utils.SnapshotFinder;
+import org.apache.flink.types.Row;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.flink.table.store.file.FileStoreOptions.relativeTablePath;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** ITCase for 'ALTER TABLE ... COMPACT'. */
+public class AlterTableCompactITCase extends FileStoreTableITCase {
+
+    @Override
+    protected List<String> ddl() {
+        return Arrays.asList(
+                "CREATE TABLE IF NOT EXISTS T0 (f0 INT, f1 STRING, f2 DOUBLE)",
+                "CREATE TABLE IF NOT EXISTS T1 ("
+                        + "f0 INT, f1 STRING, f2 STRING) PARTITIONED BY (f1)",
+                "CREATE TABLE IF NOT EXISTS T2 ("
+                        + "f0 INT, f1 STRING, f2 STRING) PARTITIONED BY (f1, f0)");
+    }
+
+    @Test
+    public void testNonPartitioned() throws Exception {
+        batchSql("INSERT INTO T0 VALUES (1, 'Pride and Prejudice', 9.0), (2, 'Emma', 8.5)");
+        batchSql(
+                "INSERT INTO T0 VALUES (3, 'The Mansfield Park', 7.0), (4, 'Sense and Sensibility', 9.0)");
+        batchSql("INSERT INTO T0 VALUES (5, 'Northanger Abby', 8.6)");
+        batchSql("INSERT INTO T0 VALUES (6, 'Jane Eyre', 9.9)");
+
+        Long snapshot = findLatestSnapshotId("T0");
+        List<Row> expected = batchSql("SELECT * FROM T0", 6);
+
+        batchSql("ALTER TABLE T0 SET ('num-sorted-run.compaction-trigger' = '2')");
+        batchSql("ALTER TABLE T0 COMPACT");
+
+        assertThat(batchSql("SELECT * FROM T0", 6)).containsExactlyInAnyOrderElementsOf(expected);
+        assertThat(findLatestSnapshotId("T0")).isEqualTo(snapshot + 2);
+    }
+
+    @Test
+    public void testSinglePartitioned() throws Exception {
+        batchSql("ALTER TABLE T1 SET ('num-levels' = '3')");
+
+        // increase trigger to avoid compaction
+        batchSql("ALTER TABLE T1 SET ('num-sorted-run.compaction-trigger' = '20')");
+        batchSql("ALTER TABLE T1 SET ('num-sorted-run.stop-trigger' = '20')");
+        batchSql(
+                "INSERT INTO T1 VALUES (1, 'Winter', 'Winter is Coming'),"
+                        + " (2, 'Winter', 'The First Snowflake'),"
+                        + " (2, 'Spring', 'The First Rose in Spring'),"
+                        + " (7, 'Summer', 'Summertime Sadness')");
+        batchSql("INSERT INTO T1 VALUES (12, 'Winter', 'Last Christmas')");
+        batchSql("INSERT INTO T1 VALUES (11, 'Winter', 'Winter is Coming')");
+        batchSql("INSERT INTO T1 VALUES (10, 'Autumn', 'Refrain')");
+        batchSql(
+                "INSERT INTO T1 VALUES (6, 'Summer', 'Watermelon Sugar'),"
+                        + " (4, 'Spring', 'Spring Water')");
+        batchSql(
+                "INSERT INTO T1 VALUES (66, 'Summer', 'Summer Vibe'),"
+                        + " (9, 'Autumn', 'Wake Me Up When September Ends')");
+        batchSql(
+                "INSERT INTO T1 VALUES (666, 'Summer', 'Summer Vibe'),"
+                        + " (9, 'Autumn', 'Wake Me Up When September Ends')");
+        batchSql(
+                "INSERT INTO T1 VALUES (6666, 'Summer', 'Summer Vibe'),"
+                        + " (9, 'Autumn', 'Wake Me Up When September Ends')");
+        batchSql(
+                "INSERT INTO T1 VALUES (66666, 'Summer', 'Summer Vibe'),"
+                        + " (9, 'Autumn', 'Wake Me Up When September Ends')");
+        batchSql(
+                "INSERT INTO T1 VALUES (666666, 'Summer', 'Summer Vibe'),"
+                        + " (9, 'Autumn', 'Wake Me Up When September Ends')");
+        batchSql(
+                "INSERT INTO T1 VALUES (6666666, 'Summer', 'Summer Vibe'),"
+                        + " (9, 'Autumn', 'Wake Me Up When September Ends')");
+
+        Long snapshot1 = findLatestSnapshotId("T1");
+        List<Row> expectedSummer = batchSql("SELECT * FROM T1 WHERE f1 = 'Summer'", 8);
+        List<Row> expectedFourSeasons = batchSql("SELECT * FROM T1", 21);
+
+        // revert to default
+        batchSql("ALTER TABLE T1 RESET ('num-sorted-run.compaction-trigger')");
+
+        // compact a single partition
+        batchSql("ALTER TABLE T1 PARTITION (f1 = 'Summer') COMPACT");
+        assertThat(batchSql("SELECT * FROM T1 WHERE f1 = 'Summer'", 8))
+                .containsExactlyElementsOf(expectedSummer);
+        Long snapshot2 = findLatestSnapshotId("T1");
+        assertThat(snapshot2).isEqualTo(snapshot1 + 2);
+
+        // compact whole table
+        batchSql("ALTER TABLE T1 SET ('num-sorted-run.compaction-trigger' = '1')");
+        batchSql("ALTER TABLE T1 COMPACT");
+        assertThat(batchSql("SELECT * FROM T1", 21))
+                .containsExactlyInAnyOrderElementsOf(expectedFourSeasons);
+        Long snapshot3 = findLatestSnapshotId("T1");
+        assertThat(snapshot3).isEqualTo(snapshot2 + 2);
+
+        // compact again will not generate new snapshot
+        batchSql("ALTER TABLE T1 COMPACT");
+        assertThat(findLatestSnapshotId("T1")).isEqualTo(snapshot3);
+    }
+
+    @Test
+    public void testMultiPartitioned() throws Exception {
+        batchSql("ALTER TABLE T2 SET ('num-levels' = '3')");
+        // increase trigger to avoid compaction
+        batchSql("ALTER TABLE T2 SET ('num-sorted-run.compaction-trigger' = '20')");
+        batchSql("ALTER TABLE T2 SET ('num-sorted-run.stop-trigger' = '20')");
+
+        batchSql(
+                "INSERT INTO T2 VALUES (1, '2022-05-19', 'Hello'),"
+                        + " (2, '2022-05-19', 'Bye'),"
+                        + " (3, '2022-05-19', 'Meow')");
+
+        batchSql(
+                "INSERT INTO T2 VALUES (1, '2022-05-19', 'Bonjour'),"
+                        + " (2, '2022-05-19', 'Ciao'),"
+                        + " (3, '2022-05-19', 'Bark')");
+
+        batchSql(
+                "INSERT INTO T2 VALUES (1, '2022-05-20', 'Hasta la vista'),"
+                        + " (1, '2022-05-19', 'Bonjour'),"
+                        + " (2, '2022-05-19', 'Ciao'),"
+                        + " (3, '2022-05-19', 'Bark')");
+
+        Long snapshot1 = findLatestSnapshotId("T2");
+        List<Row> theSecond = batchSql("SELECT * FROM T2 WHERE f0 = 2", 3);
+
+        batchSql("ALTER TABLE T2 SET ('num-sorted-run.compaction-trigger' = '1')");
+        batchSql("ALTER TABLE T2 PARTITION (f0 = 2) COMPACT");
+        assertThat(batchSql("SELECT * FROM T2 WHERE f0 = 2", 3))
+                .containsExactlyInAnyOrderElementsOf(theSecond);
+        assertThat(findLatestSnapshotId("T2")).isEqualTo(snapshot1 + 2);
+    }
+
+    private Long findLatestSnapshotId(String tableName) throws IOException {
+        return SnapshotFinder.findLatest(
+                Path.fromLocalFile(
+                        new File(
+                                URI.create(
+                                        path
+                                                + relativeTablePath(
+                                                        ObjectIdentifier.of(
+                                                                bEnv.getCurrentCatalog(),
+                                                                bEnv.getCurrentDatabase(),
+                                                                tableName))
+                                                + "/snapshot"))));
+    }
+}

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileStoreTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileStoreTableITCase.java
@@ -44,13 +44,14 @@ public abstract class FileStoreTableITCase extends AbstractTestBase {
 
     protected TableEnvironment bEnv;
     protected TableEnvironment sEnv;
+    protected String path;
 
     @Before
     public void before() throws IOException {
         bEnv = TableEnvironment.create(EnvironmentSettings.newInstance().inBatchMode().build());
         sEnv = TableEnvironment.create(EnvironmentSettings.newInstance().inStreamingMode().build());
         sEnv.getConfig().getConfiguration().set(CHECKPOINTING_INTERVAL, Duration.ofMillis(100));
-        String path = TEMPORARY_FOLDER.newFolder().toURI().toString();
+        path = TEMPORARY_FOLDER.newFolder().toURI().toString();
         prepareEnv(bEnv, path);
         prepareEnv(sEnv, path);
     }

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/MockTableStoreManagedFactory.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/MockTableStoreManagedFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.store.file.data.DataFileMeta;
+import org.apache.flink.table.store.file.mergetree.MergeTreeOptions;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.table.store.file.TestKeyValueGenerator.DEFAULT_PART_TYPE;
+import static org.apache.flink.table.store.file.TestKeyValueGenerator.DEFAULT_ROW_TYPE;
+import static org.apache.flink.table.store.file.TestKeyValueGenerator.KEY_TYPE;
+
+/** Mock {@link TableStoreManagedFactory} to create {@link TestTableStore} for tests. */
+public class MockTableStoreManagedFactory extends TableStoreManagedFactory {
+
+    private final RowType partitionType;
+    private final RowType rowType;
+
+    public MockTableStoreManagedFactory() {
+        partitionType = DEFAULT_PART_TYPE;
+        rowType = DEFAULT_ROW_TYPE;
+    }
+
+    public MockTableStoreManagedFactory(RowType partitionType, RowType rowType) {
+        this.partitionType = partitionType;
+        this.rowType = rowType;
+    }
+
+    @Override
+    TableStore buildTableStore(Context context) {
+        return new TestTableStore(
+                context.getObjectIdentifier(),
+                Configuration.fromMap(context.getCatalogTable().getOptions()),
+                partitionType,
+                KEY_TYPE,
+                rowType);
+    }
+
+    @Override
+    Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> pickManifest(
+            Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> groupBy,
+            MergeTreeOptions options,
+            Comparator<RowData> keyComparator) {
+        return Collections.emptyMap();
+    }
+}

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TestTableStore.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TestTableStore.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.store.file.FileStore;
+import org.apache.flink.table.store.file.FileStoreOptions;
+import org.apache.flink.table.store.file.TestFileStore;
+import org.apache.flink.table.store.file.mergetree.compact.DeduplicateMergeFunction;
+import org.apache.flink.table.types.logical.RowType;
+
+/** {@link TableStore} for tests. */
+public class TestTableStore extends TableStore {
+
+    private final Configuration options;
+    private final RowType partitionType;
+    private final RowType keyType;
+    private final RowType rowType;
+
+    public TestTableStore(
+            ObjectIdentifier tableIdentifier,
+            Configuration options,
+            RowType partitionType,
+            RowType keyType,
+            RowType rowType) {
+        super(tableIdentifier, options);
+        this.options = options;
+        this.partitionType = partitionType;
+        this.keyType = keyType;
+        this.rowType = rowType;
+    }
+
+    @Override
+    FileStore buildFileStore() {
+        return TestFileStore.create(
+                "avro",
+                options.getString(FileStoreOptions.PATH),
+                options.getInteger(FileStoreOptions.BUCKET),
+                partitionType,
+                keyType,
+                rowType,
+                new DeduplicateMergeFunction());
+    }
+}

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceTest.java
@@ -77,14 +77,14 @@ public class FileStoreSourceTest {
     @ParameterizedTest
     public void testSerDe(boolean hasPk, boolean partitioned, boolean specified)
             throws ClassNotFoundException, IOException {
-        FileStore fileStore = buildFileStore(hasPk, partitioned);
-        Long specifiedSnapshotId = specified ? 1L : null;
         Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> specifiedManifestEntries =
                 specified ? buildManifestEntries(hasPk, partitioned) : null;
+        Long specifiedSnapshotId = specified ? 1L : null;
         PartitionedManifestMeta partitionedManifestMeta =
                 specified
                         ? new PartitionedManifestMeta(specifiedSnapshotId, specifiedManifestEntries)
                         : null;
+        FileStore fileStore = buildFileStore(hasPk, partitioned, partitionedManifestMeta);
         FileStoreSource source =
                 new FileStoreSource(
                         fileStore,
@@ -138,7 +138,8 @@ public class FileStoreSourceTest {
                 Arguments.of(false, true, true));
     }
 
-    private FileStore buildFileStore(boolean hasPk, boolean partitioned) {
+    private FileStore buildFileStore(
+            boolean hasPk, boolean partitioned, PartitionedManifestMeta partitionedManifestMeta) {
         String user = "user";
         RowType partitionType = getPartitionType(partitioned);
         RowType keyType = getKeyType(hasPk);
@@ -154,7 +155,8 @@ public class FileStoreSourceTest {
                 partitionType,
                 keyType,
                 valueType,
-                mergeFunction);
+                mergeFunction,
+                partitionedManifestMeta);
     }
 
     private static Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> buildManifestEntries(

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/TestDataReadWrite.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/TestDataReadWrite.java
@@ -107,7 +107,8 @@ public class TestDataReadWrite {
                         avro,
                         pathFactory,
                         null, // not used, we only create an empty writer
-                        options)
+                        options,
+                        null)
                 .createEmptyWriter(partition, bucket, service);
     }
 }

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/TestDataReadWrite.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/TestDataReadWrite.java
@@ -77,7 +77,7 @@ public class TestDataReadWrite {
                 WriteMode.CHANGE_LOG,
                 KEY_TYPE,
                 VALUE_TYPE,
-                COMPARATOR,
+                () -> COMPARATOR,
                 new DeduplicateMergeFunction(),
                 avro,
                 pathFactory);

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreImpl.java
@@ -20,11 +20,7 @@ package org.apache.flink.table.store.file;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
-import org.apache.flink.table.runtime.generated.RecordComparator;
-import org.apache.flink.table.store.codegen.CodeGenUtils;
 import org.apache.flink.table.store.file.manifest.ManifestFile;
 import org.apache.flink.table.store.file.manifest.ManifestList;
 import org.apache.flink.table.store.file.mergetree.compact.DeduplicateMergeFunction;
@@ -37,13 +33,16 @@ import org.apache.flink.table.store.file.operation.FileStoreReadImpl;
 import org.apache.flink.table.store.file.operation.FileStoreScanImpl;
 import org.apache.flink.table.store.file.operation.FileStoreWriteImpl;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
+import org.apache.flink.table.store.file.utils.KeyComparatorSupplier;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 
 import javax.annotation.Nullable;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /** File store implementation. */
@@ -58,7 +57,7 @@ public class FileStoreImpl implements FileStore {
     private final RowType keyType;
     private final RowType valueType;
     @Nullable private final MergeFunction mergeFunction;
-    private final GeneratedRecordComparator genRecordComparator;
+    private final Supplier<Comparator<RowData>> keyComparatorSupplier;
 
     public FileStoreImpl(
             String tablePath,
@@ -79,9 +78,7 @@ public class FileStoreImpl implements FileStore {
         this.keyType = keyType;
         this.valueType = valueType;
         this.mergeFunction = mergeFunction;
-        this.genRecordComparator =
-                CodeGenUtils.generateRecordComparator(
-                        new TableConfig(), keyType.getChildren(), "KeyComparator");
+        this.keyComparatorSupplier = new KeyComparatorSupplier(keyType);
     }
 
     public FileStorePathFactory pathFactory() {
@@ -103,17 +100,13 @@ public class FileStoreImpl implements FileStore {
         return new ManifestList.Factory(partitionType, options.manifestFormat(), pathFactory());
     }
 
-    private RecordComparator newKeyComparator() {
-        return genRecordComparator.newInstance(Thread.currentThread().getContextClassLoader());
-    }
-
     @Override
     public FileStoreWriteImpl newWrite() {
         return new FileStoreWriteImpl(
                 writeMode,
                 keyType,
                 valueType,
-                this::newKeyComparator,
+                keyComparatorSupplier,
                 mergeFunction,
                 options.fileFormat(),
                 pathFactory(),
@@ -127,7 +120,7 @@ public class FileStoreImpl implements FileStore {
                 writeMode,
                 keyType,
                 valueType,
-                newKeyComparator(),
+                keyComparatorSupplier,
                 mergeFunction,
                 options.fileFormat(),
                 pathFactory());

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/CompactManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/CompactManager.java
@@ -97,23 +97,25 @@ public class CompactManager {
 
                             if (LOG.isDebugEnabled()) {
                                 LOG.debug(
-                                        "Submit compaction with files (level, size): "
+                                        "Submit compaction with files (name, level, size): "
                                                 + levels.levelSortedRuns().stream()
                                                         .flatMap(lsr -> lsr.run().files().stream())
                                                         .map(
                                                                 file ->
                                                                         String.format(
-                                                                                "(%d, %d)",
+                                                                                "(%s, %d, %d)",
+                                                                                file.fileName(),
                                                                                 file.level(),
                                                                                 file.fileSize()))
                                                         .collect(Collectors.joining(", ")));
                                 LOG.debug(
-                                        "Pick these files (level, size) for compaction: "
+                                        "Pick these files (name, level, size) for compaction: "
                                                 + unit.files().stream()
                                                         .map(
                                                                 file ->
                                                                         String.format(
-                                                                                "(%d, %d)",
+                                                                                "(%s, %d, %d)",
+                                                                                file.fileName(),
                                                                                 file.level(),
                                                                                 file.fileSize()))
                                                         .collect(Collectors.joining(", ")));

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/CompactUnit.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/CompactUnit.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /** A files unit for compaction. */
-interface CompactUnit {
+public interface CompactUnit {
 
     int outputLevel();
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreReadImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreReadImpl.java
@@ -39,13 +39,14 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.Supplier;
 
 /** Default implementation of {@link FileStoreRead}. */
 public class FileStoreReadImpl implements FileStoreRead {
 
     private final DataFileReader.Factory dataFileReaderFactory;
     private final WriteMode writeMode;
-    private final Comparator<RowData> keyComparator;
+    private final Supplier<Comparator<RowData>> keyComparatorSupplier;
     @Nullable private final MergeFunction mergeFunction;
 
     private boolean keyProjected;
@@ -55,14 +56,14 @@ public class FileStoreReadImpl implements FileStoreRead {
             WriteMode writeMode,
             RowType keyType,
             RowType valueType,
-            Comparator<RowData> keyComparator,
+            Supplier<Comparator<RowData>> keyComparatorSupplier,
             @Nullable MergeFunction mergeFunction,
             FileFormat fileFormat,
             FileStorePathFactory pathFactory) {
         this.dataFileReaderFactory =
                 new DataFileReader.Factory(keyType, valueType, fileFormat, pathFactory);
         this.writeMode = writeMode;
-        this.keyComparator = keyComparator;
+        this.keyComparatorSupplier = keyComparatorSupplier;
         this.mergeFunction = mergeFunction;
 
         this.keyProjected = false;
@@ -136,6 +137,7 @@ public class FileStoreReadImpl implements FileStoreRead {
         } else {
             // key projection is not applied, so data file readers will return key-values in order,
             // in this case merge tree can merge records with same key for us
+            Comparator<RowData> keyComparator = keyComparatorSupplier.get();
             return new MergeTreeReader(
                     new IntervalPartition(files, keyComparator).partition(),
                     dropDelete,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/FileStorePathFactory.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/FileStorePathFactory.java
@@ -61,18 +61,22 @@ public class FileStorePathFactory {
         this.root = root;
         this.uuid = UUID.randomUUID().toString();
 
-        String[] partitionColumns = partitionType.getFieldNames().toArray(new String[0]);
-        this.partitionComputer =
-                new RowDataPartitionComputer(
-                        defaultPartValue,
-                        partitionColumns,
-                        partitionType.getFields().stream()
-                                .map(f -> LogicalTypeDataTypeConverter.toDataType(f.getType()))
-                                .toArray(DataType[]::new),
-                        partitionColumns);
+        this.partitionComputer = getPartitionComputer(partitionType, defaultPartValue);
 
         this.manifestFileCount = new AtomicInteger(0);
         this.manifestListCount = new AtomicInteger(0);
+    }
+
+    public static RowDataPartitionComputer getPartitionComputer(
+            RowType partitionType, String defaultPartValue) {
+        String[] partitionColumns = partitionType.getFieldNames().toArray(new String[0]);
+        return new RowDataPartitionComputer(
+                defaultPartValue,
+                partitionColumns,
+                partitionType.getFields().stream()
+                        .map(f -> LogicalTypeDataTypeConverter.toDataType(f.getType()))
+                        .toArray(DataType[]::new),
+                partitionColumns);
     }
 
     public Path newManifestFile() {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/JsonSerdeUtil.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/JsonSerdeUtil.java
@@ -73,6 +73,8 @@ public class JsonSerdeUtil {
         SimpleModule module = new SimpleModule("Table store");
         registerJsonObjects(module, Schema.class, SchemaSerializer.INSTANCE);
         registerJsonObjects(module, DataField.class, DataFieldSerializer.INSTANCE);
+        registerJsonObjects(
+                module, PartitionedManifestMeta.class, PartitionedManifestMetaSerializer.INSTANCE);
         return module;
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/JsonSerializer.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/JsonSerializer.java
@@ -28,5 +28,5 @@ public interface JsonSerializer<T> {
 
     void serialize(T t, JsonGenerator generator) throws IOException;
 
-    T deserialize(JsonNode node);
+    T deserialize(JsonNode node) throws IOException;
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/KeyComparatorSupplier.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/KeyComparatorSupplier.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.utils;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
+import org.apache.flink.table.runtime.generated.RecordComparator;
+import org.apache.flink.table.store.codegen.CodeGenUtils;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.function.SerializableSupplier;
+
+import java.util.Comparator;
+import java.util.function.Supplier;
+
+/** A {@link Supplier} that returns the comparator for the file store key. */
+public class KeyComparatorSupplier implements SerializableSupplier<Comparator<RowData>> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final GeneratedRecordComparator genRecordComparator;
+
+    public KeyComparatorSupplier(RowType keyType) {
+        genRecordComparator =
+                CodeGenUtils.generateRecordComparator(
+                        new TableConfig(), keyType.getChildren(), "KeyComparator");
+    }
+
+    @Override
+    public RecordComparator get() {
+        return genRecordComparator.newInstance(Thread.currentThread().getContextClassLoader());
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/PartitionedManifestMetaSerializer.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/PartitionedManifestMetaSerializer.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.utils;
+
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.store.file.data.DataFileMeta;
+import org.apache.flink.table.store.file.data.DataFileMetaSerializer;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/** JSON serializer for {@link PartitionedManifestMeta}. */
+public class PartitionedManifestMetaSerializer implements JsonSerializer<PartitionedManifestMeta> {
+
+    private static final String SNAPSHOT_ID = "snapshotId";
+    private static final String MANIFEST_ENTRIES = "manifestEntries";
+    private static final String BUCKET_PREFIX = "bucket-";
+
+    public static final PartitionedManifestMetaSerializer INSTANCE =
+            new PartitionedManifestMetaSerializer();
+
+    @Override
+    public void serialize(PartitionedManifestMeta partitionedManifestMeta, JsonGenerator generator)
+            throws IOException {
+        DataFileMetaSerializer metaSerializer = new DataFileMetaSerializer();
+        Base64.Encoder encoder = Base64.getEncoder();
+        generator.writeStartObject();
+        generator.writeFieldName(SNAPSHOT_ID);
+        generator.writeNumber(partitionedManifestMeta.getSnapshotId());
+        generator.writeObjectFieldStart(MANIFEST_ENTRIES);
+        for (Map.Entry<BinaryRowData, Map<Integer, List<DataFileMeta>>> partEntry :
+                partitionedManifestMeta.getManifestEntries().entrySet()) {
+            generator.writeFieldName(
+                    encoder.encodeToString(
+                            SerializationUtils.serializeBinaryRow(partEntry.getKey())));
+            generator.writeStartObject();
+            for (Map.Entry<Integer, List<DataFileMeta>> bucketEntry :
+                    partEntry.getValue().entrySet()) {
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                metaSerializer.serializeList(
+                        bucketEntry.getValue(), new DataOutputViewStreamWrapper(out));
+                generator.writeStringField(
+                        BUCKET_PREFIX + bucketEntry.getKey(),
+                        encoder.encodeToString(out.toByteArray()));
+            }
+            generator.writeEndObject();
+        }
+        generator.writeEndObject();
+        generator.writeEndObject();
+    }
+
+    @Override
+    public PartitionedManifestMeta deserialize(JsonNode node) throws IOException {
+        DataFileMetaSerializer metaSerializer = new DataFileMetaSerializer();
+        Base64.Decoder decoder = Base64.getDecoder();
+        Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> manifestEntries = new HashMap<>();
+        Long snapshotId = node.get(SNAPSHOT_ID).asLong();
+
+        JsonNode manifestEntriesNode = node.get(MANIFEST_ENTRIES);
+        Iterator<Map.Entry<String, JsonNode>> partIter = manifestEntriesNode.fields();
+        while (partIter.hasNext()) {
+            Map.Entry<String, JsonNode> bucketNodeEntry = partIter.next();
+            BinaryRowData partition =
+                    SerializationUtils.deserializeBinaryRow(
+                            decoder.decode(bucketNodeEntry.getKey()));
+            Map<Integer, List<DataFileMeta>> bucketEntries = new HashMap<>();
+
+            Iterator<Map.Entry<String, JsonNode>> bucketIter = bucketNodeEntry.getValue().fields();
+            while (bucketIter.hasNext()) {
+                Map.Entry<String, JsonNode> manifestNodeEntry = bucketIter.next();
+                Integer bucket =
+                        Integer.parseInt(manifestNodeEntry.getKey().replace(BUCKET_PREFIX, ""));
+                bucketEntries.put(
+                        bucket,
+                        metaSerializer.deserializeList(
+                                new DataInputViewStreamWrapper(
+                                        new ByteArrayInputStream(
+                                                decoder.decode(
+                                                        manifestNodeEntry.getValue().asText())))));
+            }
+            manifestEntries.put(partition, bucketEntries);
+        }
+        return new PartitionedManifestMeta(snapshotId, manifestEntries);
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/KeyValueSerializerTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/KeyValueSerializerTest.java
@@ -32,7 +32,7 @@ public class KeyValueSerializerTest extends ObjectSerializerTestBase<KeyValue> {
     @Override
     protected ObjectSerializer<KeyValue> serializer() {
         return new KeyValueSerializer(
-                TestKeyValueGenerator.KEY_TYPE, TestKeyValueGenerator.ROW_TYPE);
+                TestKeyValueGenerator.KEY_TYPE, TestKeyValueGenerator.DEFAULT_ROW_TYPE);
     }
 
     @Override
@@ -47,7 +47,7 @@ public class KeyValueSerializerTest extends ObjectSerializerTestBase<KeyValue> {
                                 expected,
                                 actual,
                                 TestKeyValueGenerator.KEY_SERIALIZER,
-                                TestKeyValueGenerator.ROW_SERIALIZER))
+                                TestKeyValueGenerator.DEFAULT_ROW_SERIALIZER))
                 .isTrue();
     }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -119,7 +119,8 @@ public class TestFileStore extends FileStoreImpl {
                 partitionType,
                 keyType,
                 valueType,
-                mergeFunction);
+                mergeFunction,
+                null);
         this.root = root;
         this.keySerializer = new RowDataSerializer(keyType);
         this.valueSerializer = new RowDataSerializer(valueType);

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestKeyValueGenerator.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestKeyValueGenerator.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.store.file;
 
 import org.apache.flink.table.data.GenericArrayData;
 import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.runtime.generated.RecordComparator;
@@ -34,10 +35,16 @@ import org.apache.flink.table.types.logical.VarCharType;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.table.store.file.TestKeyValueGenerator.GeneratorMode.MULTI_PARTITIONED;
+import static org.apache.flink.table.store.file.TestKeyValueGenerator.GeneratorMode.NON_PARTITIONED;
+import static org.apache.flink.table.store.file.TestKeyValueGenerator.GeneratorMode.SINGLE_PARTITIONED;
 
 /** Random {@link KeyValue} generator. */
 public class TestKeyValueGenerator {
@@ -53,7 +60,7 @@ public class TestKeyValueGenerator {
     // * itemId: long, any value
     // * price & amount: int[], [1 ~ 100, 1 ~ 10]
     // * comment: string, length from 10 to 1000
-    public static final RowType ROW_TYPE =
+    public static final RowType DEFAULT_ROW_TYPE =
             RowType.of(
                     new LogicalType[] {
                         new VarCharType(false, 8),
@@ -67,18 +74,22 @@ public class TestKeyValueGenerator {
                     new String[] {
                         "dt", "hr", "shopId", "orderId", "itemId", "priceAmount", "comment"
                     });
-    public static final RowType PARTITION_TYPE =
+    public static final RowType DEFAULT_PART_TYPE =
             RowType.of(
                     new LogicalType[] {new VarCharType(false, 8), new IntType(false)},
                     new String[] {"dt", "hr"});
+    public static final RowType SINGLE_PARTITIONED_ROW_TYPE = singlePartType(DEFAULT_ROW_TYPE);
+    public static final RowType SINGLE_PARTITIONED_PART_TYPE = singlePartType(DEFAULT_PART_TYPE);
+    public static final RowType NON_PARTITIONED_ROW_TYPE =
+            nonPartType(DEFAULT_PART_TYPE.getFieldCount());
+    public static final RowType NON_PARTITIONED_PART_TYPE = RowType.of();
     public static final RowType KEY_TYPE =
             RowType.of(
                     new LogicalType[] {new IntType(false), new BigIntType(false)},
                     new String[] {"key_shopId", "key_orderId"});
 
-    public static final RowDataSerializer ROW_SERIALIZER = new RowDataSerializer(ROW_TYPE);
-    private static final RowDataSerializer PARTITION_SERIALIZER =
-            new RowDataSerializer(PARTITION_TYPE);
+    public static final RowDataSerializer DEFAULT_ROW_SERIALIZER =
+            new RowDataSerializer(DEFAULT_ROW_TYPE);
     public static final RowDataSerializer KEY_SERIALIZER = new RowDataSerializer(KEY_TYPE);
     public static final RecordComparator KEY_COMPARATOR =
             (a, b) -> {
@@ -89,6 +100,7 @@ public class TestKeyValueGenerator {
                 return Long.compare(a.getLong(1), b.getLong(1));
             };
 
+    private final GeneratorMode mode;
     private final Random random;
 
     private final List<Order> addedOrders;
@@ -96,13 +108,42 @@ public class TestKeyValueGenerator {
 
     private long sequenceNumber;
 
+    private final RowDataSerializer rowSerializer;
+    private final RowDataSerializer partitionSerializer;
+
     public TestKeyValueGenerator() {
+        this(MULTI_PARTITIONED);
+    }
+
+    public TestKeyValueGenerator(GeneratorMode mode) {
+        this.mode = mode;
         this.random = new Random();
 
         this.addedOrders = new ArrayList<>();
         this.deletedOrders = new ArrayList<>();
 
         this.sequenceNumber = 0;
+
+        RowType rowType;
+        RowType partitionType;
+        switch (mode) {
+            case NON_PARTITIONED:
+                rowType = NON_PARTITIONED_ROW_TYPE;
+                partitionType = NON_PARTITIONED_PART_TYPE;
+                break;
+            case SINGLE_PARTITIONED:
+                rowType = SINGLE_PARTITIONED_ROW_TYPE;
+                partitionType = SINGLE_PARTITIONED_PART_TYPE;
+                break;
+            case MULTI_PARTITIONED:
+                rowType = DEFAULT_ROW_TYPE;
+                partitionType = DEFAULT_PART_TYPE;
+                break;
+            default:
+                throw new UnsupportedOperationException("Unsupported generator mode: " + mode);
+        }
+        rowSerializer = new RowDataSerializer(rowType);
+        partitionSerializer = new RowDataSerializer(partitionType);
     }
 
     public KeyValue next() {
@@ -140,31 +181,65 @@ public class TestKeyValueGenerator {
                                 .copy(),
                         sequenceNumber++,
                         kind,
-                        ROW_SERIALIZER
-                                .toBinaryRow(
-                                        GenericRowData.of(
-                                                StringData.fromString(order.dt),
-                                                order.hr,
-                                                order.shopId,
-                                                order.orderId,
-                                                order.itemId,
-                                                order.priceAmount == null
-                                                        ? null
-                                                        : new GenericArrayData(order.priceAmount),
-                                                StringData.fromString(order.comment)))
-                                .copy());
+                        rowSerializer.toBinaryRow(convertToRow(order)).copy());
+    }
+
+    private RowData convertToRow(Order order) {
+        List<Object> values =
+                new ArrayList<>(
+                        Arrays.asList(
+                                order.shopId,
+                                order.orderId,
+                                order.itemId,
+                                order.priceAmount == null
+                                        ? null
+                                        : new GenericArrayData(order.priceAmount),
+                                StringData.fromString(order.comment)));
+
+        if (mode == MULTI_PARTITIONED) {
+            values.add(0, StringData.fromString(order.dt));
+            values.add(1, order.hr);
+        } else if (mode == SINGLE_PARTITIONED) {
+            values.add(0, StringData.fromString(order.dt));
+        }
+        return GenericRowData.of(values.toArray(new Object[0]));
     }
 
     public BinaryRowData getPartition(KeyValue kv) {
-        return PARTITION_SERIALIZER
-                .toBinaryRow(GenericRowData.of(kv.value().getString(0), kv.value().getInt(1)))
-                .copy();
+        Object[] values;
+        if (mode == MULTI_PARTITIONED) {
+            values = new Object[] {kv.value().getString(0), kv.value().getInt(1)};
+        } else if (mode == SINGLE_PARTITIONED) {
+            values = new Object[] {kv.value().getString(0)};
+        } else {
+            values = new Object[0];
+        }
+        return partitionSerializer.toBinaryRow(GenericRowData.of(values)).copy();
     }
 
-    public static Map<String, String> toPartitionMap(BinaryRowData partition) {
+    public static List<String> getPrimaryKeys(GeneratorMode mode) {
+        List<String> trimmedPk =
+                KEY_TYPE.getFieldNames().stream()
+                        .map(f -> f.replaceFirst("key_", ""))
+                        .collect(Collectors.toList());
+        if (mode != NON_PARTITIONED) {
+            trimmedPk = new ArrayList<>(trimmedPk);
+            trimmedPk.addAll(
+                    mode == MULTI_PARTITIONED
+                            ? DEFAULT_PART_TYPE.getFieldNames()
+                            : SINGLE_PARTITIONED_PART_TYPE.getFieldNames());
+        }
+        return trimmedPk;
+    }
+
+    public static Map<String, String> toPartitionMap(BinaryRowData partition, GeneratorMode mode) {
         Map<String, String> map = new HashMap<>();
-        map.put("dt", partition.getString(0).toString());
-        map.put("hr", String.valueOf(partition.getInt(1)));
+        if (mode == MULTI_PARTITIONED) {
+            map.put("dt", partition.getString(0).toString());
+            map.put("hr", String.valueOf(partition.getInt(1)));
+        } else if (mode == SINGLE_PARTITIONED) {
+            map.put("dt", partition.getString(0).toString());
+        }
         return map;
     }
 
@@ -184,6 +259,17 @@ public class TestKeyValueGenerator {
         list.set(idx, list.get(list.size() - 1));
         list.remove(list.size() - 1);
         return tmp;
+    }
+
+    private static RowType nonPartType(int to) {
+        List<RowType.RowField> fields = TestKeyValueGenerator.DEFAULT_PART_TYPE.getFields();
+        return new RowType(fields.subList(2, to));
+    }
+
+    private static RowType singlePartType(RowType type) {
+        List<RowType.RowField> fields = new ArrayList<>(type.getFields());
+        fields.remove(1);
+        return new RowType(fields);
     }
 
     private class Order {
@@ -219,5 +305,12 @@ public class TestKeyValueGenerator {
                             : new int[] {random.nextInt(100) + 1, random.nextInt(100) + 1};
             comment = random.nextInt(10) == 0 ? null : randomString(random.nextInt(1001 - 10) + 10);
         }
+    }
+
+    /** Generator mode for {@link TestKeyValueGenerator}. */
+    public enum GeneratorMode {
+        NON_PARTITIONED,
+        SINGLE_PARTITIONED,
+        MULTI_PARTITIONED
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileTest.java
@@ -80,7 +80,7 @@ public class DataFileTest {
 
         checkRollingFiles(
                 TestKeyValueGenerator.KEY_TYPE,
-                TestKeyValueGenerator.ROW_TYPE,
+                TestKeyValueGenerator.DEFAULT_ROW_TYPE,
                 data.meta,
                 actualMetas,
                 writer.suggestedFileSize());
@@ -90,7 +90,7 @@ public class DataFileTest {
                 data,
                 actualMetas,
                 TestKeyValueGenerator.KEY_SERIALIZER,
-                TestKeyValueGenerator.ROW_SERIALIZER,
+                TestKeyValueGenerator.DEFAULT_ROW_SERIALIZER,
                 serializer,
                 reader,
                 kv -> kv);
@@ -136,7 +136,7 @@ public class DataFileTest {
                 data,
                 actualMetas,
                 projectedKeySerializer,
-                TestKeyValueGenerator.ROW_SERIALIZER,
+                TestKeyValueGenerator.DEFAULT_ROW_SERIALIZER,
                 serializer,
                 fileReader,
                 kv ->
@@ -202,7 +202,7 @@ public class DataFileTest {
         int suggestedFileSize = ThreadLocalRandom.current().nextInt(8192) + 1024;
         return new DataFileWriter.Factory(
                         TestKeyValueGenerator.KEY_TYPE,
-                        TestKeyValueGenerator.ROW_TYPE,
+                        TestKeyValueGenerator.DEFAULT_ROW_TYPE,
                         // normal format will buffer changes in memory and we can't determine
                         // if the written file size is really larger than suggested, so we use a
                         // special format which flushes for every added element
@@ -218,7 +218,7 @@ public class DataFileTest {
         DataFileReader.Factory factory =
                 new DataFileReader.Factory(
                         TestKeyValueGenerator.KEY_TYPE,
-                        TestKeyValueGenerator.ROW_TYPE,
+                        TestKeyValueGenerator.DEFAULT_ROW_TYPE,
                         new FlushingFileFormat(format),
                         pathFactory);
         if (keyProjection != null) {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileTestDataGenerator.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileTestDataGenerator.java
@@ -102,7 +102,7 @@ public class DataFileTestDataGenerator {
         FieldStatsCollector keyStatsCollector =
                 new FieldStatsCollector(TestKeyValueGenerator.KEY_TYPE);
         FieldStatsCollector valueStatsCollector =
-                new FieldStatsCollector(TestKeyValueGenerator.ROW_TYPE);
+                new FieldStatsCollector(TestKeyValueGenerator.DEFAULT_ROW_TYPE);
         long totalSize = 0;
         BinaryRowData minKey = null;
         BinaryRowData maxKey = null;

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestFileTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestFileTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.store.file.manifest;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.table.store.file.TestKeyValueGenerator;
 import org.apache.flink.table.store.file.format.FileFormat;
 import org.apache.flink.table.store.file.stats.StatsTestUtils;
 import org.apache.flink.table.store.file.utils.FailingAtomicRenameFileSystem;
@@ -36,6 +35,7 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.table.store.file.TestKeyValueGenerator.DEFAULT_PART_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link ManifestFile}. */
@@ -93,11 +93,9 @@ public class ManifestFileTest {
 
     private ManifestFile createManifestFile(String path) {
         FileStorePathFactory pathFactory =
-                new FileStorePathFactory(
-                        new Path(path), TestKeyValueGenerator.PARTITION_TYPE, "default");
+                new FileStorePathFactory(new Path(path), DEFAULT_PART_TYPE, "default");
         int suggestedFileSize = ThreadLocalRandom.current().nextInt(8192) + 1024;
-        return new ManifestFile.Factory(
-                        TestKeyValueGenerator.PARTITION_TYPE, avro, pathFactory, suggestedFileSize)
+        return new ManifestFile.Factory(DEFAULT_PART_TYPE, avro, pathFactory, suggestedFileSize)
                 .create();
     }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestListTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestListTest.java
@@ -92,8 +92,8 @@ public class ManifestListTest {
     private ManifestList createManifestList(String path) {
         FileStorePathFactory pathFactory =
                 new FileStorePathFactory(
-                        new Path(path), TestKeyValueGenerator.PARTITION_TYPE, "default");
-        return new ManifestList.Factory(TestKeyValueGenerator.PARTITION_TYPE, avro, pathFactory)
+                        new Path(path), TestKeyValueGenerator.DEFAULT_PART_TYPE, "default");
+        return new ManifestList.Factory(TestKeyValueGenerator.DEFAULT_PART_TYPE, avro, pathFactory)
                 .create();
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestTestDataGenerator.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestTestDataGenerator.java
@@ -83,7 +83,7 @@ public class ManifestTestDataGenerator {
                 !entries.isEmpty(), "Manifest entries are empty. Invalid test data.");
 
         FieldStatsCollector collector =
-                new FieldStatsCollector(TestKeyValueGenerator.PARTITION_TYPE);
+                new FieldStatsCollector(TestKeyValueGenerator.DEFAULT_PART_TYPE);
 
         long numAddedFiles = 0;
         long numDeletedFiles = 0;

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/MergeTreeTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/MergeTreeTest.java
@@ -266,7 +266,8 @@ public class MergeTreeTest {
                 new DeduplicateMergeFunction(),
                 dataFileWriter,
                 options.commitForceCompact,
-                options.numSortedRunStopTrigger);
+                options.numSortedRunStopTrigger,
+                false);
     }
 
     private CompactManager createCompactManager(

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreCommitTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreCommitTest.java
@@ -276,9 +276,9 @@ public class FileStoreCommitTest {
                 "avro",
                 root,
                 numBucket,
-                TestKeyValueGenerator.PARTITION_TYPE,
+                TestKeyValueGenerator.DEFAULT_PART_TYPE,
                 TestKeyValueGenerator.KEY_TYPE,
-                TestKeyValueGenerator.ROW_TYPE,
+                TestKeyValueGenerator.DEFAULT_ROW_TYPE,
                 new DeduplicateMergeFunction());
     }
 
@@ -310,7 +310,10 @@ public class FileStoreCommitTest {
 
         LOG.debug("========== Beginning of " + name + " ==========");
         for (KeyValue kv : supplier.get()) {
-            LOG.debug(kv.toString(TestKeyValueGenerator.KEY_TYPE, TestKeyValueGenerator.ROW_TYPE));
+            LOG.debug(
+                    kv.toString(
+                            TestKeyValueGenerator.KEY_TYPE,
+                            TestKeyValueGenerator.DEFAULT_ROW_TYPE));
         }
         LOG.debug("========== End of " + name + " ==========");
     }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreExpireTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreExpireTest.java
@@ -58,9 +58,9 @@ public class FileStoreExpireTest {
                         "avro",
                         tempDir.toString(),
                         1,
-                        TestKeyValueGenerator.PARTITION_TYPE,
+                        TestKeyValueGenerator.DEFAULT_PART_TYPE,
                         TestKeyValueGenerator.KEY_TYPE,
-                        TestKeyValueGenerator.ROW_TYPE,
+                        TestKeyValueGenerator.DEFAULT_ROW_TYPE,
                         new DeduplicateMergeFunction());
         pathFactory = store.pathFactory();
     }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreReadTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreReadTest.java
@@ -133,9 +133,9 @@ public class FileStoreReadTest {
         }
         TestFileStore store =
                 createStore(
-                        TestKeyValueGenerator.PARTITION_TYPE,
+                        TestKeyValueGenerator.DEFAULT_PART_TYPE,
                         TestKeyValueGenerator.KEY_TYPE,
-                        TestKeyValueGenerator.ROW_TYPE,
+                        TestKeyValueGenerator.DEFAULT_ROW_TYPE,
                         new DeduplicateMergeFunction());
 
         RowDataSerializer projectedValueSerializer =

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreScanTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreScanTest.java
@@ -65,9 +65,9 @@ public class FileStoreScanTest {
                         "avro",
                         tempDir.toString(),
                         NUM_BUCKETS,
-                        TestKeyValueGenerator.PARTITION_TYPE,
+                        TestKeyValueGenerator.DEFAULT_PART_TYPE,
                         TestKeyValueGenerator.KEY_TYPE,
-                        TestKeyValueGenerator.ROW_TYPE,
+                        TestKeyValueGenerator.DEFAULT_ROW_TYPE,
                         new DeduplicateMergeFunction());
         pathFactory = store.pathFactory();
     }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
@@ -38,6 +38,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
 
+import static org.apache.flink.table.store.file.TestKeyValueGenerator.GeneratorMode.MULTI_PARTITIONED;
+
 /** Testing {@link Thread}s to perform concurrent commits. */
 public class TestCommitThread extends Thread {
 
@@ -114,7 +116,7 @@ public class TestCommitThread extends Thread {
                 committable,
                 () ->
                         commit.overwrite(
-                                TestKeyValueGenerator.toPartitionMap(partition),
+                                TestKeyValueGenerator.toPartitionMap(partition, MULTI_PARTITIONED),
                                 committable,
                                 Collections.emptyMap()));
     }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/PartitionedManifestMetaSerializationTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/PartitionedManifestMetaSerializationTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.utils;
+
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.store.file.data.DataFileMeta;
+import org.apache.flink.table.store.file.data.DataFileTestDataGenerator;
+
+import org.junit.jupiter.api.RepeatedTest;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** JSON serialization test for {@link PartitionedManifestMeta}. */
+public class PartitionedManifestMetaSerializationTest {
+
+    @RepeatedTest(10)
+    public void testJsonSerDe() {
+        PartitionedManifestMeta partitionedMeta =
+                new PartitionedManifestMeta(new Random().nextLong(), genManifestEntries());
+        assertThat(
+                        JsonSerdeUtil.fromJson(
+                                JsonSerdeUtil.toJson(partitionedMeta),
+                                PartitionedManifestMeta.class))
+                .isEqualTo(partitionedMeta);
+    }
+
+    private static Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> genManifestEntries() {
+        Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> manifestEntries = new HashMap<>();
+        DataFileTestDataGenerator gen =
+                DataFileTestDataGenerator.builder()
+                        .numBuckets(new Random().nextInt(16) + 1)
+                        .build();
+        IntStream.range(0, new Random().nextInt(1000))
+                .boxed()
+                .map(i -> gen.next())
+                .forEach(
+                        data ->
+                                manifestEntries
+                                        .computeIfAbsent(data.partition, entry -> new HashMap<>())
+                                        .computeIfAbsent(data.bucket, entry -> new ArrayList<>())
+                                        .add(data.meta));
+        return manifestEntries;
+    }
+}

--- a/flink-table-store-hive/src/main/java/org/apache/flink/table/store/mapred/TableStoreInputFormat.java
+++ b/flink-table-store-hive/src/main/java/org/apache/flink/table/store/mapred/TableStoreInputFormat.java
@@ -172,7 +172,8 @@ public class TableStoreInputFormat implements InputFormat<Void, RowDataContainer
                                 partitionType,
                                 primaryKeyType,
                                 rowType,
-                                options.get(FileStoreOptions.MERGE_ENGINE));
+                                options.get(FileStoreOptions.MERGE_ENGINE),
+                                null); // TODO
                 valueCountMode = false;
             } else {
                 store =
@@ -182,7 +183,8 @@ public class TableStoreInputFormat implements InputFormat<Void, RowDataContainer
                                 new FileStoreOptions(options),
                                 user,
                                 partitionType,
-                                rowType);
+                                rowType,
+                                null); // TODO
                 valueCountMode = true;
             }
         }

--- a/flink-table-store-hive/src/test/java/org/apache/flink/table/store/FileStoreTestHelper.java
+++ b/flink-table-store-hive/src/test/java/org/apache/flink/table/store/FileStoreTestHelper.java
@@ -77,7 +77,8 @@ public class FileStoreTestHelper {
                         partitionType,
                         keyType,
                         valueType,
-                        mergeFunction);
+                        mergeFunction,
+                        null);
         this.partitionCalculator = partitionCalculator;
         this.bucketCalculator = bucketCalculator;
         this.writers = new HashMap<>();


### PR DESCRIPTION
Currently, `FileStoreWrite` will scan and plan files when creating a non-empty writer. We should also create a non-empty writer for non-rescale compaction cases but instead use the pre-planned manifest entries.

The sink records should be dumped, and when `prepareCommit` is invoked, it should trigger `submitCompaction`, which will generate two snapshots. The first commit kind is `ADD` with empty new files. The second commit kind is `COMPACT` with specified manifest entries marked as deleted and compacted files marked as added.