### PR TITLE
[FLINK-27927] Improve table store connector common interfaces

### DIFF
--- a/flink-table-store-common/src/main/java/org/apache/flink/table/store/utils/RowDataUtils.java
+++ b/flink-table-store-common/src/main/java/org/apache/flink/table/store/utils/RowDataUtils.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.utils;
+
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.data.RawValueData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.binary.BinaryArrayData;
+import org.apache.flink.table.data.binary.BinaryMapData;
+import org.apache.flink.table.data.binary.BinaryRawValueData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.data.binary.NestedRowData;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.MultisetType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimestampType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** Utils for {@link RowData} structures. */
+public class RowDataUtils {
+
+    public static RowData copyRowData(RowData row, RowType rowType) {
+        if (row instanceof BinaryRowData) {
+            return ((BinaryRowData) row).copy();
+        } else if (row instanceof NestedRowData) {
+            return ((NestedRowData) row).copy();
+        } else {
+            GenericRowData ret = new GenericRowData(row.getArity());
+            ret.setRowKind(row.getRowKind());
+
+            for (int i = 0; i < row.getArity(); ++i) {
+                LogicalType fieldType = rowType.getTypeAt(i);
+                ret.setField(i, copy(get(row, i, fieldType), fieldType));
+            }
+
+            return ret;
+        }
+    }
+
+    public static ArrayData copyArray(ArrayData from, LogicalType eleType) {
+        if (from instanceof BinaryArrayData) {
+            return ((BinaryArrayData) from).copy();
+        }
+
+        if (!eleType.isNullable()) {
+            switch (eleType.getTypeRoot()) {
+                case BOOLEAN:
+                    return new GenericArrayData(from.toBooleanArray());
+                case TINYINT:
+                    return new GenericArrayData(from.toByteArray());
+                case SMALLINT:
+                    return new GenericArrayData(from.toShortArray());
+                case INTEGER:
+                case DATE:
+                case TIME_WITHOUT_TIME_ZONE:
+                    return new GenericArrayData(from.toIntArray());
+                case BIGINT:
+                    return new GenericArrayData(from.toLongArray());
+                case FLOAT:
+                    return new GenericArrayData(from.toFloatArray());
+                case DOUBLE:
+                    return new GenericArrayData(from.toDoubleArray());
+            }
+        }
+
+        Object[] newArray = new Object[from.size()];
+
+        for (int i = 0; i < newArray.length; ++i) {
+            if (!from.isNullAt(i)) {
+                newArray[i] = copy(get(from, i, eleType), eleType);
+            } else {
+                newArray[i] = null;
+            }
+        }
+
+        return new GenericArrayData(newArray);
+    }
+
+    private static MapData copyMap(MapData map, LogicalType keyType, LogicalType valueType) {
+        if (map instanceof BinaryMapData) {
+            return ((BinaryMapData) map).copy();
+        }
+
+        Map<Object, Object> javaMap = new HashMap<>();
+        ArrayData keys = map.keyArray();
+        ArrayData values = map.valueArray();
+        for (int i = 0; i < keys.size(); i++) {
+            javaMap.put(
+                    copy(get(keys, i, keyType), keyType),
+                    copy(get(values, i, valueType), valueType));
+        }
+        return new GenericMapData(javaMap);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public static Object copy(Object o, LogicalType type) {
+        if (o instanceof StringData) {
+            BinaryStringData string = (BinaryStringData) o;
+            return string.getBinarySection() == null
+                    ? StringData.fromString(string.toString())
+                    : ((BinaryStringData) o).copy();
+        } else if (o instanceof RowData) {
+            return copyRowData((RowData) o, (RowType) type);
+        } else if (o instanceof ArrayData) {
+            return copyArray((ArrayData) o, ((ArrayType) type).getElementType());
+        } else if (o instanceof MapData) {
+            if (type instanceof MapType) {
+                return copyMap(
+                        (MapData) o,
+                        ((MapType) type).getKeyType(),
+                        ((MapType) type).getValueType());
+            } else {
+                return copyMap((MapData) o, ((MultisetType) type).getElementType(), new IntType());
+            }
+        } else if (o instanceof RawValueData) {
+            BinaryRawValueData raw = (BinaryRawValueData) o;
+            if (raw.getBinarySection() != null) {
+                return BinaryRawValueData.fromBytes(raw.toBytes(null));
+            }
+        } else if (o instanceof DecimalData) {
+            return ((DecimalData) o).copy();
+        }
+        return o;
+    }
+
+    public static Object get(RowData row, int pos, LogicalType fieldType) {
+        if (row.isNullAt(pos)) {
+            return null;
+        }
+        switch (fieldType.getTypeRoot()) {
+            case BOOLEAN:
+                return row.getBoolean(pos);
+            case TINYINT:
+                return row.getByte(pos);
+            case SMALLINT:
+                return row.getShort(pos);
+            case INTEGER:
+            case DATE:
+            case TIME_WITHOUT_TIME_ZONE:
+            case INTERVAL_YEAR_MONTH:
+                return row.getInt(pos);
+            case BIGINT:
+            case INTERVAL_DAY_TIME:
+                return row.getLong(pos);
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+                TimestampType timestampType = (TimestampType) fieldType;
+                return row.getTimestamp(pos, timestampType.getPrecision());
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                LocalZonedTimestampType lzTs = (LocalZonedTimestampType) fieldType;
+                return row.getTimestamp(pos, lzTs.getPrecision());
+            case FLOAT:
+                return row.getFloat(pos);
+            case DOUBLE:
+                return row.getDouble(pos);
+            case CHAR:
+            case VARCHAR:
+                return row.getString(pos);
+            case DECIMAL:
+                DecimalType decimalType = (DecimalType) fieldType;
+                return row.getDecimal(pos, decimalType.getPrecision(), decimalType.getScale());
+            case ARRAY:
+                return row.getArray(pos);
+            case MAP:
+            case MULTISET:
+                return row.getMap(pos);
+            case ROW:
+                return row.getRow(pos, ((RowType) fieldType).getFieldCount());
+            case BINARY:
+            case VARBINARY:
+                return row.getBinary(pos);
+            case RAW:
+                return row.getRawValue(pos);
+            default:
+                throw new UnsupportedOperationException("Unsupported type: " + fieldType);
+        }
+    }
+
+    public static Object get(ArrayData array, int pos, LogicalType fieldType) {
+        if (array.isNullAt(pos)) {
+            return null;
+        }
+        switch (fieldType.getTypeRoot()) {
+            case BOOLEAN:
+                return array.getBoolean(pos);
+            case TINYINT:
+                return array.getByte(pos);
+            case SMALLINT:
+                return array.getShort(pos);
+            case INTEGER:
+            case DATE:
+            case TIME_WITHOUT_TIME_ZONE:
+            case INTERVAL_YEAR_MONTH:
+                return array.getInt(pos);
+            case BIGINT:
+            case INTERVAL_DAY_TIME:
+                return array.getLong(pos);
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+                TimestampType timestampType = (TimestampType) fieldType;
+                return array.getTimestamp(pos, timestampType.getPrecision());
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                LocalZonedTimestampType lzTs = (LocalZonedTimestampType) fieldType;
+                return array.getTimestamp(pos, lzTs.getPrecision());
+            case FLOAT:
+                return array.getFloat(pos);
+            case DOUBLE:
+                return array.getDouble(pos);
+            case CHAR:
+            case VARCHAR:
+                return array.getString(pos);
+            case DECIMAL:
+                DecimalType decimalType = (DecimalType) fieldType;
+                return array.getDecimal(pos, decimalType.getPrecision(), decimalType.getScale());
+            case ARRAY:
+                return array.getArray(pos);
+            case MAP:
+            case MULTISET:
+                return array.getMap(pos);
+            case ROW:
+                return array.getRow(pos, ((RowType) fieldType).getFieldCount());
+            case BINARY:
+            case VARBINARY:
+                return array.getBinary(pos);
+            case RAW:
+                return array.getRawValue(pos);
+            default:
+                throw new UnsupportedOperationException("Unsupported type: " + fieldType);
+        }
+    }
+}

--- a/flink-table-store-common/src/main/java/org/apache/flink/table/store/utils/TypeUtils.java
+++ b/flink-table-store-common/src/main/java/org/apache/flink/table/store/utils/TypeUtils.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.store.utils;
 import org.apache.flink.table.data.binary.BinaryStringData;
 import org.apache.flink.table.data.binary.BinaryStringDataUtil;
 import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.TimestampType;
@@ -75,7 +76,17 @@ public class TypeUtils {
                 TimestampType timestampType = (TimestampType) type;
                 return BinaryStringDataUtil.toTimestamp(str, timestampType.getPrecision());
             default:
-                throw new UnsupportedOperationException("Unsupported type " + type.toString());
+                throw new UnsupportedOperationException("Unsupported type " + type);
         }
+    }
+
+    public static int timestampPrecision(LogicalType type) {
+        if (type instanceof TimestampType) {
+            return ((TimestampType) type).getPrecision();
+        } else if (type instanceof LocalZonedTimestampType) {
+            return ((LocalZonedTimestampType) type).getPrecision();
+        }
+
+        throw new UnsupportedOperationException("Unsupported type: " + type);
     }
 }

