### PR TITLE
[FLINK-27814] Add an abstraction layer for connectors to read and write row data instead of key-values

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStore.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStore.java
@@ -180,7 +180,6 @@ public class TableStore {
         FileStoreOptions fileStoreOptions = new FileStoreOptions(options);
 
         return FileStoreImpl.createWithAppendOnly(
-                fileStoreOptions.path().toString(),
                 schema.id(),
                 fileStoreOptions,
                 user,
@@ -195,15 +194,9 @@ public class TableStore {
 
         if (trimmedPrimaryKeys.length == 0) {
             return FileStoreImpl.createWithValueCount(
-                    fileStoreOptions.path().toString(),
-                    schema.id(),
-                    fileStoreOptions,
-                    user,
-                    partitionType,
-                    type);
+                    schema.id(), fileStoreOptions, user, partitionType, type);
         } else {
             return FileStoreImpl.createWithPrimaryKey(
-                    fileStoreOptions.path().toString(),
                     schema.id(),
                     fileStoreOptions,
                     user,
@@ -215,7 +208,7 @@ public class TableStore {
     }
 
     private FileStore buildFileStore() {
-        WriteMode writeMode = options.get(TableStoreFactoryOptions.WRITE_MODE);
+        WriteMode writeMode = options.get(FileStoreOptions.WRITE_MODE);
 
         switch (writeMode) {
             case CHANGE_LOG:
@@ -320,7 +313,7 @@ public class TableStore {
         }
 
         private Source<RowData, ?, ?> buildSource() {
-            WriteMode writeMode = options.get(TableStoreFactoryOptions.WRITE_MODE);
+            WriteMode writeMode = options.get(FileStoreOptions.WRITE_MODE);
             if (isContinuous) {
                 if (schema.primaryKeys().size() > 0 && mergeEngine() == PARTIAL_UPDATE) {
                     throw new ValidationException(
@@ -411,7 +404,7 @@ public class TableStore {
         public DataStreamSink<?> build() {
             FileStore fileStore = buildFileStore();
             int numBucket = options.get(BUCKET);
-            WriteMode writeMode = options.get(TableStoreFactoryOptions.WRITE_MODE);
+            WriteMode writeMode = options.get(FileStoreOptions.WRITE_MODE);
 
             BucketStreamPartitioner partitioner =
                     new BucketStreamPartitioner(

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreFactoryOptions.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreFactoryOptions.java
@@ -21,14 +21,10 @@ package org.apache.flink.table.store.connector;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
-import org.apache.flink.configuration.description.Description;
 import org.apache.flink.table.factories.FactoryUtil;
-import org.apache.flink.table.store.file.WriteMode;
 
 import java.util.HashSet;
 import java.util.Set;
-
-import static org.apache.flink.table.store.utils.OptionsUtils.formatEnumOption;
 
 /** Options for {@link TableStoreManagedFactory}. */
 public class TableStoreFactoryOptions {
@@ -66,18 +62,6 @@ public class TableStoreFactoryOptions {
                     .stringType()
                     .noDefaultValue()
                     .withDescription("The log system used to keep changes of the table.");
-
-    public static final ConfigOption<WriteMode> WRITE_MODE =
-            ConfigOptions.key("write-mode")
-                    .enumType(WriteMode.class)
-                    .defaultValue(WriteMode.CHANGE_LOG)
-                    .withDescription(
-                            Description.builder()
-                                    .text("Specify the write mode for table.")
-                                    .linebreak()
-                                    .list(formatEnumOption(WriteMode.APPEND_ONLY))
-                                    .list(formatEnumOption(WriteMode.CHANGE_LOG))
-                                    .build());
 
     public static final ConfigOption<Integer> SINK_PARALLELISM = FactoryUtil.SINK_PARALLELISM;
 

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreManagedFactory.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreManagedFactory.java
@@ -40,10 +40,10 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static org.apache.flink.table.store.connector.TableStoreFactoryOptions.ROOT_PATH;
-import static org.apache.flink.table.store.connector.TableStoreFactoryOptions.WRITE_MODE;
 import static org.apache.flink.table.store.file.FileStoreOptions.BUCKET;
 import static org.apache.flink.table.store.file.FileStoreOptions.PATH;
 import static org.apache.flink.table.store.file.FileStoreOptions.TABLE_STORE_PREFIX;
+import static org.apache.flink.table.store.file.FileStoreOptions.WRITE_MODE;
 import static org.apache.flink.table.store.log.LogOptions.LOG_PREFIX;
 
 /** Default implementation of {@link ManagedTableFactory}. */

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceTest.java
@@ -146,7 +146,6 @@ public class FileStoreSourceTest {
         MergeFunction mergeFunction =
                 hasPk ? new DeduplicateMergeFunction() : new ValueCountMergeFunction();
         return new FileStoreImpl(
-                "/fake/path",
                 0,
                 new FileStoreOptions(new Configuration()),
                 WriteMode.CHANGE_LOG,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreImpl.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.store.file;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
@@ -49,7 +48,6 @@ import java.util.stream.Collectors;
 /** File store implementation. */
 public class FileStoreImpl implements FileStore {
 
-    private final String tablePath;
     private final long schemaId;
     private final WriteMode writeMode;
     private final FileStoreOptions options;
@@ -61,7 +59,6 @@ public class FileStoreImpl implements FileStore {
     private final GeneratedRecordComparator genRecordComparator;
 
     public FileStoreImpl(
-            String tablePath,
             long schemaId,
             FileStoreOptions options,
             WriteMode writeMode,
@@ -70,7 +67,6 @@ public class FileStoreImpl implements FileStore {
             RowType keyType,
             RowType valueType,
             @Nullable MergeFunction mergeFunction) {
-        this.tablePath = tablePath;
         this.schemaId = schemaId;
         this.options = options;
         this.writeMode = writeMode;
@@ -86,7 +82,7 @@ public class FileStoreImpl implements FileStore {
 
     public FileStorePathFactory pathFactory() {
         return new FileStorePathFactory(
-                new Path(tablePath), partitionType, options.partitionDefaultName());
+                options.path(), partitionType, options.partitionDefaultName());
     }
 
     @VisibleForTesting
@@ -187,14 +183,12 @@ public class FileStoreImpl implements FileStore {
     }
 
     public static FileStoreImpl createWithAppendOnly(
-            String tablePath,
             long schemaId,
             FileStoreOptions options,
             String user,
             RowType partitionType,
             RowType rowType) {
         return new FileStoreImpl(
-                tablePath,
                 schemaId,
                 options,
                 WriteMode.APPEND_ONLY,
@@ -206,7 +200,6 @@ public class FileStoreImpl implements FileStore {
     }
 
     public static FileStoreImpl createWithPrimaryKey(
-            String tablePath,
             long schemaId,
             FileStoreOptions options,
             String user,
@@ -244,7 +237,6 @@ public class FileStoreImpl implements FileStore {
         }
 
         return new FileStoreImpl(
-                tablePath,
                 schemaId,
                 options,
                 WriteMode.CHANGE_LOG,
@@ -256,7 +248,6 @@ public class FileStoreImpl implements FileStore {
     }
 
     public static FileStoreImpl createWithValueCount(
-            String tablePath,
             long schemaId,
             FileStoreOptions options,
             String user,
@@ -267,7 +258,6 @@ public class FileStoreImpl implements FileStore {
                         new LogicalType[] {new BigIntType(false)}, new String[] {"_VALUE_COUNT"});
         MergeFunction mergeFunction = new ValueCountMergeFunction();
         return new FileStoreImpl(
-                tablePath,
                 schemaId,
                 options,
                 WriteMode.CHANGE_LOG,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStoreOptions.java
@@ -129,6 +129,18 @@ public class FileStoreOptions implements Serializable {
                                             formatEnumOption(MergeEngine.PARTIAL_UPDATE))
                                     .build());
 
+    public static final ConfigOption<WriteMode> WRITE_MODE =
+            ConfigOptions.key("write-mode")
+                    .enumType(WriteMode.class)
+                    .defaultValue(WriteMode.CHANGE_LOG)
+                    .withDescription(
+                            Description.builder()
+                                    .text("Specify the write mode for table.")
+                                    .linebreak()
+                                    .list(formatEnumOption(WriteMode.APPEND_ONLY))
+                                    .list(formatEnumOption(WriteMode.CHANGE_LOG))
+                                    .build());
+
     private final Configuration options;
 
     public static Set<ConfigOption<?>> allOptions() {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/PredicateBuilder.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/PredicateBuilder.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.store.file.predicate;
 
 import org.apache.flink.util.Preconditions;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -105,5 +106,22 @@ public class PredicateBuilder {
                 Arrays.asList(
                         greaterOrEqual(idx, includedLowerBound),
                         lessOrEqual(idx, includedUpperBound)));
+    }
+
+    public static List<Predicate> splitAnd(Predicate predicate) {
+        List<Predicate> result = new ArrayList<>();
+        splitAnd(predicate, result);
+        return result;
+    }
+
+    private static void splitAnd(Predicate predicate, List<Predicate> result) {
+        if (predicate instanceof CompoundPredicate
+                && ((CompoundPredicate) predicate).function().equals(And.INSTANCE)) {
+            for (Predicate child : ((CompoundPredicate) predicate).children()) {
+                splitAnd(child, result);
+            }
+        } else {
+            result.add(predicate);
+        }
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/Schema.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/Schema.java
@@ -84,6 +84,10 @@ public class Schema {
         return fields;
     }
 
+    public List<String> fieldNames() {
+        return fields.stream().map(DataField::name).collect(Collectors.toList());
+    }
+
     public int highestFieldId() {
         return highestFieldId;
     }
@@ -130,6 +134,24 @@ public class Schema {
 
     public RowType logicalRowType() {
         return (RowType) new RowDataType(fields).logicalType;
+    }
+
+    public RowType logicalPartitionType() {
+        return projectedLogicalRowType(partitionKeys);
+    }
+
+    public RowType logicalPrimaryKeysType() {
+        return projectedLogicalRowType(primaryKeys);
+    }
+
+    private RowType projectedLogicalRowType(List<String> projectedFieldNames) {
+        List<String> fieldNames = fieldNames();
+        return (RowType)
+                new RowDataType(
+                                projectedFieldNames.stream()
+                                        .map(k -> fields.get(fieldNames.indexOf(k)))
+                                        .collect(Collectors.toList()))
+                        .logicalType;
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTable.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.table;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.file.FileStore;
+import org.apache.flink.table.store.file.FileStoreImpl;
+import org.apache.flink.table.store.file.FileStoreOptions;
+import org.apache.flink.table.store.file.KeyValue;
+import org.apache.flink.table.store.file.WriteMode;
+import org.apache.flink.table.store.file.operation.FileStoreRead;
+import org.apache.flink.table.store.file.predicate.Predicate;
+import org.apache.flink.table.store.file.schema.Schema;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.Iterator;
+
+/** {@link FileStoreTable} for {@link WriteMode#APPEND_ONLY} write mode. */
+public class AppendOnlyFileStoreTable implements FileStoreTable {
+
+    private final Schema schema;
+    private final boolean isStreaming;
+    private final FileStoreImpl store;
+
+    AppendOnlyFileStoreTable(Schema schema, boolean isStreaming, Configuration conf, String user) {
+        this.schema = schema;
+        this.isStreaming = isStreaming;
+
+        this.store =
+                new FileStoreImpl(
+                        schema.id(),
+                        new FileStoreOptions(conf),
+                        WriteMode.APPEND_ONLY,
+                        user,
+                        schema.logicalPartitionType(),
+                        RowType.of(),
+                        schema.logicalRowType(),
+                        null);
+    }
+
+    @Override
+    public TableScan newScan() {
+        return new TableScan(store.newScan(), schema, store.pathFactory()) {
+            @Override
+            protected void withNonPartitionFilter(Predicate predicate) {
+                scan.withValueFilter(predicate);
+            }
+        };
+    }
+
+    @Override
+    public TableRead newRead() {
+        FileStoreRead read = store.newRead();
+        if (isStreaming) {
+            read.withDropDelete(false);
+        }
+
+        return new TableRead(read) {
+            @Override
+            protected void withProjectionImpl(int[][] projection) {
+                read.withValueProjection(projection);
+            }
+
+            @Override
+            protected Iterator<RowData> rowDataIteratorFromKv(KeyValue kv) {
+                return new ValueContentRowDataIterator(kv);
+            }
+        };
+    }
+
+    @Override
+    public FileStore fileStore() {
+        return store;
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTable.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.table;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.file.FileStore;
+import org.apache.flink.table.store.file.FileStoreImpl;
+import org.apache.flink.table.store.file.FileStoreOptions;
+import org.apache.flink.table.store.file.KeyValue;
+import org.apache.flink.table.store.file.WriteMode;
+import org.apache.flink.table.store.file.mergetree.compact.MergeFunction;
+import org.apache.flink.table.store.file.mergetree.compact.ValueCountMergeFunction;
+import org.apache.flink.table.store.file.operation.FileStoreRead;
+import org.apache.flink.table.store.file.predicate.Predicate;
+import org.apache.flink.table.store.file.schema.Schema;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.Iterator;
+
+/** {@link FileStoreTable} for {@link WriteMode#CHANGE_LOG} write mode without primary keys. */
+public class ChangelogValueCountFileStoreTable implements FileStoreTable {
+
+    private final Schema schema;
+    private final boolean isStreaming;
+    private final FileStoreImpl store;
+
+    ChangelogValueCountFileStoreTable(
+            Schema schema, boolean isStreaming, Configuration conf, String user) {
+        this.schema = schema;
+        this.isStreaming = isStreaming;
+
+        RowType countType =
+                RowType.of(
+                        new LogicalType[] {new BigIntType(false)}, new String[] {"_VALUE_COUNT"});
+        MergeFunction mergeFunction = new ValueCountMergeFunction();
+        this.store =
+                new FileStoreImpl(
+                        schema.id(),
+                        new FileStoreOptions(conf),
+                        WriteMode.CHANGE_LOG,
+                        user,
+                        schema.logicalPartitionType(),
+                        schema.logicalRowType(),
+                        countType,
+                        mergeFunction);
+    }
+
+    @Override
+    public TableScan newScan() {
+        return new TableScan(store.newScan(), schema, store.pathFactory()) {
+            @Override
+            protected void withNonPartitionFilter(Predicate predicate) {
+                scan.withKeyFilter(predicate);
+            }
+        };
+    }
+
+    @Override
+    public TableRead newRead() {
+        FileStoreRead read = store.newRead();
+        if (isStreaming) {
+            read.withDropDelete(false);
+        }
+
+        return new TableRead(read) {
+            private int[][] projection = null;
+
+            @Override
+            protected void withProjectionImpl(int[][] projection) {
+                if (isStreaming) {
+                    read.withKeyProjection(projection);
+                } else {
+                    this.projection = projection;
+                }
+            }
+
+            @Override
+            protected Iterator<RowData> rowDataIteratorFromKv(KeyValue kv) {
+                return new ValueCountRowDataIterator(kv, projection);
+            }
+        };
+    }
+
+    @Override
+    public FileStore fileStore() {
+        return store;
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.table;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.file.FileStore;
+import org.apache.flink.table.store.file.FileStoreImpl;
+import org.apache.flink.table.store.file.FileStoreOptions;
+import org.apache.flink.table.store.file.KeyValue;
+import org.apache.flink.table.store.file.WriteMode;
+import org.apache.flink.table.store.file.mergetree.compact.DeduplicateMergeFunction;
+import org.apache.flink.table.store.file.mergetree.compact.MergeFunction;
+import org.apache.flink.table.store.file.mergetree.compact.PartialUpdateMergeFunction;
+import org.apache.flink.table.store.file.operation.FileStoreRead;
+import org.apache.flink.table.store.file.predicate.Predicate;
+import org.apache.flink.table.store.file.schema.Schema;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** {@link FileStoreTable} for {@link WriteMode#CHANGE_LOG} write mode with primary keys. */
+public class ChangelogWithKeyFileStoreTable implements FileStoreTable {
+
+    private final Schema schema;
+    private final boolean isStreaming;
+    private final FileStoreImpl store;
+
+    ChangelogWithKeyFileStoreTable(
+            Schema schema, boolean isStreaming, Configuration conf, String user) {
+        this.schema = schema;
+        this.isStreaming = isStreaming;
+
+        RowType rowType = schema.logicalRowType();
+
+        // add _KEY_ prefix to avoid conflict with value
+        RowType keyType =
+                new RowType(
+                        schema.logicalPrimaryKeysType().getFields().stream()
+                                .map(
+                                        f ->
+                                                new RowType.RowField(
+                                                        "_KEY_" + f.getName(),
+                                                        f.getType(),
+                                                        f.getDescription().orElse(null)))
+                                .collect(Collectors.toList()));
+
+        FileStoreOptions.MergeEngine mergeEngine = conf.get(FileStoreOptions.MERGE_ENGINE);
+        MergeFunction mergeFunction;
+        switch (mergeEngine) {
+            case DEDUPLICATE:
+                mergeFunction = new DeduplicateMergeFunction();
+                break;
+            case PARTIAL_UPDATE:
+                List<LogicalType> fieldTypes = rowType.getChildren();
+                RowData.FieldGetter[] fieldGetters = new RowData.FieldGetter[fieldTypes.size()];
+                for (int i = 0; i < fieldTypes.size(); i++) {
+                    fieldGetters[i] = RowData.createFieldGetter(fieldTypes.get(i), i);
+                }
+                mergeFunction = new PartialUpdateMergeFunction(fieldGetters);
+                break;
+            default:
+                throw new UnsupportedOperationException("Unsupported merge engine: " + mergeEngine);
+        }
+
+        this.store =
+                new FileStoreImpl(
+                        schema.id(),
+                        new FileStoreOptions(conf),
+                        WriteMode.CHANGE_LOG,
+                        user,
+                        schema.logicalPartitionType(),
+                        keyType,
+                        rowType,
+                        mergeFunction);
+    }
+
+    @Override
+    public TableScan newScan() {
+        return new TableScan(store.newScan(), schema, store.pathFactory()) {
+            @Override
+            protected void withNonPartitionFilter(Predicate predicate) {
+                scan.withValueFilter(predicate);
+            }
+        };
+    }
+
+    @Override
+    public TableRead newRead() {
+        FileStoreRead read = store.newRead();
+        if (isStreaming) {
+            read.withDropDelete(false);
+        }
+
+        return new TableRead(read) {
+            @Override
+            protected void withProjectionImpl(int[][] projection) {
+                read.withValueProjection(projection);
+            }
+
+            @Override
+            protected Iterator<RowData> rowDataIteratorFromKv(KeyValue kv) {
+                return new ValueContentRowDataIterator(kv);
+            }
+        };
+    }
+
+    @Override
+    public FileStore fileStore() {
+        return store;
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/FileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/FileStoreTable.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.table;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.store.file.FileStore;
+import org.apache.flink.table.store.file.FileStoreOptions;
+import org.apache.flink.table.store.file.WriteMode;
+import org.apache.flink.table.store.file.schema.Schema;
+
+/**
+ * An abstraction layer above {@link org.apache.flink.table.store.file.FileStore} to provide reading
+ * and writing of {@link org.apache.flink.table.data.RowData}.
+ */
+public interface FileStoreTable {
+
+    TableScan newScan();
+
+    TableRead newRead();
+
+    // TODO remove this once TableWrite is introduced
+    @VisibleForTesting
+    FileStore fileStore();
+
+    static FileStoreTable create(
+            Schema schema, boolean isStreaming, Configuration conf, String user) {
+        if (conf.get(FileStoreOptions.WRITE_MODE) == WriteMode.APPEND_ONLY) {
+            return new AppendOnlyFileStoreTable(schema, isStreaming, conf, user);
+        } else {
+            if (schema.primaryKeys().isEmpty()) {
+                return new ChangelogValueCountFileStoreTable(schema, isStreaming, conf, user);
+            } else {
+                return new ChangelogWithKeyFileStoreTable(schema, isStreaming, conf, user);
+            }
+        }
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/TableRead.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/TableRead.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.table;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.store.file.KeyValue;
+import org.apache.flink.table.store.file.data.DataFileMeta;
+import org.apache.flink.table.store.file.operation.FileStoreRead;
+import org.apache.flink.table.store.file.utils.RecordReader;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+/** An abstraction layer above {@link FileStoreRead} to provide reading of {@link RowData}. */
+public abstract class TableRead {
+
+    protected final FileStoreRead read;
+
+    protected TableRead(FileStoreRead read) {
+        this.read = read;
+    }
+
+    public TableRead withProjection(int[][] projection) {
+        withProjectionImpl(projection);
+        return this;
+    }
+
+    protected abstract void withProjectionImpl(int[][] projection);
+
+    public RecordReader<RowData> createReader(
+            BinaryRowData partition, int bucket, List<DataFileMeta> files) throws IOException {
+        return new RowDataRecordReader(read.createReader(partition, bucket, files));
+    }
+
+    protected abstract Iterator<RowData> rowDataIteratorFromKv(KeyValue kv);
+
+    private class RowDataRecordReader implements RecordReader<RowData> {
+
+        private final RecordReader<KeyValue> wrapped;
+
+        private RowDataRecordReader(RecordReader<KeyValue> wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Nullable
+        @Override
+        public RecordIterator<RowData> readBatch() throws IOException {
+            RecordIterator<KeyValue> batch = wrapped.readBatch();
+            return batch == null ? null : new RowDataRecordIterator(batch);
+        }
+
+        @Override
+        public void close() throws IOException {
+            wrapped.close();
+        }
+    }
+
+    private class RowDataRecordIterator implements RecordReader.RecordIterator<RowData> {
+
+        private final RecordReader.RecordIterator<KeyValue> wrapped;
+        private Iterator<RowData> iterator;
+
+        private RowDataRecordIterator(RecordReader.RecordIterator<KeyValue> wrapped) {
+            this.wrapped = wrapped;
+            this.iterator = null;
+        }
+
+        @Override
+        public RowData next() throws IOException {
+            while (true) {
+                if (iterator != null && iterator.hasNext()) {
+                    return iterator.next();
+                }
+                KeyValue kv = wrapped.next();
+                if (kv == null) {
+                    return null;
+                }
+                iterator = rowDataIteratorFromKv(kv);
+            }
+        }
+
+        @Override
+        public void releaseBatch() {
+            wrapped.releaseBatch();
+        }
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/TableScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/TableScan.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.table;
+
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.store.file.data.DataFileMeta;
+import org.apache.flink.table.store.file.operation.FileStoreScan;
+import org.apache.flink.table.store.file.predicate.And;
+import org.apache.flink.table.store.file.predicate.CompoundPredicate;
+import org.apache.flink.table.store.file.predicate.LeafPredicate;
+import org.apache.flink.table.store.file.predicate.Predicate;
+import org.apache.flink.table.store.file.predicate.PredicateBuilder;
+import org.apache.flink.table.store.file.schema.Schema;
+import org.apache.flink.table.store.file.utils.FileStorePathFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/** An abstraction layer above {@link FileStoreScan} to provide input split generation. */
+public abstract class TableScan {
+
+    protected final FileStoreScan scan;
+    private final int[] fieldIdxToPartitionIdx;
+    private final FileStorePathFactory pathFactory;
+
+    protected TableScan(FileStoreScan scan, Schema schema, FileStorePathFactory pathFactory) {
+        this.scan = scan;
+        List<String> partitionKeys = schema.partitionKeys();
+        this.fieldIdxToPartitionIdx =
+                schema.fields().stream().mapToInt(f -> partitionKeys.indexOf(f.name())).toArray();
+        this.pathFactory = pathFactory;
+    }
+
+    public TableScan withSnapshot(long snapshotId) {
+        scan.withSnapshot(snapshotId);
+        return this;
+    }
+
+    public TableScan withIncremental(boolean isIncremental) {
+        scan.withIncremental(isIncremental);
+        return this;
+    }
+
+    public TableScan withFilter(Predicate predicate) {
+        List<Predicate> partitionFilters = new ArrayList<>();
+        List<Predicate> nonPartitionFilters = new ArrayList<>();
+        for (Predicate p : PredicateBuilder.splitAnd(predicate)) {
+            Optional<Predicate> mapped = mapToPartitionFilter(p);
+            if (mapped.isPresent()) {
+                partitionFilters.add(mapped.get());
+            } else {
+                nonPartitionFilters.add(p);
+            }
+        }
+
+        scan.withPartitionFilter(new CompoundPredicate(And.INSTANCE, partitionFilters));
+        withNonPartitionFilter(new CompoundPredicate(And.INSTANCE, nonPartitionFilters));
+        return this;
+    }
+
+    public Plan plan() {
+        FileStoreScan.Plan plan = scan.plan();
+        List<Split> splits = new ArrayList<>();
+        for (Map.Entry<BinaryRowData, Map<Integer, List<DataFileMeta>>> entryWithPartition :
+                plan.groupByPartFiles().entrySet()) {
+            BinaryRowData partition = entryWithPartition.getKey();
+            for (Map.Entry<Integer, List<DataFileMeta>> entryWithBucket :
+                    entryWithPartition.getValue().entrySet()) {
+                int bucket = entryWithBucket.getKey();
+                splits.add(
+                        new Split(
+                                partition,
+                                bucket,
+                                entryWithBucket.getValue(),
+                                pathFactory
+                                        .createDataFilePathFactory(partition, bucket)
+                                        .bucketPath()));
+            }
+        }
+        return new Plan(plan.snapshotId(), splits);
+    }
+
+    protected abstract void withNonPartitionFilter(Predicate predicate);
+
+    private Optional<Predicate> mapToPartitionFilter(Predicate predicate) {
+        if (predicate instanceof CompoundPredicate) {
+            CompoundPredicate compoundPredicate = (CompoundPredicate) predicate;
+            List<Predicate> children = new ArrayList<>();
+            for (Predicate child : compoundPredicate.children()) {
+                Optional<Predicate> mapped = mapToPartitionFilter(child);
+                if (mapped.isPresent()) {
+                    children.add(mapped.get());
+                } else {
+                    return Optional.empty();
+                }
+            }
+            return Optional.of(new CompoundPredicate(compoundPredicate.function(), children));
+        } else {
+            LeafPredicate leafPredicate = (LeafPredicate) predicate;
+            int mapped = fieldIdxToPartitionIdx[leafPredicate.index()];
+            if (mapped >= 0) {
+                return Optional.of(
+                        new LeafPredicate(
+                                leafPredicate.function(), mapped, leafPredicate.literal()));
+            } else {
+                return Optional.empty();
+            }
+        }
+    }
+
+    /** Scanning plan containing snapshot ID and input splits. */
+    public static class Plan {
+        public final long snapshotId;
+        public final List<Split> splits;
+
+        private Plan(long snapshotId, List<Split> splits) {
+            this.snapshotId = snapshotId;
+            this.splits = splits;
+        }
+    }
+
+    /** Input splits. Needed by most batch computation engines. */
+    public static class Split {
+        public final BinaryRowData partition;
+        public final int bucket;
+        public final List<DataFileMeta> files;
+        public final Path bucketPath;
+
+        private Split(
+                BinaryRowData partition, int bucket, List<DataFileMeta> files, Path bucketPath) {
+            this.partition = partition;
+            this.bucket = bucket;
+            this.files = files;
+            this.bucketPath = bucketPath;
+        }
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ValueContentRowDataIterator.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ValueContentRowDataIterator.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.table;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.file.KeyValue;
+import org.apache.flink.types.RowKind;
+
+import java.util.Iterator;
+
+/** An {@link Iterator} mapping a {@link KeyValue} to its value. */
+public class ValueContentRowDataIterator implements Iterator<RowData> {
+
+    private final RowData rowData;
+    private boolean hasNext;
+
+    public ValueContentRowDataIterator(KeyValue kv) {
+        rowData = kv.value();
+        // kv.value() is reused, so we need to set row kind each time
+        switch (kv.valueKind()) {
+            case ADD:
+                rowData.setRowKind(RowKind.INSERT);
+                break;
+            case DELETE:
+                rowData.setRowKind(RowKind.DELETE);
+                break;
+            default:
+                throw new UnsupportedOperationException(
+                        "Unknown value kind " + kv.valueKind().name());
+        }
+        hasNext = true;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return hasNext;
+    }
+
+    @Override
+    public RowData next() {
+        if (hasNext) {
+            hasNext = false;
+            return rowData;
+        } else {
+            return null;
+        }
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ValueCountRowDataIterator.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ValueCountRowDataIterator.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.table;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.utils.ProjectedRowData;
+import org.apache.flink.table.store.file.KeyValue;
+import org.apache.flink.types.RowKind;
+
+import javax.annotation.Nullable;
+
+import java.util.Iterator;
+
+/**
+ * An {@link Iterator} mapping a {@link KeyValue} to several {@link RowData} according to its key.
+ * These {@link RowData}s are the same. The number of rows depends on the value of {@link KeyValue}.
+ */
+public class ValueCountRowDataIterator implements Iterator<RowData> {
+
+    private final RowData rowData;
+    private long count;
+
+    public ValueCountRowDataIterator(KeyValue kv, @Nullable int[][] projection) {
+        if (projection == null) {
+            rowData = kv.key();
+        } else {
+            rowData = ProjectedRowData.from(projection).replaceRow(kv.key());
+        }
+        long value = kv.value().getLong(0);
+        // kv.value() is reused, so we need to set row kind each time
+        if (value > 0) {
+            rowData.setRowKind(RowKind.INSERT);
+        } else {
+            rowData.setRowKind(RowKind.DELETE);
+        }
+        count = Math.abs(value);
+    }
+
+    @Override
+    public boolean hasNext() {
+        return count > 0;
+    }
+
+    @Override
+    public RowData next() {
+        if (count > 0) {
+            count--;
+            return rowData;
+        } else {
+            return null;
+        }
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -111,7 +111,6 @@ public class TestFileStore extends FileStoreImpl {
             RowType valueType,
             MergeFunction mergeFunction) {
         super(
-                options.path().toString(),
                 0L,
                 options,
                 WriteMode.CHANGE_LOG,

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/predicate/PredicateBuilderTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/predicate/PredicateBuilderTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.predicate;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link PredicateBuilder}. */
+public class PredicateBuilderTest {
+
+    @Test
+    public void testSplitAnd() {
+        Predicate child1 =
+                PredicateBuilder.or(
+                        PredicateBuilder.isNull(0),
+                        PredicateBuilder.isNull(1),
+                        PredicateBuilder.isNull(2));
+        Predicate child2 =
+                PredicateBuilder.and(
+                        PredicateBuilder.isNull(3),
+                        PredicateBuilder.isNull(4),
+                        PredicateBuilder.isNull(5));
+        Predicate child3 = PredicateBuilder.isNull(6);
+
+        assertThat(PredicateBuilder.splitAnd(PredicateBuilder.and(child1, child2, child3)))
+                .isEqualTo(
+                        Arrays.asList(
+                                child1,
+                                PredicateBuilder.isNull(3),
+                                PredicateBuilder.isNull(4),
+                                PredicateBuilder.isNull(5),
+                                child3));
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ValueContentRowDataIteratorTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ValueContentRowDataIteratorTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.table;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.file.KeyValue;
+import org.apache.flink.table.store.file.ValueKind;
+import org.apache.flink.types.RowKind;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link ValueContentRowDataIterator}. */
+public class ValueContentRowDataIteratorTest {
+
+    @Test
+    public void testIterator() {
+        RowData key = GenericRowData.of(1);
+        RowData value = GenericRowData.of(10L, 100.0);
+
+        ValueContentRowDataIterator iterator =
+                new ValueContentRowDataIterator(
+                        new KeyValue().replace(key, 1, ValueKind.ADD, value));
+        assertThat(iterator).hasNext();
+        assertThat(iterator.next()).isEqualTo(GenericRowData.ofKind(RowKind.INSERT, 10L, 100.0));
+        assertThat(iterator).isExhausted();
+        assertThat(iterator.next()).isNull();
+
+        iterator =
+                new ValueContentRowDataIterator(
+                        new KeyValue().replace(key, 1, ValueKind.DELETE, value));
+        assertThat(iterator).hasNext();
+        assertThat(iterator.next()).isEqualTo(GenericRowData.ofKind(RowKind.DELETE, 10L, 100.0));
+        assertThat(iterator).isExhausted();
+        assertThat(iterator.next()).isNull();
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ValueCountRowDataIteratorTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ValueCountRowDataIteratorTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.table;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.file.KeyValue;
+import org.apache.flink.table.store.file.ValueKind;
+import org.apache.flink.types.RowKind;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link ValueCountRowDataIterator}. */
+public class ValueCountRowDataIteratorTest {
+
+    @Test
+    public void testWithoutProjection() {
+        RowData key = GenericRowData.of(1, 10L);
+
+        ValueCountRowDataIterator iterator =
+                new ValueCountRowDataIterator(
+                        new KeyValue().replace(key, 1, ValueKind.ADD, GenericRowData.of(3L)), null);
+        for (int i = 0; i < 3; i++) {
+            assertThat(iterator).hasNext();
+            assertThat(iterator.next()).isEqualTo(GenericRowData.ofKind(RowKind.INSERT, 1, 10L));
+        }
+        assertThat(iterator).isExhausted();
+        assertThat(iterator.next()).isNull();
+
+        iterator =
+                new ValueCountRowDataIterator(
+                        new KeyValue().replace(key, 1, ValueKind.ADD, GenericRowData.of(-3L)),
+                        null);
+        for (int i = 0; i < 3; i++) {
+            assertThat(iterator).hasNext();
+            assertThat(iterator.next()).isEqualTo(GenericRowData.ofKind(RowKind.DELETE, 1, 10L));
+        }
+        assertThat(iterator).isExhausted();
+        assertThat(iterator.next()).isNull();
+    }
+
+    @Test
+    public void testWithProjection() {
+        RowData key = GenericRowData.of(1, 10L, 100.0);
+
+        ValueCountRowDataIterator iterator =
+                new ValueCountRowDataIterator(
+                        new KeyValue().replace(key, 1, ValueKind.ADD, GenericRowData.of(3L)),
+                        new int[][] {new int[] {1}, new int[] {0}});
+        for (int i = 0; i < 3; i++) {
+            assertThat(iterator).hasNext();
+            RowData row = iterator.next();
+            assertThat(row.getArity()).isEqualTo(2);
+            assertThat(row.getLong(0)).isEqualTo(10L);
+            assertThat(row.getInt(1)).isEqualTo(1);
+        }
+        assertThat(iterator).isExhausted();
+        assertThat(iterator.next()).isNull();
+    }
+}

--- a/flink-table-store-hive/src/main/java/org/apache/flink/table/store/TableStoreJobConf.java
+++ b/flink-table-store-hive/src/main/java/org/apache/flink/table/store/TableStoreJobConf.java
@@ -136,6 +136,7 @@ public class TableStoreJobConf {
     }
 
     public void updateFileStoreOptions(Configuration fileStoreOptions) {
+        fileStoreOptions.set(FileStoreOptions.PATH, getLocation());
         for (Map.Entry<String, String> entry :
                 jobConf.getPropsWithPrefix(INTERNAL_TBLPROPERTIES_PREFIX).entrySet()) {
             fileStoreOptions.setString(entry.getKey(), entry.getValue());

--- a/flink-table-store-hive/src/main/java/org/apache/flink/table/store/mapred/TableStoreInputSplit.java
+++ b/flink-table-store-hive/src/main/java/org/apache/flink/table/store/mapred/TableStoreInputSplit.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.data.DataFileMetaSerializer;
 import org.apache.flink.table.store.file.utils.SerializationUtils;
+import org.apache.flink.table.store.table.TableScan;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.FileSplit;
@@ -61,6 +62,11 @@ public class TableStoreInputSplit extends FileSplit {
         this.files = files;
 
         this.bucketPath = bucketPath;
+    }
+
+    public static TableStoreInputSplit create(TableScan.Split split) {
+        return new TableStoreInputSplit(
+                split.partition, split.bucket, split.files, split.bucketPath.toString());
     }
 
     public BinaryRowData partition() {

--- a/flink-table-store-hive/src/test/java/org/apache/flink/table/store/FileStoreTestHelper.java
+++ b/flink-table-store-hive/src/test/java/org/apache/flink/table/store/FileStoreTestHelper.java
@@ -20,23 +20,25 @@ package org.apache.flink.table.store;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.store.file.FileStore;
 import org.apache.flink.table.store.file.FileStoreImpl;
 import org.apache.flink.table.store.file.FileStoreOptions;
-import org.apache.flink.table.store.file.KeyValue;
 import org.apache.flink.table.store.file.ValueKind;
-import org.apache.flink.table.store.file.WriteMode;
+import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.manifest.ManifestCommittable;
-import org.apache.flink.table.store.file.manifest.ManifestEntry;
 import org.apache.flink.table.store.file.mergetree.Increment;
-import org.apache.flink.table.store.file.mergetree.compact.MergeFunction;
-import org.apache.flink.table.store.file.operation.FileStoreCommitImpl;
-import org.apache.flink.table.store.file.operation.FileStoreReadImpl;
-import org.apache.flink.table.store.file.operation.FileStoreScanImpl;
-import org.apache.flink.table.store.file.operation.FileStoreWriteImpl;
+import org.apache.flink.table.store.file.operation.FileStoreCommit;
+import org.apache.flink.table.store.file.operation.FileStoreWrite;
+import org.apache.flink.table.store.file.schema.Schema;
+import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.file.schema.UpdateSchema;
 import org.apache.flink.table.store.file.utils.RecordReader;
 import org.apache.flink.table.store.file.writer.RecordWriter;
+import org.apache.flink.table.store.table.FileStoreTable;
+import org.apache.flink.table.store.table.TableScan;
 import org.apache.flink.table.types.logical.RowType;
 
 import java.util.Collections;
@@ -48,12 +50,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /** Helper class to write and read {@link RowData} with {@link FileStoreImpl}. */
 public class FileStoreTestHelper {
 
-    private final FileStoreImpl store;
+    private final FileStoreTable table;
+    private final FileStore store;
     private final BiFunction<RowData, RowData, BinaryRowData> partitionCalculator;
     private final Function<RowData, Integer> bucketCalculator;
     private final Map<BinaryRowData, Map<Integer, RecordWriter>> writers;
@@ -61,24 +63,20 @@ public class FileStoreTestHelper {
 
     public FileStoreTestHelper(
             Configuration conf,
-            RowType partitionType,
-            RowType keyType,
-            RowType valueType,
-            MergeFunction mergeFunction,
+            RowType rowType,
+            List<String> partitionKeys,
+            List<String> primaryKeys,
             BiFunction<RowData, RowData, BinaryRowData> partitionCalculator,
-            Function<RowData, Integer> bucketCalculator) {
-        FileStoreOptions options = new FileStoreOptions(conf);
-        this.store =
-                new FileStoreImpl(
-                        options.path().toString(),
-                        0,
-                        options,
-                        WriteMode.CHANGE_LOG,
-                        UUID.randomUUID().toString(),
-                        partitionType,
-                        keyType,
-                        valueType,
-                        mergeFunction);
+            Function<RowData, Integer> bucketCalculator)
+            throws Exception {
+        Path tablePath = FileStoreOptions.path(conf);
+        Schema schema =
+                new SchemaManager(tablePath)
+                        .commitNewVersion(
+                                new UpdateSchema(
+                                        rowType, partitionKeys, primaryKeys, new HashMap<>(), ""));
+        this.table = FileStoreTable.create(schema, false, conf, "user");
+        this.store = table.fileStore();
         this.partitionCalculator = partitionCalculator;
         this.bucketCalculator = bucketCalculator;
         this.writers = new HashMap<>();
@@ -94,7 +92,7 @@ public class FileStoreTestHelper {
                                 bucket,
                                 (b, w) -> {
                                     if (w == null) {
-                                        FileStoreWriteImpl write = store.newWrite();
+                                        FileStoreWrite write = store.newWrite();
                                         return write.createWriter(
                                                 partition, bucket, compactExecutor);
                                     } else {
@@ -119,21 +117,20 @@ public class FileStoreTestHelper {
             }
         }
         writers.clear();
-        FileStoreCommitImpl commit = store.newCommit();
+        FileStoreCommit commit = store.newCommit();
         commit.commit(committable, Collections.emptyMap());
     }
 
-    public Tuple2<RecordReader<KeyValue>, Long> read(BinaryRowData partition, int bucket)
+    public Tuple2<RecordReader<RowData>, Long> read(BinaryRowData partition, int bucket)
             throws Exception {
-        FileStoreScanImpl scan = store.newScan();
-        scan.withPartitionFilter(Collections.singletonList(partition)).withBucket(bucket);
-        List<ManifestEntry> files = scan.plan().files();
-        FileStoreReadImpl read = store.newRead();
-        RecordReader<KeyValue> wrapped =
-                read.createReader(
-                        partition,
-                        bucket,
-                        files.stream().map(ManifestEntry::file).collect(Collectors.toList()));
-        return Tuple2.of(wrapped, files.stream().mapToLong(e -> e.file().fileSize()).sum());
+        for (TableScan.Split split : table.newScan().plan().splits) {
+            if (split.partition.equals(partition) && split.bucket == bucket) {
+                return Tuple2.of(
+                        table.newRead().createReader(partition, bucket, split.files),
+                        split.files.stream().mapToLong(DataFileMeta::fileSize).sum());
+            }
+        }
+        throw new IllegalArgumentException(
+                "Input split not found for partition " + partition + " and bucket " + bucket);
     }
 }

--- a/flink-table-store-hive/src/test/java/org/apache/flink/table/store/hive/TableStoreHiveStorageHandlerITCase.java
+++ b/flink-table-store-hive/src/test/java/org/apache/flink/table/store/hive/TableStoreHiveStorageHandlerITCase.java
@@ -28,8 +28,6 @@ import org.apache.flink.table.data.binary.BinaryRowDataUtil;
 import org.apache.flink.table.store.FileStoreTestHelper;
 import org.apache.flink.table.store.file.FileStoreOptions;
 import org.apache.flink.table.store.file.ValueKind;
-import org.apache.flink.table.store.file.mergetree.compact.DeduplicateMergeFunction;
-import org.apache.flink.table.store.file.mergetree.compact.ValueCountMergeFunction;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 
@@ -90,13 +88,6 @@ public class TableStoreHiveStorageHandlerITCase {
         FileStoreTestHelper helper =
                 new FileStoreTestHelper(
                         conf,
-                        RowType.of(),
-                        RowType.of(
-                                new LogicalType[] {
-                                    DataTypes.INT().getLogicalType(),
-                                    DataTypes.BIGINT().getLogicalType()
-                                },
-                                new String[] {"_KEY_a", "_KEY_b"}),
                         RowType.of(
                                 new LogicalType[] {
                                     DataTypes.INT().getLogicalType(),
@@ -104,7 +95,8 @@ public class TableStoreHiveStorageHandlerITCase {
                                     DataTypes.STRING().getLogicalType()
                                 },
                                 new String[] {"a", "b", "c"}),
-                        new DeduplicateMergeFunction(),
+                        Collections.emptyList(),
+                        Arrays.asList("a", "b"),
                         (k, v) -> BinaryRowDataUtil.EMPTY_ROW,
                         k -> k.getInt(0) % 2);
 
@@ -166,7 +158,6 @@ public class TableStoreHiveStorageHandlerITCase {
         FileStoreTestHelper helper =
                 new FileStoreTestHelper(
                         conf,
-                        RowType.of(),
                         RowType.of(
                                 new LogicalType[] {
                                     DataTypes.INT().getLogicalType(),
@@ -174,10 +165,8 @@ public class TableStoreHiveStorageHandlerITCase {
                                     DataTypes.STRING().getLogicalType()
                                 },
                                 new String[] {"a", "b", "c"}),
-                        RowType.of(
-                                new LogicalType[] {DataTypes.BIGINT().getLogicalType()},
-                                new String[] {"_VALUE_COUNT"}),
-                        new ValueCountMergeFunction(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
                         (k, v) -> BinaryRowDataUtil.EMPTY_ROW,
                         k -> k.getInt(0) % 2);
 
@@ -238,10 +227,6 @@ public class TableStoreHiveStorageHandlerITCase {
         FileStoreTestHelper helper =
                 new FileStoreTestHelper(
                         conf,
-                        RowType.of(),
-                        RowType.of(
-                                new LogicalType[] {DataTypes.INT().getLogicalType()},
-                                new String[] {"_KEY_f_int"}),
                         RowType.of(
                                 RandomGenericRowDataGenerator.TYPE_INFOS.stream()
                                         .map(
@@ -250,7 +235,8 @@ public class TableStoreHiveStorageHandlerITCase {
                                                                 .getLogicalType())
                                         .toArray(LogicalType[]::new),
                                 RandomGenericRowDataGenerator.FIELD_NAMES.toArray(new String[0])),
-                        new DeduplicateMergeFunction(),
+                        Collections.emptyList(),
+                        Collections.singletonList("f_int"),
                         (k, v) -> BinaryRowDataUtil.EMPTY_ROW,
                         k -> 0);
 
@@ -382,14 +368,11 @@ public class TableStoreHiveStorageHandlerITCase {
         FileStoreTestHelper helper =
                 new FileStoreTestHelper(
                         conf,
-                        RowType.of(),
                         RowType.of(
                                 new LogicalType[] {DataTypes.INT().getLogicalType()},
                                 new String[] {"a"}),
-                        RowType.of(
-                                new LogicalType[] {DataTypes.BIGINT().getLogicalType()},
-                                new String[] {"_VALUE_COUNT"}),
-                        new ValueCountMergeFunction(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
                         (k, v) -> BinaryRowDataUtil.EMPTY_ROW,
                         k -> 0);
 
@@ -474,17 +457,14 @@ public class TableStoreHiveStorageHandlerITCase {
         FileStoreTestHelper helper =
                 new FileStoreTestHelper(
                         conf,
-                        RowType.of(),
                         RowType.of(
                                 new LogicalType[] {
                                     DataTypes.DATE().getLogicalType(),
                                     DataTypes.TIMESTAMP(3).getLogicalType()
                                 },
                                 new String[] {"dt", "ts"}),
-                        RowType.of(
-                                new LogicalType[] {DataTypes.BIGINT().getLogicalType()},
-                                new String[] {"_VALUE_COUNT"}),
-                        new ValueCountMergeFunction(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
                         (k, v) -> BinaryRowDataUtil.EMPTY_ROW,
                         k -> 0);
 


### PR DESCRIPTION
Currently `FileStore` exposes an interface for reading and writing `KeyValue`. However connectors may have different ways to change a `RowData` to `KeyValue` under different `WriteMode`. This results in lots of `if...else...` branches and duplicated code.

We need to add an abstraction layer for connectors to read and write row data instead of key-values.