### PR TITLE
[hotfix] Fix SqlParserEOFException in AlterTableCompactITCase

### DIFF
--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/AlterTableCompactITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/AlterTableCompactITCase.java
@@ -239,6 +239,8 @@ public class AlterTableCompactITCase extends FileStoreTableITCase {
             KeyValue kv = generator.next();
             if (kv.valueKind() == ValueKind.ADD) {
                 data.add(kv);
+            } else {
+                data.add(kv.replace(kv.key(), ValueKind.ADD, kv.value()));
             }
         }
         return data;


### PR DESCRIPTION
It case is unstable, see https://github.com/apache/flink-table-store/runs/6985604079?check_suite_focus=true

The exception is caused by the empty list returned by `generateData`