--- a/flink-table-store-common/src/test/java/org.apache.flink.table.store/utils/RowDataUtilsTest.java
+++ b/flink-table-store-common/src/test/java/org.apache.flink.table.store/utils/RowDataUtilsTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.utils;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.datagen.table.RandomGeneratorVisitor;
+import org.apache.flink.connector.datagen.table.types.RowDataGenerator;
+import org.apache.flink.streaming.api.functions.source.datagen.DataGenerator;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link RowDataUtils}. */
+public class RowDataUtilsTest {
+
+    public static final RowType ROW_TYPE =
+            (RowType)
+                    TableSchema.builder()
+                            .field("id", DataTypes.INT().notNull())
+                            .field("name", DataTypes.STRING()) /* optional by default */
+                            .field("salary", DataTypes.DOUBLE().notNull())
+                            .field("strArray", DataTypes.ARRAY(DataTypes.STRING()).nullable())
+                            .field("intArray", DataTypes.ARRAY(DataTypes.INT()).nullable())
+                            .field("char", DataTypes.CHAR(10).notNull())
+                            .field("varchar", DataTypes.VARCHAR(10).notNull())
+                            .field("boolean", DataTypes.BOOLEAN().nullable())
+                            .field("tinyint", DataTypes.TINYINT())
+                            .field("smallint", DataTypes.SMALLINT())
+                            .field("bigint", DataTypes.BIGINT())
+                            .field("timestampWithoutZone", DataTypes.TIMESTAMP())
+                            .field("timestampWithZone", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE())
+                            .field("date", DataTypes.DATE())
+                            .field("decimal", DataTypes.DECIMAL(2, 2))
+                            .field("decimal2", DataTypes.DECIMAL(38, 2))
+                            .field("decimal3", DataTypes.DECIMAL(10, 1))
+                            .build()
+                            .toRowDataType()
+                            .getLogicalType();
+
+    private RowDataGenerator rowDataGenerator;
+
+    private RowDataSerializer serializer;
+
+    @BeforeEach
+    public void before() throws Exception {
+        DataGenerator[] generators =
+                ROW_TYPE.getFields().stream()
+                        .map(
+                                field ->
+                                        field.getType()
+                                                .accept(
+                                                        new RandomGeneratorVisitor(
+                                                                field.getName(),
+                                                                new Configuration()))
+                                                .getGenerator())
+                        .toArray(DataGenerator[]::new);
+        this.rowDataGenerator = new RowDataGenerator(generators, ROW_TYPE.getFieldNames());
+        this.rowDataGenerator.open(null, null, null);
+        this.serializer = new RowDataSerializer(ROW_TYPE);
+    }
+
+    @Test
+    public void testCopy() {
+        for (int i = 0; i < 10; i++) {
+            RowData row = rowDataGenerator.next();
+            RowData copied = RowDataUtils.copyRowData(row, ROW_TYPE);
+            assertThat(toBinary(copied)).isEqualTo(toBinary(row));
+            RowData copied2 = serializer.copy(row);
+
+            // check copied
+            for (int j = 0; j < copied.getArity(); j++) {
+                Object origin = RowDataUtils.get(row, j, ROW_TYPE.getTypeAt(j));
+                Object field1 = RowDataUtils.get(copied, j, ROW_TYPE.getTypeAt(j));
+                Object field2 = RowDataUtils.get(copied2, j, ROW_TYPE.getTypeAt(j));
+
+                if (field2 != origin) {
+                    assertThat(field1).isNotSameAs(origin);
+                }
+            }
+        }
+    }
+
+    private BinaryRowData toBinary(RowData row) {
+        return serializer.toBinaryRow(row).copy();
+    }
+}

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileStoreITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileStoreITCase.java
@@ -351,19 +351,22 @@ public class FileStoreITCase extends AbstractTestBase {
         ObjectIdentifier identifier = ObjectIdentifier.of("catalog", "db", "t");
         Configuration options = buildConfiguration(noFail, temporaryFolder.newFolder());
         Path tablePath = new FileStoreOptions(options).path();
-        new SchemaManager(tablePath)
-                .commitNewVersion(
-                        new UpdateSchema(
-                                TABLE_TYPE,
-                                Arrays.stream(partitions)
-                                        .mapToObj(i -> TABLE_TYPE.getFieldNames().get(i))
-                                        .collect(Collectors.toList()),
-                                Arrays.stream(primaryKey)
-                                        .mapToObj(i -> TABLE_TYPE.getFieldNames().get(i))
-                                        .collect(Collectors.toList()),
-                                options.toMap(),
-                                ""));
-        return retryArtificialException(() -> new TableStore(identifier, options));
+        UpdateSchema updateSchema =
+                new UpdateSchema(
+                        TABLE_TYPE,
+                        Arrays.stream(partitions)
+                                .mapToObj(i -> TABLE_TYPE.getFieldNames().get(i))
+                                .collect(Collectors.toList()),
+                        Arrays.stream(primaryKey)
+                                .mapToObj(i -> TABLE_TYPE.getFieldNames().get(i))
+                                .collect(Collectors.toList()),
+                        options.toMap(),
+                        "");
+        return retryArtificialException(
+                () -> {
+                    new SchemaManager(tablePath).commitNewVersion(updateSchema);
+                    return new TableStore(identifier, options);
+                });
     }
 
     public static Configuration buildConfiguration(boolean noFail, File folder) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/Schema.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/Schema.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.util.Preconditions;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -39,7 +40,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 /** Schema of table store. */
