### PR TITLE
[FLINK-28066] Use FileSystem.createRecoverableWriter in FileStoreCommit

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
@@ -32,8 +32,8 @@ import org.apache.flink.table.store.file.manifest.ManifestFileMeta;
 import org.apache.flink.table.store.file.manifest.ManifestList;
 import org.apache.flink.table.store.file.predicate.Predicate;
 import org.apache.flink.table.store.file.predicate.PredicateConverter;
-import org.apache.flink.table.store.file.utils.AtomicFileWriter;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
+import org.apache.flink.table.store.file.utils.MetaFileWriter;
 import org.apache.flink.table.store.file.utils.RowDataToObjectArrayConverter;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
 import org.apache.flink.table.types.logical.RowType;
@@ -401,8 +401,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                         }
 
                         boolean committed =
-                                AtomicFileWriter.create(fs)
-                                        .writeFileSafety(newSnapshotPath, newSnapshot.toJson());
+                                MetaFileWriter.writeFileSafety(
+                                        newSnapshotPath, newSnapshot.toJson());
                         if (committed) {
                             snapshotManager.commitLatestHint(newSnapshotId);
                         }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
@@ -22,7 +22,6 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.store.file.operation.Lock;
 import org.apache.flink.table.store.file.utils.AtomicFileWriter;
-import org.apache.flink.table.store.file.utils.AtomicFsDataOutputStream;
 import org.apache.flink.table.store.file.utils.FileUtils;
 import org.apache.flink.table.store.file.utils.JsonSerdeUtil;
 import org.apache.flink.table.types.logical.RowType;
@@ -140,15 +139,8 @@ public class SchemaManager implements Serializable {
                                     return false;
                                 }
 
-                                AtomicFsDataOutputStream out =
-                                        AtomicFileWriter.create(fs).open(schemaPath);
-                                try {
-                                    FileUtils.writeFileUtf8(out, schema.toString());
-                                    return out.closeAndCommit();
-                                } catch (IOException e) {
-                                    out.close();
-                                    return false;
-                                }
+                                return AtomicFileWriter.create(tableRoot.getFileSystem())
+                                        .writeFileSafety(schemaPath, schema.toString());
                             });
             if (success) {
                 return schema;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
@@ -21,9 +21,9 @@ package org.apache.flink.table.store.file.schema;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.store.file.operation.Lock;
-import org.apache.flink.table.store.file.utils.AtomicFileWriter;
 import org.apache.flink.table.store.file.utils.FileUtils;
 import org.apache.flink.table.store.file.utils.JsonSerdeUtil;
+import org.apache.flink.table.store.file.utils.MetaFileWriter;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Preconditions;
 
@@ -139,8 +139,8 @@ public class SchemaManager implements Serializable {
                                     return false;
                                 }
 
-                                return AtomicFileWriter.create(tableRoot.getFileSystem())
-                                        .writeFileSafety(schemaPath, schema.toString());
+                                return MetaFileWriter.writeFileSafety(
+                                        schemaPath, schema.toString());
                             });
             if (success) {
                 return schema;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
@@ -18,8 +18,11 @@
 
 package org.apache.flink.table.store.file.schema;
 
+import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.store.file.operation.Lock;
+import org.apache.flink.table.store.file.utils.AtomicFileWriter;
+import org.apache.flink.table.store.file.utils.AtomicFsDataOutputStream;
 import org.apache.flink.table.store.file.utils.FileUtils;
 import org.apache.flink.table.store.file.utils.JsonSerdeUtil;
 import org.apache.flink.table.types.logical.RowType;
@@ -31,7 +34,6 @@ import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
@@ -128,20 +130,28 @@ public class SchemaManager implements Serializable {
                             options,
                             updateSchema.comment());
 
-            Path temp = toTmpSchemaPath(id);
-            Path finalFile = toSchemaPath(id);
+            Path schemaPath = toSchemaPath(id);
 
-            boolean success = false;
-            try {
-                FileUtils.writeFileUtf8(temp, schema.toString());
-                success = lock.runWithLock(() -> temp.getFileSystem().rename(temp, finalFile));
-                if (success) {
-                    return schema;
-                }
-            } finally {
-                if (!success) {
-                    FileUtils.deleteOrWarn(temp);
-                }
+            FileSystem fs = schemaPath.getFileSystem();
+            boolean success =
+                    lock.runWithLock(
+                            () -> {
+                                if (fs.exists(schemaPath)) {
+                                    return false;
+                                }
+
+                                AtomicFsDataOutputStream out =
+                                        AtomicFileWriter.create(fs).open(schemaPath);
+                                try {
+                                    FileUtils.writeFileUtf8(out, schema.toString());
+                                    return out.closeAndCommit();
+                                } catch (IOException e) {
+                                    out.close();
+                                    return false;
+                                }
+                            });
+            if (success) {
+                return schema;
             }
         }
     }
