### PR TITLE
[FLINK-27371] Record schema id in ManifestFileMeta and DataFileMeta

### DIFF
--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/TestFileStore.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/TestFileStore.java
@@ -215,6 +215,7 @@ public class TestFileStore implements FileStore {
                                                     newEmptyTableStats(3),
                                                     0,
                                                     0,
+                                                    0,
                                                     0))
                             .collect(Collectors.toList());
             return new Increment(newFiles, Collections.emptyList(), Collections.emptyList());

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitGeneratorTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitGeneratorTest.java
@@ -129,6 +129,7 @@ public class FileStoreSourceSplitGeneratorTest {
                         StatsTestUtils.newEmptyTableStats(), // not used
                         0, // not used
                         0, // not used
+                        0, // not used
                         0 // not used
                         ));
     }

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitSerializerTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitSerializerTest.java
@@ -82,6 +82,7 @@ public class FileStoreSourceSplitSerializerTest {
                 StatsTestUtils.newEmptyTableStats(),
                 0,
                 1,
+                0,
                 level);
     }
 

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/TestChangelogDataReadWrite.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/TestChangelogDataReadWrite.java
@@ -35,6 +35,7 @@ import org.apache.flink.table.store.file.mergetree.compact.DeduplicateMergeFunct
 import org.apache.flink.table.store.file.operation.FileStoreRead;
 import org.apache.flink.table.store.file.operation.FileStoreReadImpl;
 import org.apache.flink.table.store.file.operation.FileStoreWriteImpl;
