### PR TITLE
[FLINK-27863] Refactor RecordReader and RecordIterator in table store into generic types

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitReader.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitReader.java
@@ -57,10 +57,10 @@ public class FileStoreSourceSplitReader
 
     private final Pool<FileStoreRecordIterator> pool;
 
-    @Nullable private RecordReader currentReader;
+    @Nullable private RecordReader<KeyValue> currentReader;
     @Nullable private String currentSplitId;
     private long currentNumRead;
-    private RecordReader.RecordIterator currentFirstBatch;
+    private RecordReader.RecordIterator<KeyValue> currentFirstBatch;
 
     @VisibleForTesting
     public FileStoreSourceSplitReader(FileStoreRead fileStoreRead, boolean valueCountMode) {
@@ -87,7 +87,7 @@ public class FileStoreSourceSplitReader
         // to be read at the same time
         FileStoreRecordIterator iterator = pool();
 
-        RecordReader.RecordIterator nextBatch;
+        RecordReader.RecordIterator<KeyValue> nextBatch;
         if (currentFirstBatch != null) {
             nextBatch = currentFirstBatch;
             currentFirstBatch = null;
@@ -154,7 +154,7 @@ public class FileStoreSourceSplitReader
 
     private void seek(long toSkip) throws IOException {
         while (true) {
-            RecordReader.RecordIterator nextBatch = currentReader.readBatch();
+            RecordReader.RecordIterator<KeyValue> nextBatch = currentReader.readBatch();
             if (nextBatch == null) {
                 throw new RuntimeException(
                         String.format(
@@ -191,7 +191,7 @@ public class FileStoreSourceSplitReader
 
         private final Supplier<RowData> rowDataSupplier;
 
-        private RecordReader.RecordIterator iterator;
+        private RecordReader.RecordIterator<KeyValue> iterator;
 
         private final MutableRecordAndPosition<RowData> recordAndPosition =
                 new MutableRecordAndPosition<>();
@@ -209,7 +209,7 @@ public class FileStoreSourceSplitReader
                             : new PrimaryKeyRowDataSupplier(this::nextKeyValue);
         }
 
-        public FileStoreRecordIterator replace(RecordReader.RecordIterator iterator) {
+        public FileStoreRecordIterator replace(RecordReader.RecordIterator<KeyValue> iterator) {
             this.iterator = iterator;
             this.recordAndPosition.set(null, RecordAndPosition.NO_OFFSET, currentNumRead);
             return this;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileReader.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileReader.java
@@ -61,11 +61,11 @@ public class DataFileReader {
         this.pathFactory = pathFactory;
     }
 
-    public RecordReader read(String fileName) throws IOException {
+    public RecordReader<KeyValue> read(String fileName) throws IOException {
         return new DataFileRecordReader(pathFactory.toPath(fileName));
     }
 
-    private class DataFileRecordReader implements RecordReader {
+    private class DataFileRecordReader implements RecordReader<KeyValue> {
 
         private final BulkFormat.Reader<RowData> reader;
         private final KeyValueSerializer serializer;
@@ -79,7 +79,7 @@ public class DataFileReader {
 
         @Nullable
         @Override
-        public RecordIterator readBatch() throws IOException {
+        public RecordIterator<KeyValue> readBatch() throws IOException {
             BulkFormat.RecordIterator<RowData> iterator = reader.readBatch();
             return iterator == null ? null : new DataFileRecordIterator(iterator, serializer);
         }
@@ -90,7 +90,7 @@ public class DataFileReader {
         }
     }
 
-    private static class DataFileRecordIterator implements RecordReader.RecordIterator {
+    private static class DataFileRecordIterator implements RecordReader.RecordIterator<KeyValue> {
 
         private final BulkFormat.RecordIterator<RowData> iterator;
         private final KeyValueSerializer serializer;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreRead.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreRead.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.store.file.operation;
 
 import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.store.file.KeyValue;
 import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.utils.RecordReader;
 
@@ -49,6 +50,6 @@ public interface FileStoreRead {
      *       reader is guaranteed to be ordered by keys and does not contain duplicated keys.
      * </ul>
      */
-    RecordReader createReader(BinaryRowData partition, int bucket, List<DataFileMeta> files)
-            throws IOException;
+    RecordReader<KeyValue> createReader(
+            BinaryRowData partition, int bucket, List<DataFileMeta> files) throws IOException;
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreReadImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreReadImpl.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.store.file.operation;
 
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.store.file.KeyValue;
 import org.apache.flink.table.store.file.WriteMode;
 import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.data.DataFileReader;
@@ -91,8 +92,8 @@ public class FileStoreReadImpl implements FileStoreRead {
     }
 
     @Override
-    public RecordReader createReader(BinaryRowData partition, int bucket, List<DataFileMeta> files)
-            throws IOException {
+    public RecordReader<KeyValue> createReader(
+            BinaryRowData partition, int bucket, List<DataFileMeta> files) throws IOException {
         switch (writeMode) {
             case APPEND_ONLY:
                 return createAppendOnlyReader(partition, bucket, files);
@@ -105,7 +106,7 @@ public class FileStoreReadImpl implements FileStoreRead {
         }
     }
 
-    private RecordReader createAppendOnlyReader(
+    private RecordReader<KeyValue> createAppendOnlyReader(
             BinaryRowData partition, int bucket, List<DataFileMeta> files) throws IOException {
         DataFileReader dataFileReader = dataFileReaderFactory.create(partition, bucket);
         List<ConcatRecordReader.ReaderSupplier> suppliers = new ArrayList<>();
@@ -116,7 +117,7 @@ public class FileStoreReadImpl implements FileStoreRead {
         return ConcatRecordReader.create(suppliers);
     }
 
-    private RecordReader createMergeTreeReader(
+    private RecordReader<KeyValue> createMergeTreeReader(
             BinaryRowData partition, int bucket, List<DataFileMeta> files) throws IOException {
         DataFileReader dataFileReader = dataFileReaderFactory.create(partition, bucket);
         if (keyProjected) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreWriteImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreWriteImpl.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.store.file.operation;
 
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.store.file.KeyValue;
 import org.apache.flink.table.store.file.WriteMode;
 import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.data.DataFilePathFactory;
@@ -175,7 +176,7 @@ public class FileStoreWriteImpl implements FileStoreWrite {
         CompactManager.Rewriter rewriter =
                 (outputLevel, dropDelete, sections) ->
                         dataFileWriter.write(
-                                new RecordReaderIterator(
+                                new RecordReaderIterator<KeyValue>(
                                         new MergeTreeReader(
                                                 sections,
                                                 dropDelete,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RecordReader.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RecordReader.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.table.store.file.utils;
 
-import org.apache.flink.table.store.file.KeyValue;
-
 import javax.annotation.Nullable;
 
 import java.io.Closeable;
@@ -27,7 +25,7 @@ import java.io.IOException;
 import java.util.Iterator;
 
 /** The reader that reads the batches of records. */
-public interface RecordReader extends Closeable {
+public interface RecordReader<T> extends Closeable {
 
     /**
      * Reads one batch. The method should return null when reaching the end of the input.
@@ -36,7 +34,7 @@ public interface RecordReader extends Closeable {
      * some time, so it should not be immediately reused by the reader.
      */
     @Nullable
-    RecordIterator readBatch() throws IOException;
+    RecordIterator<T> readBatch() throws IOException;
 
     /** Closes the reader and should release all resources. */
     @Override
@@ -45,13 +43,15 @@ public interface RecordReader extends Closeable {
     /**
      * An internal iterator interface which presents a more restrictive API than {@link Iterator}.
      */
-    interface RecordIterator {
+    interface RecordIterator<T> {
 
         /**
          * Gets the next record from the iterator. Returns null if this iterator has no more
          * elements.
+         *
+         * @return
          */
-        KeyValue next() throws IOException;
+        T next() throws IOException;
 
         /**
          * Releases the batch that this iterator iterated over. This is not supposed to close the

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RecordReaderIterator.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RecordReaderIterator.java
@@ -18,20 +18,19 @@
 
 package org.apache.flink.table.store.file.utils;
 
-import org.apache.flink.table.store.file.KeyValue;
 import org.apache.flink.util.CloseableIterator;
 
 import java.io.IOException;
 
 /** Wrap a {@link RecordReader} as an {@link CloseableIterator}. */
-public class RecordReaderIterator implements CloseableIterator<KeyValue> {
+public class RecordReaderIterator<T> implements CloseableIterator<T> {
 
-    private final RecordReader reader;
-    private RecordReader.RecordIterator currentIterator;
+    private final RecordReader<T> reader;
+    private RecordReader.RecordIterator<T> currentIterator;
     private boolean advanced;
-    private KeyValue currentResult;
+    private T currentResult;
 
-    public RecordReaderIterator(RecordReader reader) {
+    public RecordReaderIterator(RecordReader<T> reader) {
         this.reader = reader;
         try {
             this.currentIterator = reader.readBatch();
@@ -56,7 +55,7 @@ public class RecordReaderIterator implements CloseableIterator<KeyValue> {
     }
 
     @Override
-    public KeyValue next() {
+    public T next() {
         if (!hasNext()) {
             return null;
         }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -274,8 +274,8 @@ public class TestFileStore extends FileStoreImpl {
                 filesPerPartitionAndBucket.entrySet()) {
             for (Map.Entry<Integer, List<DataFileMeta>> entryWithBucket :
                     entryWithPartition.getValue().entrySet()) {
-                RecordReaderIterator iterator =
-                        new RecordReaderIterator(
+                RecordReaderIterator<KeyValue> iterator =
+                        new RecordReaderIterator<>(
                                 read.createReader(
                                         entryWithPartition.getKey(),
                                         entryWithBucket.getKey(),

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileTest.java
@@ -243,7 +243,7 @@ public class DataFileTest {
         for (DataFileMeta meta : actualMetas) {
             // check the contents of data file
             CloseableIterator<KeyValue> actualKvsIterator =
-                    new RecordReaderIterator(fileReader.read(meta.fileName()));
+                    new RecordReaderIterator<>(fileReader.read(meta.fileName()));
             while (actualKvsIterator.hasNext()) {
                 assertThat(expectedIterator.hasNext()).isTrue();
                 KeyValue actualKv = actualKvsIterator.next();

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/MergeTreeTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/MergeTreeTest.java
@@ -279,7 +279,7 @@ public class MergeTreeTest {
         CompactManager.Rewriter rewriter =
                 (outputLevel, dropDelete, sections) ->
                         dataFileWriter.write(
-                                new RecordReaderIterator(
+                                new RecordReaderIterator<KeyValue>(
                                         new MergeTreeReader(
                                                 sections,
                                                 dropDelete,
@@ -353,7 +353,7 @@ public class MergeTreeTest {
 
     private List<TestRecord> readAll(List<DataFileMeta> files, boolean dropDelete)
             throws Exception {
-        RecordReader reader =
+        RecordReader<KeyValue> reader =
                 new MergeTreeReader(
                         new IntervalPartition(files, comparator).partition(),
                         dropDelete,
@@ -361,7 +361,7 @@ public class MergeTreeTest {
                         comparator,
                         new DeduplicateMergeFunction());
         List<TestRecord> records = new ArrayList<>();
-        try (RecordReaderIterator iterator = new RecordReaderIterator(reader)) {
+        try (RecordReaderIterator<KeyValue> iterator = new RecordReaderIterator<KeyValue>(reader)) {
             while (iterator.hasNext()) {
                 KeyValue kv = iterator.next();
                 records.add(

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/CombiningRecordReaderTestBase.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/CombiningRecordReaderTestBase.java
@@ -46,7 +46,8 @@ public abstract class CombiningRecordReaderTestBase {
 
     protected abstract List<ReusingTestData> getExpected(List<ReusingTestData> input);
 
-    protected abstract RecordReader createRecordReader(List<TestReusingRecordReader> readers);
+    protected abstract RecordReader<KeyValue> createRecordReader(
+            List<TestReusingRecordReader> readers);
 
     @RepeatedTest(100)
     public void testRandom() throws IOException {
@@ -84,9 +85,9 @@ public abstract class CombiningRecordReaderTestBase {
         for (List<ReusingTestData> readerData : readersData) {
             readers.add(new TestReusingRecordReader(readerData));
         }
-        RecordReader recordReader = createRecordReader(readers);
+        RecordReader<KeyValue> recordReader = createRecordReader(readers);
 
-        RecordReader.RecordIterator batch;
+        RecordReader.RecordIterator<KeyValue> batch;
         while ((batch = recordReader.readBatch()) != null) {
             KeyValue kv;
             while ((kv = batch.next()) != null) {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/ConcatRecordReaderTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/ConcatRecordReaderTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.store.file.mergetree.compact;
 
+import org.apache.flink.table.store.file.KeyValue;
 import org.apache.flink.table.store.file.utils.RecordReader;
 import org.apache.flink.table.store.file.utils.ReusingTestData;
 import org.apache.flink.table.store.file.utils.TestReusingRecordReader;
@@ -42,7 +43,7 @@ public class ConcatRecordReaderTest extends CombiningRecordReaderTestBase {
     }
 
     @Override
-    protected RecordReader createRecordReader(List<TestReusingRecordReader> readers) {
+    protected RecordReader<KeyValue> createRecordReader(List<TestReusingRecordReader> readers) {
         return new ConcatRecordReader(
                 readers.stream()
                         .map(r -> (ConcatRecordReader.ReaderSupplier) () -> r)

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/SortMergeReaderTestBase.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/SortMergeReaderTestBase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.store.file.mergetree.compact;
 
+import org.apache.flink.table.store.file.KeyValue;
 import org.apache.flink.table.store.file.utils.RecordReader;
 import org.apache.flink.table.store.file.utils.ReusingTestData;
 import org.apache.flink.table.store.file.utils.TestReusingRecordReader;
@@ -34,7 +35,7 @@ public abstract class SortMergeReaderTestBase extends CombiningRecordReaderTestB
     protected abstract MergeFunction createMergeFunction();
 
     @Override
-    protected RecordReader createRecordReader(List<TestReusingRecordReader> readers) {
+    protected RecordReader<KeyValue> createRecordReader(List<TestReusingRecordReader> readers) {
         return new SortMergeReader(new ArrayList<>(readers), KEY_COMPARATOR, createMergeFunction());
     }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreReadTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreReadTest.java
@@ -200,14 +200,14 @@ public class FileStoreReadTest {
         List<KeyValue> result = new ArrayList<>();
         for (Map.Entry<BinaryRowData, List<ManifestEntry>> entry :
                 filesGroupedByPartition.entrySet()) {
-            RecordReader reader =
+            RecordReader<KeyValue> reader =
                     read.createReader(
                             entry.getKey(),
                             0,
                             entry.getValue().stream()
                                     .map(ManifestEntry::file)
                                     .collect(Collectors.toList()));
-            RecordReaderIterator actualIterator = new RecordReaderIterator(reader);
+            RecordReaderIterator<KeyValue> actualIterator = new RecordReaderIterator<>(reader);
             while (actualIterator.hasNext()) {
                 result.add(
                         actualIterator

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/TestReusingRecordReader.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/TestReusingRecordReader.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * sizes (possibly empty). {@link KeyValue}s produced by the same reader is reused to test that
  * other components correctly handles the reusing.
  */
-public class TestReusingRecordReader implements RecordReader {
+public class TestReusingRecordReader implements RecordReader<KeyValue> {
 
     private final List<ReusingTestData> testData;
     private final ReusingKeyValue reuse;
@@ -58,7 +58,7 @@ public class TestReusingRecordReader implements RecordReader {
 
     @Nullable
     @Override
-    public RecordIterator readBatch() {
+    public RecordIterator<KeyValue> readBatch() {
         assertThat(nextLowerBound != -1).isTrue();
         if (nextLowerBound == testData.size() && random.nextBoolean()) {
             nextLowerBound = -1;
@@ -83,7 +83,7 @@ public class TestReusingRecordReader implements RecordReader {
         }
     }
 
-    private class TestRecordIterator implements RecordIterator {
+    private class TestRecordIterator implements RecordIterator<KeyValue> {
 
         private final int upperBound;
 

--- a/flink-table-store-hive/src/main/java/org/apache/flink/table/store/mapred/TableStoreInputFormat.java
+++ b/flink-table-store-hive/src/main/java/org/apache/flink/table/store/mapred/TableStoreInputFormat.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.store.SearchArgumentToPredicateConverter;
 import org.apache.flink.table.store.TableStoreJobConf;
 import org.apache.flink.table.store.file.FileStoreImpl;
 import org.apache.flink.table.store.file.FileStoreOptions;
+import org.apache.flink.table.store.file.KeyValue;
 import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.operation.FileStoreRead;
 import org.apache.flink.table.store.file.operation.FileStoreScan;
@@ -91,7 +92,7 @@ public class TableStoreInputFormat implements InputFormat<Void, RowDataContainer
         FileStoreWrapper wrapper = new FileStoreWrapper(jobConf);
         FileStoreRead read = wrapper.store.newRead();
         TableStoreInputSplit split = (TableStoreInputSplit) inputSplit;
-        org.apache.flink.table.store.file.utils.RecordReader wrapped =
+        org.apache.flink.table.store.file.utils.RecordReader<KeyValue> wrapped =
                 read.withDropDelete(true)
                         .createReader(split.partition(), split.bucket(), split.files());
         long splitLength = split.getLength();

--- a/flink-table-store-hive/src/main/java/org/apache/flink/table/store/mapred/TableStoreRecordReader.java
+++ b/flink-table-store-hive/src/main/java/org/apache/flink/table/store/mapred/TableStoreRecordReader.java
@@ -36,17 +36,17 @@ import java.util.function.Supplier;
  */
 public class TableStoreRecordReader implements RecordReader<Void, RowDataContainer> {
 
-    private final RecordReaderIterator iterator;
+    private final RecordReaderIterator<KeyValue> iterator;
     private final Supplier<RowData> rowDataSupplier;
     private final long splitLength;
 
     private float progress;
 
     public TableStoreRecordReader(
-            org.apache.flink.table.store.file.utils.RecordReader wrapped,
+            org.apache.flink.table.store.file.utils.RecordReader<KeyValue> wrapped,
             boolean valueCountMode,
             long splitLength) {
-        this.iterator = new RecordReaderIterator(wrapped);
+        this.iterator = new RecordReaderIterator<>(wrapped);
         this.rowDataSupplier =
                 valueCountMode
                         ? new ValueCountRowDataSupplier(iterator::next)

--- a/flink-table-store-hive/src/test/java/org/apache/flink/table/store/FileStoreTestHelper.java
+++ b/flink-table-store-hive/src/test/java/org/apache/flink/table/store/FileStoreTestHelper.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.store.file.FileStoreImpl;
 import org.apache.flink.table.store.file.FileStoreOptions;
+import org.apache.flink.table.store.file.KeyValue;
 import org.apache.flink.table.store.file.ValueKind;
 import org.apache.flink.table.store.file.WriteMode;
 import org.apache.flink.table.store.file.manifest.ManifestCommittable;
@@ -122,12 +123,13 @@ public class FileStoreTestHelper {
         commit.commit(committable, Collections.emptyMap());
     }
 
-    public Tuple2<RecordReader, Long> read(BinaryRowData partition, int bucket) throws Exception {
+    public Tuple2<RecordReader<KeyValue>, Long> read(BinaryRowData partition, int bucket)
+            throws Exception {
         FileStoreScanImpl scan = store.newScan();
         scan.withPartitionFilter(Collections.singletonList(partition)).withBucket(bucket);
         List<ManifestEntry> files = scan.plan().files();
         FileStoreReadImpl read = store.newRead();
-        RecordReader wrapped =
+        RecordReader<KeyValue> wrapped =
                 read.createReader(
                         partition,
                         bucket,

--- a/flink-table-store-hive/src/test/java/org/apache/flink/table/store/mapred/TableStoreRecordReaderTest.java
+++ b/flink-table-store-hive/src/test/java/org/apache/flink/table/store/mapred/TableStoreRecordReaderTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.data.binary.BinaryRowDataUtil;
 import org.apache.flink.table.store.FileStoreTestHelper;
 import org.apache.flink.table.store.RowDataContainer;
 import org.apache.flink.table.store.file.FileStoreOptions;
+import org.apache.flink.table.store.file.KeyValue;
 import org.apache.flink.table.store.file.ValueKind;
 import org.apache.flink.table.store.file.mergetree.compact.DeduplicateMergeFunction;
 import org.apache.flink.table.store.file.mergetree.compact.ValueCountMergeFunction;
@@ -94,7 +95,7 @@ public class TableStoreRecordReaderTest {
                 GenericRowData.of(2L, StringData.fromString("Hello")));
         helper.commit();
 
-        Tuple2<RecordReader, Long> tuple = helper.read(BinaryRowDataUtil.EMPTY_ROW, 0);
+        Tuple2<RecordReader<KeyValue>, Long> tuple = helper.read(BinaryRowDataUtil.EMPTY_ROW, 0);
         TableStoreRecordReader reader = new TableStoreRecordReader(tuple.f0, false, tuple.f1);
         RowDataContainer container = reader.createValue();
         Set<String> actual = new HashSet<>();
@@ -158,7 +159,7 @@ public class TableStoreRecordReaderTest {
                 GenericRowData.of(1L));
         helper.commit();
 
-        Tuple2<RecordReader, Long> tuple = helper.read(BinaryRowDataUtil.EMPTY_ROW, 0);
+        Tuple2<RecordReader<KeyValue>, Long> tuple = helper.read(BinaryRowDataUtil.EMPTY_ROW, 0);
         TableStoreRecordReader reader = new TableStoreRecordReader(tuple.f0, true, tuple.f1);
         RowDataContainer container = reader.createValue();
         Map<String, Integer> actual = new HashMap<>();


### PR DESCRIPTION
We'd like to introduce a `TableRead` class between file store and the users. This class should provide an iterator for `RowData` instead of `KeyValue`s. So we'll need an iterator not only for `KeyValue` but also for `RowData`.