-public class Schema {
+public class Schema implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     private final long id;
 
@@ -152,6 +155,11 @@ public class Schema {
                                         .map(k -> fields.get(fieldNames.indexOf(k)))
                                         .collect(Collectors.toList()))
                         .logicalType;
+    }
+
+    public Schema copy(Map<String, String> newOptions) {
+        return new Schema(
+                id, fields, highestFieldId, partitionKeys, primaryKeys, newOptions, comment);
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AbstractFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AbstractFileStoreTable.java
@@ -18,29 +18,29 @@
 
 package org.apache.flink.table.store.table;
 
-import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.table.store.file.FileStore;
-import org.apache.flink.table.store.table.source.TableRead;
-import org.apache.flink.table.store.table.source.TableScan;
+import org.apache.flink.table.store.file.schema.Schema;
 import org.apache.flink.table.types.logical.RowType;
 
-import java.io.Serializable;
+/** Abstract {@link FileStoreTable}. */
+public abstract class AbstractFileStoreTable implements FileStoreTable {
 
-/**
- * An abstraction layer above {@link org.apache.flink.table.store.file.FileStore} to provide reading
- * and writing of {@link org.apache.flink.table.data.RowData}.
- */
-public interface FileStoreTable extends Serializable {
+    private static final long serialVersionUID = 1L;
 
-    String name();
+    private final String name;
+    protected final Schema schema;
 
-    RowType rowType();
+    public AbstractFileStoreTable(String name, Schema schema) {
+        this.name = name;
+        this.schema = schema;
+    }
 
-    TableScan newScan(boolean incremental);
+    @Override
+    public String name() {
+        return name;
+    }
 
-    TableRead newRead(boolean incremental);
-
-    // TODO remove this once TableWrite is introduced
-    @VisibleForTesting
-    FileStore fileStore();
+    @Override
+    public RowType rowType() {
+        return schema.logicalRowType();
+    }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTable.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.store.table;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.file.FileStore;
 import org.apache.flink.table.store.file.FileStoreImpl;
@@ -35,17 +34,20 @@ import org.apache.flink.table.store.table.source.ValueContentRowDataRecordIterat
 import org.apache.flink.table.types.logical.RowType;
 
 /** {@link FileStoreTable} for {@link WriteMode#APPEND_ONLY} write mode. */
-public class AppendOnlyFileStoreTable implements FileStoreTable {
+public class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
+
+    private static final long serialVersionUID = 1L;
 
     private final Schema schema;
     private final FileStoreImpl store;
 
-    AppendOnlyFileStoreTable(Schema schema, Configuration conf, String user) {
+    AppendOnlyFileStoreTable(String name, Schema schema, String user) {
+        super(name, schema);
         this.schema = schema;
         this.store =
                 new FileStoreImpl(
                         schema.id(),
-                        new FileStoreOptions(conf),
+                        new FileStoreOptions(schema.options()),
                         WriteMode.APPEND_ONLY,
                         user,
                         schema.logicalPartitionType(),

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTable.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.store.table;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.file.FileStore;
 import org.apache.flink.table.store.file.FileStoreImpl;
@@ -40,13 +39,14 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 
 /** {@link FileStoreTable} for {@link WriteMode#CHANGE_LOG} write mode without primary keys. */
-public class ChangelogValueCountFileStoreTable implements FileStoreTable {
+public class ChangelogValueCountFileStoreTable extends AbstractFileStoreTable {
 
-    private final Schema schema;
+    private static final long serialVersionUID = 1L;
+
     private final FileStoreImpl store;
 
-    ChangelogValueCountFileStoreTable(Schema schema, Configuration conf, String user) {
-        this.schema = schema;
+    ChangelogValueCountFileStoreTable(String name, Schema schema, String user) {
+        super(name, schema);
         RowType countType =
                 RowType.of(
                         new LogicalType[] {new BigIntType(false)}, new String[] {"_VALUE_COUNT"});
@@ -54,7 +54,7 @@ public class ChangelogValueCountFileStoreTable implements FileStoreTable {
         this.store =
                 new FileStoreImpl(
                         schema.id(),
-                        new FileStoreOptions(conf),
+                        new FileStoreOptions(schema.options()),
                         WriteMode.CHANGE_LOG,
                         user,
                         schema.logicalPartitionType(),

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
@@ -43,13 +43,14 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /** {@link FileStoreTable} for {@link WriteMode#CHANGE_LOG} write mode with primary keys. */
-public class ChangelogWithKeyFileStoreTable implements FileStoreTable {
+public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
 
-    private final Schema schema;
+    private static final long serialVersionUID = 1L;
+
     private final FileStoreImpl store;
 
-    ChangelogWithKeyFileStoreTable(Schema schema, Configuration conf, String user) {
-        this.schema = schema;
+    ChangelogWithKeyFileStoreTable(String name, Schema schema, String user) {
+        super(name, schema);
         RowType rowType = schema.logicalRowType();
 
         // add _KEY_ prefix to avoid conflict with value
@@ -63,6 +64,8 @@ public class ChangelogWithKeyFileStoreTable implements FileStoreTable {
                                                         f.getType(),
                                                         f.getDescription().orElse(null)))
                                 .collect(Collectors.toList()));
+
+        Configuration conf = Configuration.fromMap(schema.options());
 
         FileStoreOptions.MergeEngine mergeEngine = conf.get(FileStoreOptions.MERGE_ENGINE);
         MergeFunction mergeFunction;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/TableRead.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/TableRead.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.store.file.utils.RecordReader;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
 /** An abstraction layer above {@link FileStoreRead} to provide reading of {@link RowData}. */
@@ -37,6 +38,14 @@ public abstract class TableRead {
 
     protected TableRead(FileStoreRead read) {
         this.read = read;
+    }
+
+    // TODO support filter push down
+
+    public TableRead withProjection(int[] projection) {
+        int[][] nestedProjection =
+                Arrays.stream(projection).mapToObj(i -> new int[] {i}).toArray(int[][]::new);
+        return withProjection(nestedProjection);
     }
 
     public abstract TableRead withProjection(int[][] projection);

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/TableScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/TableScan.java
@@ -49,6 +49,13 @@ public abstract class TableScan {
         return this;
     }
 
+    public TableScan withFilter(List<Predicate> predicates) {
+        if (predicates == null || predicates.isEmpty()) {
+            return this;
+        }
+        return withFilter(PredicateBuilder.and(predicates));
+    }
+
     public TableScan withFilter(Predicate predicate) {
         List<String> partitionKeys = schema.partitionKeys();
         int[] fieldIdxToPartitionIdx =

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/source/SplitTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/source/SplitTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.table.source;
+
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.table.store.file.data.DataFileMeta;
+import org.apache.flink.table.store.file.data.DataFileTestDataGenerator;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link Split}. */
+public class SplitTest {
+
+    @Test
+    public void testSerializer() throws IOException {
+        DataFileTestDataGenerator gen = DataFileTestDataGenerator.builder().build();
+        DataFileTestDataGenerator.Data data = gen.next();
+        List<DataFileMeta> files = new ArrayList<>();
+        for (int i = 0; i < ThreadLocalRandom.current().nextInt(10); i++) {
+            files.add(gen.next().meta);
+        }
+        Split split = new Split(data.partition, data.bucket, files, new Path("/tmp/test"));
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        split.serialize(new DataOutputViewStreamWrapper(out));
+
+        Split newSplit = Split.deserialize(new DataInputDeserializer(out.toByteArray()));
+        assertThat(newSplit).isEqualTo(split);
+    }
+}

--- a/flink-table-store-hive/src/test/java/org/apache/flink/table/store/FileStoreTestHelper.java
+++ b/flink-table-store-hive/src/test/java/org/apache/flink/table/store/FileStoreTestHelper.java
@@ -51,6 +51,8 @@ import java.util.concurrent.Executors;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import static org.apache.flink.table.store.file.FileStoreOptions.PATH;
+
 /** Helper class to write and read {@link RowData} with {@link FileStoreImpl}. */
 public class FileStoreTestHelper {
 
@@ -72,7 +74,12 @@ public class FileStoreTestHelper {
         Path tablePath = FileStoreOptions.path(conf);
         new SchemaManager(tablePath)
                 .commitNewVersion(
-                        new UpdateSchema(rowType, partitionKeys, primaryKeys, new HashMap<>(), ""));
+                        new UpdateSchema(rowType, partitionKeys, primaryKeys, conf.toMap(), ""));
+
+        // only path, other config should be read from file store.
+        conf = new Configuration();
+        conf.set(PATH, tablePath.toString());
+
         this.table = FileStoreTableFactory.create(conf, "user");
         this.store = table.fileStore();
         this.partitionCalculator = partitionCalculator;


### PR DESCRIPTION
We currently have the initial FileStoreTable-related interface, but something is missing to satisfy our four approaches:
1. Type conversion
2. Data structure conversion
3. Filter conversion
4. Scan and Read

In this jira, more easy-to-use features will be added.

[e6bff85](https://github.com/apache/flink-table-store/pull/146/commits/e6bff8554ae7ca4c6600173ffba08f4f6b7466ea) Add copy rowdata: In some places, such as Spark, InternalRow needs to provide a copy method, but passing a Serializer in will have thread safety problems, consider not on the critical path, switch performance is also okay, so add a convenient copy
[05a22a1](https://github.com/apache/flink-table-store/pull/146/commits/05a22a1ae2f10825989ec1ab89c4b27d15b74aa3) Table name can be displayed in the job graph.