@@ -157,10 +167,6 @@ public class SchemaManager implements Serializable {
 
     private Path schemaDirectory() {
         return new Path(tableRoot + "/schema");
-    }
-
-    private Path toTmpSchemaPath(long id) {
-        return new Path(tableRoot + "/schema/." + SCHEMA_PREFIX + id + "-" + UUID.randomUUID());
     }
 
     private Path toSchemaPath(long id) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/AtomicFileWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/AtomicFileWriter.java
@@ -37,30 +37,6 @@ public interface AtomicFileWriter {
     /** Opens a new atomic stream to write to the given path. */
     AtomicFsDataOutputStream open(Path path) throws IOException;
 
-    /**
-     * Write an utf8 string to file. In addition to that, it checks if the committed file is equal
-     * to the input {@code content}, if not, the committing has failed.
-     *
-     * <p>But this does not solve overwritten committing.
-     *
-     * @return True if the committing was successful, False otherwise
-     */
-    default boolean writeFileSafety(Path path, String content) throws IOException {
-        AtomicFsDataOutputStream out = open(path);
-        try {
-            FileUtils.writeOutputStreamUtf8(out, content);
-            boolean success = out.closeAndCommit();
-            if (success) {
-                return content.equals(FileUtils.readFileUtf8(path));
-            } else {
-                return false;
-            }
-        } catch (IOException e) {
-            out.close();
-            return false;
-        }
-    }
-
     static AtomicFileWriter create(FileSystem fs) throws IOException {
         RecoverableWriter recoverableWriter = null;
         try {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/AtomicFileWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/AtomicFileWriter.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.utils;
+
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.FileSystemKind;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.fs.RecoverableWriter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * The AtomicFileWriter creates {@link AtomicFsDataOutputStream}.The streams do not make the files
+ * they write to immediately visible, but instead write to temp files or other temporary storage. To
+ * publish the data atomically in the end, the stream offers the {@link
+ * RenamingAtomicFsDataOutputStream#closeAndCommit()} method to publish the result.
+ */
+public interface AtomicFileWriter {
+
+    /** Opens a new atomic stream to write to the given path. */
+    AtomicFsDataOutputStream open(Path path) throws IOException;
+
+    static AtomicFileWriter create(FileSystem fs) throws IOException {
+        RecoverableWriter recoverableWriter = null;
+        try {
+            recoverableWriter = fs.createRecoverableWriter();
+        } catch (UnsupportedOperationException ignore) {
+        }
+
+        if (recoverableWriter == null || fs.getKind() == FileSystemKind.FILE_SYSTEM) {
+            return path ->
+                    new RenamingAtomicFsDataOutputStream(
+                            path.getFileSystem(),
+                            path,
+                            new Path(path.getParent(), "." + path.getName() + UUID.randomUUID()));
+        } else {
+            return new RecoverableAtomicFileWriter(recoverableWriter);
+        }
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/AtomicFileWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/AtomicFileWriter.java
@@ -37,6 +37,30 @@ public interface AtomicFileWriter {
     /** Opens a new atomic stream to write to the given path. */
     AtomicFsDataOutputStream open(Path path) throws IOException;
 
+    /**
+     * Write an utf8 string to file. In addition to that, it checks if the committed file is equal
+     * to the input {@code content}, if not, the committing has failed.
+     *
+     * <p>But this does not solve overwritten committing.
+     *
+     * @return True if the committing was successful, False otherwise
+     */
+    default boolean writeFileSafety(Path path, String content) throws IOException {
+        AtomicFsDataOutputStream out = open(path);
+        try {
+            FileUtils.writeOutputStreamUtf8(out, content);
+            boolean success = out.closeAndCommit();
+            if (success) {
+                return content.equals(FileUtils.readFileUtf8(path));
+            } else {
+                return false;
+            }
+        } catch (IOException e) {
+            out.close();
+            return false;
+        }
+    }
+
     static AtomicFileWriter create(FileSystem fs) throws IOException {
         RecoverableWriter recoverableWriter = null;
         try {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/AtomicFsDataOutputStream.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/AtomicFsDataOutputStream.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.utils;
+
+import org.apache.flink.core.fs.FSDataOutputStream;
+
+import java.io.IOException;
+
+/**
+ * A stream initially writes to hidden files or temp files and only creates the target file once it
+ * is closed and "committed".
+ */
+public abstract class AtomicFsDataOutputStream extends FSDataOutputStream {
+
+    /**
+     * Closes the stream, ensuring persistence of all data (similar to {@link #sync()}). And commits
+     * the file, publish (make visible) the file that the stream was writing to.
+     */
+    public abstract boolean closeAndCommit() throws IOException;
+
+    /**
+     * Closes this stream. Closing the steam releases the local resources that the stream uses, but
+     * does NOT result in durability of previously written data. This method should be interpreted
+     * as a "close in order to dispose" or "close on failure".
+     *
+     * <p>In order to persist all previously written data, one needs to call the {@link
+     * #closeAndCommit()} method.
+     *
+     * @throws IOException Thrown if an error occurred during closing.
+     */
+    @Override
+    public abstract void close() throws IOException;
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/AtomicFsDataOutputStream.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/AtomicFsDataOutputStream.java
@@ -32,7 +32,8 @@ public abstract class AtomicFsDataOutputStream extends FSDataOutputStream {
      * Closes the stream, ensuring persistence of all data (similar to {@link #sync()}). And commits
      * the file, publish (make visible) the file that the stream was writing to.
      *
-     * @return True if the committing was successful, False otherwise
+     * @return Returns true if the commit may be successful. Returns false if the commit definitely
+     *     fails.
      */
     public abstract boolean closeAndCommit() throws IOException;
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/AtomicFsDataOutputStream.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/AtomicFsDataOutputStream.java
@@ -31,6 +31,8 @@ public abstract class AtomicFsDataOutputStream extends FSDataOutputStream {
     /**
      * Closes the stream, ensuring persistence of all data (similar to {@link #sync()}). And commits
      * the file, publish (make visible) the file that the stream was writing to.
+     *
+     * @return True if the committing was successful, False otherwise
      */
     public abstract boolean closeAndCommit() throws IOException;
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/FileStorePathFactory.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/FileStorePathFactory.java
@@ -71,6 +71,10 @@ public class FileStorePathFactory {
         this.manifestListCount = new AtomicInteger(0);
     }
 
+    public Path root() {
+        return root;
+    }
+
     @VisibleForTesting
     public static RowDataPartitionComputer getPartitionComputer(
             RowType partitionType, String defaultPartValue) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/FileUtils.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/FileUtils.java
@@ -110,10 +110,14 @@ public class FileUtils {
     public static void writeFileUtf8(Path file, String content) throws IOException {
         try (FSDataOutputStream out =
                 file.getFileSystem().create(file, FileSystem.WriteMode.NO_OVERWRITE)) {
-            OutputStreamWriter writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
-            writer.write(content);
-            writer.close();
+            writeFileUtf8(out, content);
         }
+    }
+
+    public static void writeFileUtf8(FSDataOutputStream out, String content) throws IOException {
+        OutputStreamWriter writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
+        writer.write(content);
+        writer.flush();
     }
 
     public static void deleteOrWarn(Path file) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/FileUtils.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/FileUtils.java
@@ -110,11 +110,12 @@ public class FileUtils {
     public static void writeFileUtf8(Path file, String content) throws IOException {
         try (FSDataOutputStream out =
                 file.getFileSystem().create(file, FileSystem.WriteMode.NO_OVERWRITE)) {
-            writeFileUtf8(out, content);
+            writeOutputStreamUtf8(out, content);
         }
     }
 
-    public static void writeFileUtf8(FSDataOutputStream out, String content) throws IOException {
+    public static void writeOutputStreamUtf8(FSDataOutputStream out, String content)
+            throws IOException {
         OutputStreamWriter writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
         writer.write(content);
         writer.flush();

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/MetaFileWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/MetaFileWriter.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.utils;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.core.fs.Path;
+
+import java.io.IOException;
+
+/** File writer to write a metadata file which contains only a small amount of text data. */
+public class MetaFileWriter {
+
+    /**
+     * Write an utf8 string to file. In addition to that, it checks if the committed file is equal
+     * to the input {@code content}, if not, the committing has failed.
+     *
+     * <p>But this does not solve overwritten committing.
+     *
+     * @return True if the committing was successful, False otherwise
+     */
+    public static boolean writeFileSafety(Path path, String content) throws IOException {
+        return writeFileSafety(AtomicFileWriter.create(path.getFileSystem()), path, content);
+    }
+
+    @VisibleForTesting
+    static boolean writeFileSafety(AtomicFileWriter writer, Path path, String content)
+            throws IOException {
+        AtomicFsDataOutputStream out = writer.open(path);
+        try {
+            FileUtils.writeOutputStreamUtf8(out, content);
+            boolean success = out.closeAndCommit();
+            if (success) {
+                return content.equals(FileUtils.readFileUtf8(path));
+            } else {
+                return false;
+            }
+        } catch (IOException e) {
+            out.close();
+            return false;
+        }
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RecoverableAtomicFileWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RecoverableAtomicFileWriter.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.utils;
+
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
+import org.apache.flink.core.fs.RecoverableWriter;
+
+import java.io.IOException;
+
+/** A {@link AtomicFileWriter} to wrap {@link RecoverableWriter}. */
+public class RecoverableAtomicFileWriter implements AtomicFileWriter {
+
+    private final RecoverableWriter recoverableWriter;
+
+    public RecoverableAtomicFileWriter(RecoverableWriter recoverableWriter) {
+        this.recoverableWriter = recoverableWriter;
+    }
+
+    @Override
+    public AtomicFsDataOutputStream open(Path path) throws IOException {
+        RecoverableFsDataOutputStream out = recoverableWriter.open(path);
+        return new RecoverableAtomicFsDataOutputStream(out);
+    }
+
+    private static class RecoverableAtomicFsDataOutputStream extends AtomicFsDataOutputStream {
+
+        private final RecoverableFsDataOutputStream out;
+
+        public RecoverableAtomicFsDataOutputStream(RecoverableFsDataOutputStream out) {
+            this.out = out;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            this.out.write(b);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            this.out.write(b, off, len);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            this.out.flush();
+        }
+
+        @Override
+        public void sync() throws IOException {
+            this.out.sync();
+        }
+
+        @Override
+        public long getPos() throws IOException {
+            return this.out.getPos();
+        }
+
+        @Override
+        public boolean closeAndCommit() throws IOException {
+            RecoverableFsDataOutputStream.Committer committer = this.out.closeForCommit();
+            committer.commit();
+
+            /*
+             * When using RecoverableWriter, we can only return true, and there are
+             * two cases where commit actually fails.
+             * 1. Commit has an exception, here it will not return true, throwing an
+             *    exception for the outer caller to handle.
+             * 2. Commit fails but there is no exception. This case requires the outer
+             *    caller to have a lock to ensure that there is no concurrent writing of
+             *    the current file.
+             */
+            return true;
+        }
+
+        @Override
+        public void close() throws IOException {
+            this.out.close();
+        }
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RenamingAtomicFsDataOutputStream.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RenamingAtomicFsDataOutputStream.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.utils;
+
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.FileStatus;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+
+import java.io.IOException;
+
+/**
+ * A stream initially writes to hidden files or temp files and only creates the target file once it
+ * is closed and "committed".
+ */
+public class RenamingAtomicFsDataOutputStream extends AtomicFsDataOutputStream {
+
+    private final FileSystem fs;
+    private final Path targetFile;
+    private final Path tempFile;
+    private final FSDataOutputStream out;
+
+    public RenamingAtomicFsDataOutputStream(FileSystem fs, Path targetFile, Path tempFile)
+            throws IOException {
+        this.fs = fs;
+        this.targetFile = targetFile;
+        this.tempFile = tempFile;
+        this.out = fs.create(tempFile, FileSystem.WriteMode.OVERWRITE);
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        this.out.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        this.out.write(b, off, len);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        this.out.flush();
+    }
+
+    @Override
+    public void sync() throws IOException {
+        this.out.sync();
+    }
+
+    @Override
+    public long getPos() throws IOException {
+        return this.out.getPos();
+    }
+
+    @Override
+    public boolean closeAndCommit() throws IOException {
+        final long offset = getPos();
+        out.close();
+
+        final FileStatus srcStatus;
+        try {
+            srcStatus = fs.getFileStatus(tempFile);
+        } catch (IOException e) {
+            throw new IOException("Cannot clean commit: Staging file does not exist.");
+        }
+
+        if (srcStatus.getLen() != offset) {
+            throw new IOException("Cannot clean commit: File has trailing junk data.");
+        }
+
+        try {
+            boolean success = fs.rename(tempFile, targetFile);
+            if (success) {
+                return true;
+            } else {
+                FileUtils.deleteOrWarn(tempFile);
+                return false;
+            }
+        } catch (IOException e) {
+            FileUtils.deleteOrWarn(tempFile);
+            throw new IOException(
+                    "Committing file by rename failed: " + tempFile + " to " + targetFile, e);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        out.close();
+        FileUtils.deleteOrWarn(tempFile);
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/SnapshotManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/SnapshotManager.java
@@ -51,10 +51,6 @@ public class SnapshotManager {
         return new Path(tablePath + "/snapshot/" + SNAPSHOT_PREFIX + snapshotId);
     }
 
-    public Path tmpSnapshotPath(long id) {
-        return new Path(tablePath + "/snapshot/." + SNAPSHOT_PREFIX + id + "-" + UUID.randomUUID());
-    }
-
     public Snapshot snapshot(long snapshotId) {
         return Snapshot.fromPath(snapshotPath(snapshotId));
     }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/AtomicFileWriterTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/AtomicFileWriterTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.utils;
+
+import org.apache.flink.core.fs.Path;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import static org.apache.flink.table.store.file.utils.FileUtils.readFileUtf8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link AtomicFileWriter}. */
+public class AtomicFileWriterTest {
+
+    @TempDir java.nio.file.Path tempDir;
+
+    private Path root;
+
+    @BeforeEach
+    public void beforeEach() {
+        root = new Path(TestAtomicRenameFileSystem.SCHEME + "://" + tempDir.toString());
+    }
+
+    @Test
+    public void testDefault() throws IOException {
+        test(root, AtomicFileWriter.create(root.getFileSystem()));
+    }
+
+    @Test
+    public void testSafety() throws IOException {
+        AtomicFileWriter writer =
+                path ->
+                        new RenamingAtomicFsDataOutputStream(
+                                path.getFileSystem(),
+                                path,
+                                new Path(
+                                        path.getParent(),
+                                        "." + path.getName() + UUID.randomUUID())) {
+                            @Override
+                            public boolean closeAndCommit() throws IOException {
+                                super.closeAndCommit();
+
+                                // always return true
+                                return true;
+                            }
+                        };
+        test(root, writer);
+    }
+
+    private void test(Path root, AtomicFileWriter writer) throws IOException {
+        Path path1 = new Path(root, "f1");
+        boolean success = writer.writeFileSafety(path1, "hahaha");
+        assertThat(success).isTrue();
+        assertThat(readFileUtf8(path1)).isEqualTo("hahaha");
+
+        success = writer.writeFileSafety(path1, "xixixi");
+        assertThat(success).isFalse();
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/MetaFileWriterTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/MetaFileWriterTest.java
@@ -28,10 +28,11 @@ import java.io.IOException;
 import java.util.UUID;
 
 import static org.apache.flink.table.store.file.utils.FileUtils.readFileUtf8;
+import static org.apache.flink.table.store.file.utils.MetaFileWriter.writeFileSafety;
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Test for {@link AtomicFileWriter}. */
-public class AtomicFileWriterTest {
+/** Test for {@link MetaFileWriter}. */
+public class MetaFileWriterTest {
 
     @TempDir java.nio.file.Path tempDir;
 
@@ -70,11 +71,11 @@ public class AtomicFileWriterTest {
 
     private void test(Path root, AtomicFileWriter writer) throws IOException {
         Path path1 = new Path(root, "f1");
-        boolean success = writer.writeFileSafety(path1, "hahaha");
+        boolean success = writeFileSafety(writer, path1, "hahaha");
         assertThat(success).isTrue();
         assertThat(readFileUtf8(path1)).isEqualTo("hahaha");
 
-        success = writer.writeFileSafety(path1, "xixixi");
+        success = writeFileSafety(writer, path1, "xixixi");
         assertThat(success).isFalse();
     }
 }


### PR DESCRIPTION
In FileStoreCommitImpl, currently, it uses `rename` to support atomic commit.
But this is not work for object store like S3. We can use RecoverableWriter to support atomic commit for object store.
We can introduce `AtomicFileWriter`:
- Use rename if createRecoverableWriter is not supported or the filesystem is FILE_SYSTEM
- Use RecoverableWriter if FileSystem supports createRecoverableWriter