+import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 import org.apache.flink.table.store.file.utils.RecordReader;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
@@ -66,6 +67,7 @@ public class TestChangelogDataReadWrite {
             Comparator.comparingLong(o -> o.getLong(0));
 
     private final FileFormat avro;
+    private final Path tablePath;
     private final FileStorePathFactory pathFactory;
     private final SnapshotManager snapshotManager;
     private final ExecutorService service;
@@ -76,9 +78,10 @@ public class TestChangelogDataReadWrite {
                         Thread.currentThread().getContextClassLoader(),
                         "avro",
                         new Configuration());
+        this.tablePath = new Path(root);
         this.pathFactory =
                 new FileStorePathFactory(
-                        new Path(root),
+                        tablePath,
                         RowType.of(new IntType()),
                         "default",
                         FileStoreOptions.FILE_FORMAT.defaultValue());
@@ -99,6 +102,8 @@ public class TestChangelogDataReadWrite {
                     rowDataIteratorCreator) {
         FileStoreRead read =
                 new FileStoreReadImpl(
+                        new SchemaManager(tablePath),
+                        0,
                         WriteMode.CHANGE_LOG,
                         KEY_TYPE,
                         VALUE_TYPE,
@@ -143,6 +148,8 @@ public class TestChangelogDataReadWrite {
         MergeTreeOptions options = new MergeTreeOptions(new Configuration());
         return new FileStoreWriteImpl(
                         WriteMode.CHANGE_LOG,
+                        new SchemaManager(tablePath),
+                        0,
                         KEY_TYPE,
                         VALUE_TYPE,
                         () -> COMPARATOR,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileMeta.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileMeta.java
@@ -56,6 +56,7 @@ public class DataFileMeta {
 
     private final long minSequenceNumber;
     private final long maxSequenceNumber;
+    private final long schemaId;
     private final int level;
 
     public static DataFileMeta forAppend(
@@ -64,7 +65,8 @@ public class DataFileMeta {
             long rowCount,
             BinaryTableStats rowStats,
             long minSequenceNumber,
-            long maxSequenceNumber) {
+            long maxSequenceNumber,
+            long schemaId) {
         return new DataFileMeta(
                 fileName,
                 fileSize,
@@ -75,6 +77,7 @@ public class DataFileMeta {
                 rowStats,
                 minSequenceNumber,
                 maxSequenceNumber,
+                schemaId,
                 DUMMY_LEVEL);
     }
 
@@ -88,6 +91,7 @@ public class DataFileMeta {
             BinaryTableStats valueStats,
             long minSequenceNumber,
             long maxSequenceNumber,
+            long schemaId,
             int level) {
         this.fileName = fileName;
         this.fileSize = fileSize;
@@ -101,6 +105,7 @@ public class DataFileMeta {
         this.minSequenceNumber = minSequenceNumber;
         this.maxSequenceNumber = maxSequenceNumber;
         this.level = level;
+        this.schemaId = schemaId;
     }
 
     public String fileName() {
@@ -139,6 +144,10 @@ public class DataFileMeta {
         return maxSequenceNumber;
     }
 
+    public long schemaId() {
+        return schemaId;
+    }
+
     public int level() {
         return level;
     }
@@ -155,6 +164,7 @@ public class DataFileMeta {
                 valueStats,
                 minSequenceNumber,
                 maxSequenceNumber,
+                schemaId,
                 newLevel);
     }
 
@@ -173,6 +183,7 @@ public class DataFileMeta {
                 && Objects.equals(valueStats, that.valueStats)
                 && minSequenceNumber == that.minSequenceNumber
                 && maxSequenceNumber == that.maxSequenceNumber
+                && schemaId == that.schemaId
                 && level == that.level;
     }
 
@@ -188,13 +199,14 @@ public class DataFileMeta {
                 valueStats,
                 minSequenceNumber,
                 maxSequenceNumber,
+                schemaId,
                 level);
     }
 
     @Override
     public String toString() {
         return String.format(
-                "{%s, %d, %d, %s, %s, %s, %s, %d, %d, %d}",
+                "{%s, %d, %d, %s, %s, %s, %s, %d, %d, %d, %d}",
                 fileName,
                 fileSize,
                 rowCount,
@@ -204,6 +216,7 @@ public class DataFileMeta {
                 valueStats,
                 minSequenceNumber,
                 maxSequenceNumber,
+                schemaId,
                 level);
     }
 
@@ -218,6 +231,7 @@ public class DataFileMeta {
         fields.add(new RowType.RowField("_VALUE_STATS", FieldStatsArraySerializer.schema()));
         fields.add(new RowType.RowField("_MIN_SEQUENCE_NUMBER", new BigIntType(false)));
         fields.add(new RowType.RowField("_MAX_SEQUENCE_NUMBER", new BigIntType(false)));
+        fields.add(new RowType.RowField("_SCHEMA_ID", new BigIntType(false)));
         fields.add(new RowType.RowField("_LEVEL", new IntType(false)));
         return new RowType(fields);
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileMetaSerializer.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileMetaSerializer.java
@@ -48,6 +48,7 @@ public class DataFileMetaSerializer extends ObjectSerializer<DataFileMeta> {
                 meta.valueStats().toRowData(),
                 meta.minSequenceNumber(),
                 meta.maxSequenceNumber(),
+                meta.schemaId(),
                 meta.level());
     }
 
@@ -63,6 +64,7 @@ public class DataFileMetaSerializer extends ObjectSerializer<DataFileMeta> {
                 BinaryTableStats.fromRowData(row.getRow(6, 3)),
                 row.getLong(7),
                 row.getLong(8),
-                row.getInt(9));
+                row.getLong(9),
+                row.getInt(10));
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileWriter.java
@@ -57,6 +57,7 @@ public class DataFileWriter {
 
     private static final Logger LOG = LoggerFactory.getLogger(DataFileWriter.class);
 
+    private final long schemaId;
     private final RowType keyType;
     private final RowType valueType;
     private final BulkWriter.Factory<RowData> writerFactory;
@@ -67,12 +68,14 @@ public class DataFileWriter {
     private final long suggestedFileSize;
 
     private DataFileWriter(
+            long schemaId,
             RowType keyType,
             RowType valueType,
             BulkWriter.Factory<RowData> writerFactory,
             @Nullable FileStatsExtractor fileStatsExtractor,
             DataFilePathFactory pathFactory,
             long suggestedFileSize) {
+        this.schemaId = schemaId;
         this.keyType = keyType;
         this.valueType = valueType;
         this.writerFactory = writerFactory;
@@ -199,6 +202,7 @@ public class DataFileWriter {
                     valueStats,
                     minSeqNumber,
                     maxSeqNumber,
+                    schemaId,
                     level);
         }
     }
@@ -235,6 +239,7 @@ public class DataFileWriter {
     /** Creates {@link DataFileWriter}. */
     public static class Factory {
 
+        private final long schemaId;
         private final RowType keyType;
         private final RowType valueType;
         private final FileFormat fileFormat;
@@ -242,11 +247,13 @@ public class DataFileWriter {
         private final long suggestedFileSize;
 
         public Factory(
+                long schemaId,
                 RowType keyType,
                 RowType valueType,
                 FileFormat fileFormat,
                 FileStorePathFactory pathFactory,
                 long suggestedFileSize) {
+            this.schemaId = schemaId;
             this.keyType = keyType;
             this.valueType = valueType;
             this.fileFormat = fileFormat;
@@ -257,6 +264,7 @@ public class DataFileWriter {
         public DataFileWriter create(BinaryRowData partition, int bucket) {
             RowType recordType = KeyValue.schema(keyType, valueType);
             return new DataFileWriter(
+                    schemaId,
                     keyType,
                     valueType,
                     fileFormat.createWriterFactory(recordType),

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestFileMeta.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestFileMeta.java
@@ -39,18 +39,21 @@ public class ManifestFileMeta {
     private final long numAddedFiles;
     private final long numDeletedFiles;
     private final BinaryTableStats partitionStats;
+    private final long schemaId;
 
     public ManifestFileMeta(
             String fileName,
             long fileSize,
             long numAddedFiles,
             long numDeletedFiles,
-            BinaryTableStats partitionStats) {
+            BinaryTableStats partitionStats,
+            long schemaId) {
         this.fileName = fileName;
         this.fileSize = fileSize;
         this.numAddedFiles = numAddedFiles;
         this.numDeletedFiles = numDeletedFiles;
         this.partitionStats = partitionStats;
+        this.schemaId = schemaId;
     }
 
     public String fileName() {
@@ -73,6 +76,10 @@ public class ManifestFileMeta {
         return partitionStats;
     }
 
+    public long schemaId() {
+        return schemaId;
+    }
+
     public static RowType schema() {
         List<RowType.RowField> fields = new ArrayList<>();
         fields.add(new RowType.RowField("_FILE_NAME", new VarCharType(false, Integer.MAX_VALUE)));
@@ -80,6 +87,7 @@ public class ManifestFileMeta {
         fields.add(new RowType.RowField("_NUM_ADDED_FILES", new BigIntType(false)));
         fields.add(new RowType.RowField("_NUM_DELETED_FILES", new BigIntType(false)));
         fields.add(new RowType.RowField("_PARTITION_STATS", FieldStatsArraySerializer.schema()));
+        fields.add(new RowType.RowField("_SCHEMA_ID", new BigIntType(false)));
         return new RowType(fields);
     }
 
@@ -93,19 +101,21 @@ public class ManifestFileMeta {
                 && fileSize == that.fileSize
                 && numAddedFiles == that.numAddedFiles
                 && numDeletedFiles == that.numDeletedFiles
-                && Objects.equals(partitionStats, that.partitionStats);
+                && Objects.equals(partitionStats, that.partitionStats)
+                && schemaId == that.schemaId;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(fileName, fileSize, numAddedFiles, numDeletedFiles, partitionStats);
+        return Objects.hash(
+                fileName, fileSize, numAddedFiles, numDeletedFiles, partitionStats, schemaId);
     }
 
     @Override
     public String toString() {
         return String.format(
-                "{%s, %d, %d, %d, %s}",
-                fileName, fileSize, numAddedFiles, numDeletedFiles, partitionStats);
+                "{%s, %d, %d, %d, %s, %d}",
+                fileName, fileSize, numAddedFiles, numDeletedFiles, partitionStats, schemaId);
     }
 
     /**

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestFileMetaSerializer.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestFileMetaSerializer.java
@@ -40,13 +40,13 @@ public class ManifestFileMetaSerializer extends VersionedObjectSerializer<Manife
 
     @Override
     public RowData convertTo(ManifestFileMeta meta) {
-        GenericRowData row = new GenericRowData(5);
-        row.setField(0, StringData.fromString(meta.fileName()));
-        row.setField(1, meta.fileSize());
-        row.setField(2, meta.numAddedFiles());
-        row.setField(3, meta.numDeletedFiles());
-        row.setField(4, meta.partitionStats().toRowData());
-        return row;
+        return GenericRowData.of(
+                StringData.fromString(meta.fileName()),
+                meta.fileSize(),
+                meta.numAddedFiles(),
+                meta.numDeletedFiles(),
+                meta.partitionStats().toRowData(),
+                meta.schemaId());
     }
 
     @Override
@@ -65,6 +65,7 @@ public class ManifestFileMetaSerializer extends VersionedObjectSerializer<Manife
                 row.getLong(1),
                 row.getLong(2),
                 row.getLong(3),
-                BinaryTableStats.fromRowData(row.getRow(4, 3)));
+                BinaryTableStats.fromRowData(row.getRow(4, 3)),
+                row.getLong(5));
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreReadImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreReadImpl.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.store.file.mergetree.MergeTreeReader;
 import org.apache.flink.table.store.file.mergetree.compact.ConcatRecordReader;
 import org.apache.flink.table.store.file.mergetree.compact.IntervalPartition;
 import org.apache.flink.table.store.file.mergetree.compact.MergeFunction;
+import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 import org.apache.flink.table.store.file.utils.RecordReader;
 import org.apache.flink.table.types.logical.RowType;
@@ -53,6 +54,8 @@ public class FileStoreReadImpl implements FileStoreRead {
     private boolean dropDelete = true;
 
     public FileStoreReadImpl(
+            SchemaManager schemaManager,
+            long schemaId,
             WriteMode writeMode,
             RowType keyType,
             RowType valueType,
@@ -61,7 +64,8 @@ public class FileStoreReadImpl implements FileStoreRead {
             FileFormat fileFormat,
             FileStorePathFactory pathFactory) {
         this.dataFileReaderFactory =
-                new DataFileReader.Factory(keyType, valueType, fileFormat, pathFactory);
+                new DataFileReader.Factory(
+                        schemaManager, schemaId, keyType, valueType, fileFormat, pathFactory);
         this.writeMode = writeMode;
         this.keyComparator = keyComparator;
         this.mergeFunction = mergeFunction;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/writer/AppendOnlyWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/writer/AppendOnlyWriter.java
@@ -43,6 +43,7 @@ import java.util.function.Supplier;
  * operations and don't have any unique keys or sort keys.
  */
 public class AppendOnlyWriter implements RecordWriter {
+    private final long schemaId;
     private final long targetFileSize;
     private final DataFilePathFactory pathFactory;
     private final FieldStatsArraySerializer statsArraySerializer;
@@ -53,12 +54,13 @@ public class AppendOnlyWriter implements RecordWriter {
     private RowRollingWriter writer;
 
     public AppendOnlyWriter(
+            long schemaId,
             FileFormat fileFormat,
             long targetFileSize,
             RowType writeSchema,
             long maxWroteSeqNumber,
             DataFilePathFactory pathFactory) {
-
+        this.schemaId = schemaId;
         this.targetFileSize = targetFileSize;
         this.pathFactory = pathFactory;
         this.statsArraySerializer = new FieldStatsArraySerializer(writeSchema);
@@ -158,7 +160,8 @@ public class AppendOnlyWriter implements RecordWriter {
                     recordCount(),
                     stats,
                     minSeqNum,
-                    Math.max(minSeqNum, nextSeqNum - 1));
+                    Math.max(minSeqNum, nextSeqNum - 1),
+                    schemaId);
         }
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTable.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.store.file.ValueKind;
 import org.apache.flink.table.store.file.WriteMode;
 import org.apache.flink.table.store.file.predicate.Predicate;
 import org.apache.flink.table.store.file.schema.Schema;
+import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.utils.RecordReader;
 import org.apache.flink.table.store.file.writer.RecordWriter;
 import org.apache.flink.table.store.table.sink.SinkRecord;
@@ -46,10 +47,11 @@ public class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
 
     private final FileStoreImpl store;
 
-    AppendOnlyFileStoreTable(String name, Schema schema, String user) {
+    AppendOnlyFileStoreTable(String name, SchemaManager schemaManager, Schema schema, String user) {
         super(name, schema);
         this.store =
                 new FileStoreImpl(
+                        schemaManager,
                         schema.id(),
                         new FileStoreOptions(schema.options()),
                         WriteMode.APPEND_ONLY,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTable.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.store.file.mergetree.compact.MergeFunction;
 import org.apache.flink.table.store.file.mergetree.compact.ValueCountMergeFunction;
 import org.apache.flink.table.store.file.predicate.Predicate;
 import org.apache.flink.table.store.file.schema.Schema;
+import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.utils.RecordReader;
 import org.apache.flink.table.store.file.writer.RecordWriter;
 import org.apache.flink.table.store.table.sink.SinkRecord;
@@ -48,7 +49,8 @@ public class ChangelogValueCountFileStoreTable extends AbstractFileStoreTable {
 
     private final FileStoreImpl store;
 
-    ChangelogValueCountFileStoreTable(String name, Schema schema, String user) {
+    ChangelogValueCountFileStoreTable(
+            String name, SchemaManager schemaManager, Schema schema, String user) {
         super(name, schema);
         RowType countType =
                 RowType.of(
@@ -56,6 +58,7 @@ public class ChangelogValueCountFileStoreTable extends AbstractFileStoreTable {
         MergeFunction mergeFunction = new ValueCountMergeFunction();
         this.store =
                 new FileStoreImpl(
+                        schemaManager,
                         schema.id(),
                         new FileStoreOptions(schema.options()),
                         WriteMode.CHANGE_LOG,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.store.file.mergetree.compact.PartialUpdateMergeFun
 import org.apache.flink.table.store.file.predicate.Predicate;
 import org.apache.flink.table.store.file.predicate.PredicateBuilder;
 import org.apache.flink.table.store.file.schema.Schema;
+import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.utils.RecordReader;
 import org.apache.flink.table.store.file.writer.RecordWriter;
 import org.apache.flink.table.store.table.sink.SinkRecord;
@@ -54,7 +55,8 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
 
     private final FileStoreImpl store;
 
-    ChangelogWithKeyFileStoreTable(String name, Schema schema, String user) {
+    ChangelogWithKeyFileStoreTable(
+            String name, SchemaManager schemaManager, Schema schema, String user) {
         super(name, schema);
         RowType rowType = schema.logicalRowType();
 
@@ -92,6 +94,7 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
 
         this.store =
                 new FileStoreImpl(
+                        schemaManager,
                         schema.id(),
                         new FileStoreOptions(conf),
                         WriteMode.CHANGE_LOG,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/FileStoreTableFactory.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/FileStoreTableFactory.java
@@ -39,8 +39,9 @@ public class FileStoreTableFactory {
     public static FileStoreTable create(Configuration conf, String user) {
         Path tablePath = FileStoreOptions.path(conf);
         String name = tablePath.getName();
+        SchemaManager schemaManager = new SchemaManager(tablePath);
         Schema schema =
-                new SchemaManager(tablePath)
+                schemaManager
                         .latest()
                         .orElseThrow(
                                 () ->
@@ -55,12 +56,12 @@ public class FileStoreTableFactory {
         schema = schema.copy(newOptions);
 
         if (conf.get(FileStoreOptions.WRITE_MODE) == WriteMode.APPEND_ONLY) {
-            return new AppendOnlyFileStoreTable(name, schema, user);
+            return new AppendOnlyFileStoreTable(name, schemaManager, schema, user);
         } else {
             if (schema.primaryKeys().isEmpty()) {
-                return new ChangelogValueCountFileStoreTable(name, schema, user);
+                return new ChangelogValueCountFileStoreTable(name, schemaManager, schema, user);
             } else {
-                return new ChangelogWithKeyFileStoreTable(name, schema, user);
+                return new ChangelogWithKeyFileStoreTable(name, schemaManager, schema, user);
             }
         }
     }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -36,6 +36,7 @@ import org.apache.flink.table.store.file.operation.FileStoreExpireImpl;
 import org.apache.flink.table.store.file.operation.FileStoreRead;
 import org.apache.flink.table.store.file.operation.FileStoreScan;
 import org.apache.flink.table.store.file.operation.FileStoreWrite;
+import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 import org.apache.flink.table.store.file.utils.RecordReaderIterator;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
@@ -111,6 +112,7 @@ public class TestFileStore extends FileStoreImpl {
             RowType valueType,
             MergeFunction mergeFunction) {
         super(
+                new SchemaManager(options.path()),
                 0L,
                 options,
                 WriteMode.CHANGE_LOG,

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.store.file.KeyValue;
 import org.apache.flink.table.store.file.KeyValueSerializerTest;
 import org.apache.flink.table.store.file.TestKeyValueGenerator;
 import org.apache.flink.table.store.file.format.FlushingFileFormat;
+import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.stats.FieldStatsArraySerializer;
 import org.apache.flink.table.store.file.stats.StatsTestUtils;
 import org.apache.flink.table.store.file.utils.FailingAtomicRenameFileSystem;
@@ -207,6 +208,7 @@ public class DataFileTest {
                         format);
         int suggestedFileSize = ThreadLocalRandom.current().nextInt(8192) + 1024;
         return new DataFileWriter.Factory(
+                        0,
                         TestKeyValueGenerator.KEY_TYPE,
                         TestKeyValueGenerator.DEFAULT_ROW_TYPE,
                         // normal format will buffer changes in memory and we can't determine
@@ -223,6 +225,8 @@ public class DataFileTest {
         FileStorePathFactory pathFactory = new FileStorePathFactory(new Path(path));
         DataFileReader.Factory factory =
                 new DataFileReader.Factory(
+                        new SchemaManager(new Path(path)),
+                        0,
                         TestKeyValueGenerator.KEY_TYPE,
                         TestKeyValueGenerator.DEFAULT_ROW_TYPE,
                         new FlushingFileFormat(format),

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileTestDataGenerator.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileTestDataGenerator.java
@@ -137,6 +137,7 @@ public class DataFileTestDataGenerator {
                         valueStatsCollector.extract(),
                         minSequenceNumber,
                         maxSequenceNumber,
+                        0,
                         level),
                 kvs);
     }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestCommittableSerializerTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestCommittableSerializerTest.java
@@ -96,6 +96,7 @@ public class ManifestCommittableSerializerTest {
                 newTableStats(0, 1),
                 0,
                 1,
+                0,
                 level);
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestFileMetaTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestFileMetaTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.store.file.FileStoreOptions;
 import org.apache.flink.table.store.file.ValueKind;
 import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.format.FileFormat;
+import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.stats.StatsTestUtils;
 import org.apache.flink.table.store.file.utils.FailingAtomicRenameFileSystem;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
@@ -143,6 +144,8 @@ public class ManifestFileMetaTest {
 
     private ManifestFile createManifestFile(String path) {
         return new ManifestFile.Factory(
+                        new SchemaManager(new Path(path)),
+                        0,
                         PARTITION_TYPE,
                         avro,
                         new FileStorePathFactory(
@@ -222,7 +225,8 @@ public class ManifestFileMetaTest {
                 entries.length * 100, // for testing purpose
                 writtenMeta.numAddedFiles(),
                 writtenMeta.numDeletedFiles(),
-                writtenMeta.partitionStats());
+                writtenMeta.partitionStats(),
+                0);
     }
 
     private ManifestEntry makeEntry(boolean isAdd, String fileName) {
@@ -244,6 +248,7 @@ public class ManifestFileMetaTest {
                         binaryRowData, // not used
                         StatsTestUtils.newEmptyTableStats(), // not used
                         StatsTestUtils.newEmptyTableStats(), // not used
+                        0, // not used
                         0, // not used
                         0, // not used
                         0 // not used

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestFileTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestFileTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.store.file.FileStoreOptions;
 import org.apache.flink.table.store.file.format.FileFormat;
+import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.stats.StatsTestUtils;
 import org.apache.flink.table.store.file.utils.FailingAtomicRenameFileSystem;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
@@ -100,7 +101,13 @@ public class ManifestFileTest {
                         "default",
                         FileStoreOptions.FILE_FORMAT.defaultValue());
         int suggestedFileSize = ThreadLocalRandom.current().nextInt(8192) + 1024;
-        return new ManifestFile.Factory(DEFAULT_PART_TYPE, avro, pathFactory, suggestedFileSize)
+        return new ManifestFile.Factory(
+                        new SchemaManager(new Path(path)),
+                        0,
+                        DEFAULT_PART_TYPE,
+                        avro,
+                        pathFactory,
+                        suggestedFileSize)
                 .create();
     }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestTestDataGenerator.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestTestDataGenerator.java
@@ -101,7 +101,8 @@ public class ManifestTestDataGenerator {
                 entries.size() * 100L,
                 numAddedFiles,
                 numDeletedFiles,
-                collector.extract());
+                collector.extract(),
+                0);
     }
 
     private void mergeLevelsIfNeeded(BinaryRowData partition, int bucket) {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/LevelsTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/LevelsTest.java
@@ -62,6 +62,6 @@ public class LevelsTest {
     }
 
     public static DataFileMeta newFile(int level) {
-        return new DataFileMeta("", 0, 1, row(0), row(0), null, null, 0, 1, level);
+        return new DataFileMeta("", 0, 1, row(0), row(0), null, null, 0, 1, 0, level);
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/CompactManagerTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/CompactManagerTest.java
@@ -214,6 +214,7 @@ public class CompactManagerTest {
                 null,
                 0,
                 maxSequence,
+                0,
                 level);
     }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/IntervalPartitionTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/IntervalPartitionTest.java
@@ -176,6 +176,7 @@ public class IntervalPartitionTest {
                 StatsTestUtils.newEmptyTableStats(), // not used
                 0,
                 24,
+                0,
                 0);
     }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/UniversalCompactionTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/UniversalCompactionTest.java
@@ -227,6 +227,6 @@ public class UniversalCompactionTest {
     }
 
     private DataFileMeta file(long size) {
-        return new DataFileMeta("", size, 1, null, null, null, null, 0, 0, 0);
+        return new DataFileMeta("", size, 1, null, null, null, null, 0, 0, 0, 0);
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/writer/AppendOnlyWriterTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/writer/AppendOnlyWriterTest.java
@@ -226,6 +226,6 @@ public class AppendOnlyWriterTest {
                         Thread.currentThread().getContextClassLoader(), AVRO, new Configuration());
 
         return new AppendOnlyWriter(
-                fileFormat, targetFileSize, writeSchema, maxSeqNum, pathFactory);
+                0, fileFormat, targetFileSize, writeSchema, maxSeqNum, pathFactory);
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTableTest.java
@@ -173,15 +173,15 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         conf.set(FileStoreOptions.PATH, tablePath.toString());
         conf.set(FileStoreOptions.FILE_FORMAT, "avro");
         conf.set(FileStoreOptions.WRITE_MODE, WriteMode.APPEND_ONLY);
+        SchemaManager schemaManager = new SchemaManager(tablePath);
         Schema schema =
-                new SchemaManager(tablePath)
-                        .commitNewVersion(
-                                new UpdateSchema(
-                                        ROW_TYPE,
-                                        Collections.singletonList("pt"),
-                                        Collections.emptyList(),
-                                        conf.toMap(),
-                                        ""));
-        return new AppendOnlyFileStoreTable(tablePath.getName(), schema, "user");
+                schemaManager.commitNewVersion(
+                        new UpdateSchema(
+                                ROW_TYPE,
+                                Collections.singletonList("pt"),
+                                Collections.emptyList(),
+                                conf.toMap(),
+                                ""));
+        return new AppendOnlyFileStoreTable(tablePath.getName(), schemaManager, schema, "user");
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTableTest.java
@@ -170,15 +170,16 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
         conf.set(FileStoreOptions.PATH, tablePath.toString());
         conf.set(FileStoreOptions.FILE_FORMAT, "avro");
         conf.set(FileStoreOptions.WRITE_MODE, WriteMode.CHANGE_LOG);
+        SchemaManager schemaManager = new SchemaManager(tablePath);
         Schema schema =
-                new SchemaManager(tablePath)
-                        .commitNewVersion(
-                                new UpdateSchema(
-                                        ROW_TYPE,
-                                        Collections.singletonList("pt"),
-                                        Collections.emptyList(),
-                                        conf.toMap(),
-                                        ""));
-        return new ChangelogValueCountFileStoreTable(tablePath.getName(), schema, "user");
+                schemaManager.commitNewVersion(
+                        new UpdateSchema(
+                                ROW_TYPE,
+                                Collections.singletonList("pt"),
+                                Collections.emptyList(),
+                                conf.toMap(),
+                                ""));
+        return new ChangelogValueCountFileStoreTable(
+                tablePath.getName(), schemaManager, schema, "user");
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTableTest.java
@@ -180,15 +180,16 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         conf.set(FileStoreOptions.PATH, tablePath.toString());
         conf.set(FileStoreOptions.FILE_FORMAT, "avro");
         conf.set(FileStoreOptions.WRITE_MODE, WriteMode.CHANGE_LOG);
+        SchemaManager schemaManager = new SchemaManager(tablePath);
         Schema schema =
-                new SchemaManager(tablePath)
-                        .commitNewVersion(
-                                new UpdateSchema(
-                                        ROW_TYPE,
-                                        Collections.singletonList("pt"),
-                                        Arrays.asList("pt", "a"),
-                                        conf.toMap(),
-                                        ""));
-        return new ChangelogWithKeyFileStoreTable(tablePath.getName(), schema, "user");
+                schemaManager.commitNewVersion(
+                        new UpdateSchema(
+                                ROW_TYPE,
+                                Collections.singletonList("pt"),
+                                Arrays.asList("pt", "a"),
+                                conf.toMap(),
+                                ""));
+        return new ChangelogWithKeyFileStoreTable(
+                tablePath.getName(), schemaManager, schema, "user");
     }
 }

--- a/flink-table-store-format/src/test/java/org/apache/flink/table/store/format/FileFormatSuffixTest.java
+++ b/flink-table-store-format/src/test/java/org/apache/flink/table/store/format/FileFormatSuffixTest.java
@@ -66,7 +66,7 @@ public class FileFormatSuffixTest extends DataFileTest {
                         format,
                         new Configuration());
         AppendOnlyWriter appendOnlyWriter =
-                new AppendOnlyWriter(fileFormat, 10, SCHEMA, 10, dataFilePathFactory);
+                new AppendOnlyWriter(0, fileFormat, 10, SCHEMA, 10, dataFilePathFactory);
         appendOnlyWriter.write(
                 ValueKind.ADD,
                 BinaryRowDataUtil.EMPTY_ROW,


### PR DESCRIPTION
For future schema evolution, the schema id should be recorded inside the data, and when the schema changes, the previous schema can still be used to restore the existing data.

This PR just stuffs the schemaId into the Meta of the file, and the schema manager is also putted into the reader, but it's actually useless, the schema evolution hasn't been done yet.