### PR TITLE
[FLINK-28211] Rename Schema to TableSchema

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/AbstractTableStoreFactory.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/AbstractTableStoreFactory.java
@@ -32,7 +32,7 @@ import org.apache.flink.table.store.connector.sink.TableStoreSink;
 import org.apache.flink.table.store.connector.source.TableStoreSource;
 import org.apache.flink.table.store.file.FileStoreOptions;
 import org.apache.flink.table.store.file.mergetree.MergeTreeOptions;
-import org.apache.flink.table.store.file.schema.Schema;
+import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.schema.UpdateSchema;
 import org.apache.flink.table.store.log.LogOptions;
 import org.apache.flink.table.store.log.LogStoreTableFactory;
@@ -164,7 +164,7 @@ public abstract class AbstractTableStoreFactory
                 FileStoreTableFactory.create(
                         Configuration.fromMap(context.getCatalogTable().getOptions()));
 
-        Schema schema = table.schema();
+        TableSchema tableSchema = table.schema();
         UpdateSchema updateSchema = UpdateSchema.fromCatalogTable(context.getCatalogTable());
 
         RowType rowType = updateSchema.rowType();
@@ -173,24 +173,24 @@ public abstract class AbstractTableStoreFactory
 
         // compare fields to ignore isNullable for row type
         Preconditions.checkArgument(
-                schema.logicalRowType().getFields().equals(rowType.getFields()),
+                tableSchema.logicalRowType().getFields().equals(rowType.getFields()),
                 "Flink schema and store schema are not the same, "
                         + "store schema is %s, Flink schema is %s",
-                schema.logicalRowType(),
+                tableSchema.logicalRowType(),
                 rowType);
 
         Preconditions.checkArgument(
-                schema.partitionKeys().equals(partitionKeys),
+                tableSchema.partitionKeys().equals(partitionKeys),
                 "Flink partitionKeys and store partitionKeys are not the same, "
                         + "store partitionKeys is %s, Flink partitionKeys is %s",
-                schema.partitionKeys(),
+                tableSchema.partitionKeys(),
                 partitionKeys);
 
         Preconditions.checkArgument(
-                schema.primaryKeys().equals(primaryKeys),
+                tableSchema.primaryKeys().equals(primaryKeys),
                 "Flink primaryKeys and store primaryKeys are not the same, "
                         + "store primaryKeys is %s, Flink primaryKeys is %s",
-                schema.primaryKeys(),
+                tableSchema.primaryKeys(),
                 primaryKeys);
 
         return table;

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/BucketStreamPartitioner.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/BucketStreamPartitioner.java
@@ -23,26 +23,26 @@ import org.apache.flink.runtime.plugable.SerializationDelegate;
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.store.file.schema.Schema;
+import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.table.sink.SinkRecordConverter;
 
 /** A {@link StreamPartitioner} to partition records by bucket. */
 public class BucketStreamPartitioner extends StreamPartitioner<RowData> {
 
     private final int numBucket;
-    private final Schema schema;
+    private final TableSchema tableSchema;
 
     private transient SinkRecordConverter recordConverter;
 
-    public BucketStreamPartitioner(int numBucket, Schema schema) {
+    public BucketStreamPartitioner(int numBucket, TableSchema tableSchema) {
         this.numBucket = numBucket;
-        this.schema = schema;
+        this.tableSchema = tableSchema;
     }
 
     @Override
     public void setup(int numberOfChannels) {
         super.setup(numberOfChannels);
-        this.recordConverter = new SinkRecordConverter(numBucket, schema);
+        this.recordConverter = new SinkRecordConverter(numBucket, tableSchema);
     }
 
     @Override

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/RescaleBucketITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/RescaleBucketITCase.java
@@ -25,8 +25,8 @@ import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.store.file.Snapshot;
-import org.apache.flink.table.store.file.schema.Schema;
 import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
 import org.apache.flink.types.Row;
 
@@ -162,9 +162,10 @@ public class RescaleBucketITCase extends FileStoreTableITCase {
     private void assertLatestSchema(
             SchemaManager schemaManager, long expectedSchemaId, int expectedBucketNum) {
         assertThat(schemaManager.latest()).isPresent();
-        Schema schema = schemaManager.latest().get();
-        assertThat(schema.id()).isEqualTo(expectedSchemaId);
-        assertThat(schema.options()).containsEntry(BUCKET.key(), String.valueOf(expectedBucketNum));
+        TableSchema tableSchema = schemaManager.latest().get();
+        assertThat(tableSchema.id()).isEqualTo(expectedSchemaId);
+        assertThat(tableSchema.options())
+                .containsEntry(BUCKET.key(), String.valueOf(expectedBucketNum));
     }
 
     private void assertSnapshotSchema(
@@ -173,8 +174,9 @@ public class RescaleBucketITCase extends FileStoreTableITCase {
             long expectedSchemaId,
             int expectedBucketNum) {
         assertThat(schemaIdFromSnapshot).isEqualTo(expectedSchemaId);
-        Schema schema = schemaManager.schema(schemaIdFromSnapshot);
-        assertThat(schema.options()).containsEntry(BUCKET.key(), String.valueOf(expectedBucketNum));
+        TableSchema tableSchema = schemaManager.schema(schemaIdFromSnapshot);
+        assertThat(tableSchema.options())
+                .containsEntry(BUCKET.key(), String.valueOf(expectedBucketNum));
     }
 
     private void innerTest(String catalogName, String tableName, boolean managedTable) {

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/StoreSinkTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/StoreSinkTest.java
@@ -33,8 +33,8 @@ import org.apache.flink.table.store.connector.StatefulPrecommittingSinkWriter;
 import org.apache.flink.table.store.connector.sink.TestFileStore.TestRecordWriter;
 import org.apache.flink.table.store.file.KeyValue;
 import org.apache.flink.table.store.file.manifest.ManifestCommittable;
-import org.apache.flink.table.store.file.schema.Schema;
 import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.schema.UpdateSchema;
 import org.apache.flink.table.store.file.writer.RecordWriter;
 import org.apache.flink.table.types.logical.IntType;
@@ -89,7 +89,7 @@ public class StoreSinkTest {
 
     @Before
     public void before() throws Exception {
-        Schema schema =
+        TableSchema tableSchema =
                 new SchemaManager(new Path(tempFolder.newFolder().toURI().toString()))
                         .commitNewVersion(
                                 new UpdateSchema(
@@ -105,9 +105,9 @@ public class StoreSinkTest {
                                         new HashMap<>(),
                                         ""));
 
-        RowType partitionType = schema.logicalPartitionType();
+        RowType partitionType = tableSchema.logicalPartitionType();
         fileStore = new TestFileStore(hasPk, partitionType);
-        table = new TestFileStoreTable(fileStore, schema);
+        table = new TestFileStoreTable(fileStore, tableSchema);
     }
 
     @Parameterized.Parameters(name = "hasPk-{0}, partitioned-{1}")

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/TestFileStoreTable.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/TestFileStoreTable.java
@@ -21,7 +21,7 @@ package org.apache.flink.table.store.connector.sink;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.store.file.KeyValue;
 import org.apache.flink.table.store.file.ValueKind;
-import org.apache.flink.table.store.file.schema.Schema;
+import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
 import org.apache.flink.table.store.file.writer.RecordWriter;
 import org.apache.flink.table.store.table.FileStoreTable;
@@ -39,11 +39,11 @@ import org.apache.flink.types.RowKind;
 public class TestFileStoreTable implements FileStoreTable {
 
     private final TestFileStore store;
-    private final Schema schema;
+    private final TableSchema tableSchema;
 
-    public TestFileStoreTable(TestFileStore store, Schema schema) {
+    public TestFileStoreTable(TestFileStore store, TableSchema tableSchema) {
         this.store = store;
-        this.schema = schema;
+        this.tableSchema = tableSchema;
     }
 
     @Override
@@ -52,8 +52,8 @@ public class TestFileStoreTable implements FileStoreTable {
     }
 
     @Override
-    public Schema schema() {
-        return schema;
+    public TableSchema schema() {
+        return tableSchema;
     }
 
     @Override
@@ -74,7 +74,7 @@ public class TestFileStoreTable implements FileStoreTable {
     @Override
     public TableWrite newWrite() {
         return new AbstractTableWrite<KeyValue>(
-                store.newWrite(), new SinkRecordConverter(2, schema)) {
+                store.newWrite(), new SinkRecordConverter(2, tableSchema)) {
             @Override
             protected void writeSinkRecord(SinkRecord record, RecordWriter<KeyValue> writer)
                     throws Exception {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/FileSystemCatalog.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/FileSystemCatalog.java
@@ -37,8 +37,8 @@ import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.factories.DynamicTableFactory;
 import org.apache.flink.table.factories.Factory;
 import org.apache.flink.table.factories.FactoryUtil;
-import org.apache.flink.table.store.file.schema.Schema;
 import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.schema.UpdateSchema;
 import org.apache.flink.util.function.RunnableWithException;
 
@@ -167,12 +167,12 @@ public class FileSystemCatalog extends TableStoreCatalog {
     public CatalogBaseTable getTable(ObjectPath tablePath)
             throws TableNotExistException, CatalogException {
         Path path = tablePath(tablePath);
-        Schema schema =
+        TableSchema tableSchema =
                 new SchemaManager(path)
                         .latest()
                         .orElseThrow(() -> new TableNotExistException(getName(), tablePath));
 
-        CatalogTable table = schema.toUpdateSchema().toCatalogTable();
+        CatalogTable table = tableSchema.toUpdateSchema().toCatalogTable();
         // add path to source and sink
         table.getOptions().put(PATH.key(), path.toString());
         return table;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaSerializer.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaSerializer.java
@@ -31,52 +31,52 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-/** A {@link JsonSerializer} for {@link Schema}. */
-public class SchemaSerializer implements JsonSerializer<Schema> {
+/** A {@link JsonSerializer} for {@link TableSchema}. */
+public class SchemaSerializer implements JsonSerializer<TableSchema> {
 
     public static final SchemaSerializer INSTANCE = new SchemaSerializer();
 
     @Override
-    public void serialize(Schema schema, JsonGenerator generator) throws IOException {
+    public void serialize(TableSchema tableSchema, JsonGenerator generator) throws IOException {
         generator.writeStartObject();
 
-        generator.writeNumberField("id", schema.id());
+        generator.writeNumberField("id", tableSchema.id());
 
         generator.writeArrayFieldStart("fields");
-        for (DataField field : schema.fields()) {
+        for (DataField field : tableSchema.fields()) {
             DataFieldSerializer.INSTANCE.serialize(field, generator);
         }
         generator.writeEndArray();
 
-        generator.writeNumberField("highestFieldId", schema.highestFieldId());
+        generator.writeNumberField("highestFieldId", tableSchema.highestFieldId());
 
         generator.writeArrayFieldStart("partitionKeys");
-        for (String partitionKey : schema.partitionKeys()) {
+        for (String partitionKey : tableSchema.partitionKeys()) {
             generator.writeString(partitionKey);
         }
         generator.writeEndArray();
 
         generator.writeArrayFieldStart("primaryKeys");
-        for (String primaryKey : schema.primaryKeys()) {
+        for (String primaryKey : tableSchema.primaryKeys()) {
             generator.writeString(primaryKey);
         }
         generator.writeEndArray();
 
         generator.writeObjectFieldStart("options");
-        for (Map.Entry<String, String> entry : schema.options().entrySet()) {
+        for (Map.Entry<String, String> entry : tableSchema.options().entrySet()) {
             generator.writeStringField(entry.getKey(), entry.getValue());
         }
         generator.writeEndObject();
 
-        if (!StringUtils.isNullOrWhitespaceOnly(schema.comment())) {
-            generator.writeStringField("comment", schema.comment());
+        if (!StringUtils.isNullOrWhitespaceOnly(tableSchema.comment())) {
+            generator.writeStringField("comment", tableSchema.comment());
         }
 
         generator.writeEndObject();
     }
 
     @Override
-    public Schema deserialize(JsonNode node) {
+    public TableSchema deserialize(JsonNode node) {
         int id = node.get("id").asInt();
 
         Iterator<JsonNode> fieldJsons = node.get("fields").elements();
@@ -113,6 +113,7 @@ public class SchemaSerializer implements JsonSerializer<Schema> {
             comment = commentNode.asText();
         }
 
-        return new Schema(id, fields, highestFieldId, partitionKeys, primaryKeys, options, comment);
+        return new TableSchema(
+                id, fields, highestFieldId, partitionKeys, primaryKeys, options, comment);
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/TableSchema.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/TableSchema.java
@@ -37,8 +37,8 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-/** Schema of table store. */
-public class Schema implements Serializable {
+/** Schema of a table. */
+public class TableSchema implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
@@ -57,7 +57,7 @@ public class Schema implements Serializable {
 
     private final String comment;
 
-    public Schema(
+    public TableSchema(
             long id,
             List<DataField> fields,
             int highestFieldId,
@@ -160,8 +160,8 @@ public class Schema implements Serializable {
                         .logicalType;
     }
 
-    public Schema copy(Map<String, String> newOptions) {
-        return new Schema(
+    public TableSchema copy(Map<String, String> newOptions) {
+        return new TableSchema(
                 id, fields, highestFieldId, partitionKeys, primaryKeys, newOptions, comment);
     }
 
@@ -178,12 +178,12 @@ public class Schema implements Serializable {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        Schema schema = (Schema) o;
-        return Objects.equals(fields, schema.fields)
-                && Objects.equals(partitionKeys, schema.partitionKeys)
-                && Objects.equals(primaryKeys, schema.primaryKeys)
-                && Objects.equals(options, schema.options)
-                && Objects.equals(comment, schema.comment);
+        TableSchema tableSchema = (TableSchema) o;
+        return Objects.equals(fields, tableSchema.fields)
+                && Objects.equals(partitionKeys, tableSchema.partitionKeys)
+                && Objects.equals(primaryKeys, tableSchema.primaryKeys)
+                && Objects.equals(options, tableSchema.options)
+                && Objects.equals(comment, tableSchema.comment);
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/JsonSerdeUtil.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/JsonSerdeUtil.java
@@ -21,8 +21,8 @@ package org.apache.flink.table.store.file.utils;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.store.file.schema.DataField;
 import org.apache.flink.table.store.file.schema.DataFieldSerializer;
-import org.apache.flink.table.store.file.schema.Schema;
 import org.apache.flink.table.store.file.schema.SchemaSerializer;
+import org.apache.flink.table.store.file.schema.TableSchema;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
@@ -71,7 +71,7 @@ public class JsonSerdeUtil {
 
     private static Module createTableStoreJacksonModule() {
         SimpleModule module = new SimpleModule("Table store");
-        registerJsonObjects(module, Schema.class, SchemaSerializer.INSTANCE);
+        registerJsonObjects(module, TableSchema.class, SchemaSerializer.INSTANCE);
         registerJsonObjects(module, DataField.class, DataFieldSerializer.INSTANCE);
         return module;
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AbstractFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AbstractFileStoreTable.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.store.table;
 
 import org.apache.flink.table.store.file.FileStore;
-import org.apache.flink.table.store.file.schema.Schema;
+import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
 import org.apache.flink.table.store.table.sink.TableCommit;
 import org.apache.flink.table.store.table.sink.TableCompact;
@@ -30,11 +30,11 @@ public abstract class AbstractFileStoreTable implements FileStoreTable {
     private static final long serialVersionUID = 1L;
 
     private final String name;
-    protected final Schema schema;
+    protected final TableSchema tableSchema;
 
-    public AbstractFileStoreTable(String name, Schema schema) {
+    public AbstractFileStoreTable(String name, TableSchema tableSchema) {
         this.name = name;
-        this.schema = schema;
+        this.tableSchema = tableSchema;
     }
 
     protected abstract FileStore<?> store();
@@ -45,8 +45,8 @@ public abstract class AbstractFileStoreTable implements FileStoreTable {
     }
 
     @Override
-    public Schema schema() {
-        return schema;
+    public TableSchema schema() {
+        return tableSchema;
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/FileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/FileStoreTable.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.store.table;
 
-import org.apache.flink.table.store.file.schema.Schema;
+import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
 import org.apache.flink.table.store.table.sink.TableCommit;
 import org.apache.flink.table.store.table.sink.TableCompact;
@@ -36,7 +36,7 @@ public interface FileStoreTable extends Serializable {
 
     String name();
 
-    Schema schema();
+    TableSchema schema();
 
     SnapshotManager snapshotManager();
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/SinkRecordConverter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/SinkRecordConverter.java
@@ -22,7 +22,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.runtime.generated.Projection;
 import org.apache.flink.table.store.codegen.CodeGenUtils;
-import org.apache.flink.table.store.file.schema.Schema;
+import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.RowKind;
 
@@ -44,13 +44,13 @@ public class SinkRecordConverter {
 
     @Nullable private final Projection<RowData, BinaryRowData> logPkProjection;
 
-    public SinkRecordConverter(int numBucket, Schema schema) {
+    public SinkRecordConverter(int numBucket, TableSchema tableSchema) {
         this(
                 numBucket,
-                schema.logicalRowType(),
-                schema.projection(schema.partitionKeys()),
-                schema.projection(schema.trimmedPrimaryKeys()),
-                schema.projection(schema.primaryKeys()));
+                tableSchema.logicalRowType(),
+                tableSchema.projection(tableSchema.partitionKeys()),
+                tableSchema.projection(tableSchema.trimmedPrimaryKeys()),
+                tableSchema.projection(tableSchema.primaryKeys()));
     }
 
     public SinkRecordConverter(

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/TableScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/TableScan.java
@@ -27,7 +27,7 @@ import org.apache.flink.table.store.file.predicate.CompoundPredicate;
 import org.apache.flink.table.store.file.predicate.LeafPredicate;
 import org.apache.flink.table.store.file.predicate.Predicate;
 import org.apache.flink.table.store.file.predicate.PredicateBuilder;
-import org.apache.flink.table.store.file.schema.Schema;
+import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 
 import javax.annotation.Nullable;
@@ -41,12 +41,13 @@ import java.util.Optional;
 public abstract class TableScan {
 
     private final FileStoreScan scan;
-    private final Schema schema;
+    private final TableSchema tableSchema;
     private final FileStorePathFactory pathFactory;
 
-    protected TableScan(FileStoreScan scan, Schema schema, FileStorePathFactory pathFactory) {
+    protected TableScan(
+            FileStoreScan scan, TableSchema tableSchema, FileStorePathFactory pathFactory) {
         this.scan = scan;
-        this.schema = schema;
+        this.tableSchema = tableSchema;
         this.pathFactory = pathFactory;
     }
 
@@ -63,9 +64,11 @@ public abstract class TableScan {
     }
 
     public TableScan withFilter(Predicate predicate) {
-        List<String> partitionKeys = schema.partitionKeys();
+        List<String> partitionKeys = tableSchema.partitionKeys();
         int[] fieldIdxToPartitionIdx =
-                schema.fields().stream().mapToInt(f -> partitionKeys.indexOf(f.name())).toArray();
+                tableSchema.fields().stream()
+                        .mapToInt(f -> partitionKeys.indexOf(f.name()))
+                        .toArray();
 
         List<Predicate> partitionFilters = new ArrayList<>();
         List<Predicate> nonPartitionFilters = new ArrayList<>();

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/schema/TableSchemaManagerTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/schema/TableSchemaManagerTest.java
@@ -48,7 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /** Test for {@link SchemaManager}. */
-public class SchemaManagerTest {
+public class TableSchemaManagerTest {
 
     @TempDir java.nio.file.Path tempDir;
 
@@ -83,9 +83,10 @@ public class SchemaManagerTest {
 
     @Test
     public void testCommitNewVersion() throws Exception {
-        Schema schema = retryArtificialException(() -> manager.commitNewVersion(updateSchema));
+        TableSchema tableSchema =
+                retryArtificialException(() -> manager.commitNewVersion(updateSchema));
 
-        Optional<Schema> latest = retryArtificialException(() -> manager.latest());
+        Optional<TableSchema> latest = retryArtificialException(() -> manager.latest());
 
         List<DataField> fields =
                 Arrays.asList(
@@ -94,11 +95,11 @@ public class SchemaManagerTest {
                         new DataField(2, "f2", new AtomicDataType(new VarCharType())));
 
         assertThat(latest.isPresent()).isTrue();
-        assertThat(schema).isEqualTo(latest.get());
-        assertThat(schema.fields()).isEqualTo(fields);
-        assertThat(schema.partitionKeys()).isEqualTo(partitionKeys);
-        assertThat(schema.primaryKeys()).isEqualTo(primaryKeys);
-        assertThat(schema.options()).isEqualTo(options);
+        assertThat(tableSchema).isEqualTo(latest.get());
+        assertThat(tableSchema.fields()).isEqualTo(fields);
+        assertThat(tableSchema.partitionKeys()).isEqualTo(partitionKeys);
+        assertThat(tableSchema.primaryKeys()).isEqualTo(primaryKeys);
+        assertThat(tableSchema.options()).isEqualTo(options);
     }
 
     @Test
@@ -108,7 +109,7 @@ public class SchemaManagerTest {
         UpdateSchema updateSchema =
                 new UpdateSchema(rowType, partitionKeys, primaryKeys, newOptions, "my_comment_2");
         retryArtificialException(() -> manager.commitNewVersion(updateSchema));
-        Optional<Schema> latest = retryArtificialException(() -> manager.latest());
+        Optional<TableSchema> latest = retryArtificialException(() -> manager.latest());
         assertThat(latest.isPresent()).isTrue();
         assertThat(latest.get().options()).isEqualTo(newOptions);
     }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/schema/TableSchemaSerializationTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/schema/TableSchemaSerializationTest.java
@@ -29,11 +29,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.flink.table.store.file.schema.SchemaTest.newRowType;
+import static org.apache.flink.table.store.file.schema.TableSchemaTest.newRowType;
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Test for serialize {@link Schema}. */
-public class SchemaSerializationTest {
+/** Test for serialize {@link TableSchema}. */
+public class TableSchemaSerializationTest {
 
     @Test
     public void testSchema() {
@@ -50,11 +50,11 @@ public class SchemaSerializationTest {
         options.put("option-1", "value-1");
         options.put("option-2", "value-2");
 
-        Schema schema =
-                new Schema(1, fields, 10, partitionKeys, primaryKeys, options, "my_comment");
-        String serialized = JsonSerdeUtil.toJson(schema);
+        TableSchema tableSchema =
+                new TableSchema(1, fields, 10, partitionKeys, primaryKeys, options, "my_comment");
+        String serialized = JsonSerdeUtil.toJson(tableSchema);
 
-        Schema deserialized = JsonSerdeUtil.fromJson(serialized, Schema.class);
-        assertThat(deserialized).isEqualTo(schema);
+        TableSchema deserialized = JsonSerdeUtil.fromJson(serialized, TableSchema.class);
+        assertThat(deserialized).isEqualTo(tableSchema);
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/schema/TableSchemaTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/schema/TableSchemaTest.java
@@ -36,8 +36,8 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Test for {@link Schema}. */
-public class SchemaTest {
+/** Test for {@link TableSchema}. */
+public class TableSchemaTest {
 
     @Test
     public void testInvalidPrimaryKeys() {
@@ -52,7 +52,7 @@ public class SchemaTest {
 
         Assertions.assertThrows(
                 IllegalStateException.class,
-                () -> new Schema(1, fields, 10, partitionKeys, primaryKeys, options, ""));
+                () -> new TableSchema(1, fields, 10, partitionKeys, primaryKeys, options, ""));
     }
 
     @Test
@@ -61,7 +61,8 @@ public class SchemaTest {
                 Arrays.asList(
                         new DataField(0, "f0", new AtomicDataType(new IntType())),
                         new DataField(0, "f1", new AtomicDataType(new IntType())));
-        Assertions.assertThrows(RuntimeException.class, () -> Schema.currentHighestFieldId(fields));
+        Assertions.assertThrows(
+                RuntimeException.class, () -> TableSchema.currentHighestFieldId(fields));
     }
 
     @Test
@@ -70,7 +71,7 @@ public class SchemaTest {
                 Arrays.asList(
                         new DataField(0, "f0", new AtomicDataType(new IntType())),
                         new DataField(20, "f1", new AtomicDataType(new IntType())));
-        assertThat(Schema.currentHighestFieldId(fields)).isEqualTo(20);
+        assertThat(TableSchema.currentHighestFieldId(fields)).isEqualTo(20);
     }
 
     @Test
@@ -94,7 +95,7 @@ public class SchemaTest {
                         new DataField(5, "f3", new MultisetDataType(newRowType(6))),
                         new DataField(7, "f4", new MapDataType(newRowType(8), newRowType(9))));
 
-        assertThat(Schema.newFields(type)).isEqualTo(fields);
+        assertThat(TableSchema.newFields(type)).isEqualTo(fields);
     }
 
     static RowType newLogicalRowType() {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTableTest.java
@@ -25,8 +25,8 @@ import org.apache.flink.table.store.file.FileStoreOptions;
 import org.apache.flink.table.store.file.WriteMode;
 import org.apache.flink.table.store.file.predicate.Predicate;
 import org.apache.flink.table.store.file.predicate.PredicateBuilder;
-import org.apache.flink.table.store.file.schema.Schema;
 import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.schema.UpdateSchema;
 import org.apache.flink.table.store.table.sink.TableWrite;
 import org.apache.flink.table.store.table.source.Split;
@@ -167,7 +167,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         conf.set(FileStoreOptions.FILE_FORMAT, "avro");
         conf.set(FileStoreOptions.WRITE_MODE, WriteMode.APPEND_ONLY);
         SchemaManager schemaManager = new SchemaManager(tablePath);
-        Schema schema =
+        TableSchema tableSchema =
                 schemaManager.commitNewVersion(
                         new UpdateSchema(
                                 ROW_TYPE,
@@ -175,6 +175,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                                 Collections.emptyList(),
                                 conf.toMap(),
                                 ""));
-        return new AppendOnlyFileStoreTable(tablePath.getName(), schemaManager, schema, "user");
+        return new AppendOnlyFileStoreTable(
+                tablePath.getName(), schemaManager, tableSchema, "user");
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTableTest.java
@@ -25,8 +25,8 @@ import org.apache.flink.table.store.file.FileStoreOptions;
 import org.apache.flink.table.store.file.WriteMode;
 import org.apache.flink.table.store.file.predicate.Predicate;
 import org.apache.flink.table.store.file.predicate.PredicateBuilder;
-import org.apache.flink.table.store.file.schema.Schema;
 import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.schema.UpdateSchema;
 import org.apache.flink.table.store.table.sink.TableWrite;
 import org.apache.flink.table.store.table.source.Split;
@@ -170,7 +170,7 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
         conf.set(FileStoreOptions.FILE_FORMAT, "avro");
         conf.set(FileStoreOptions.WRITE_MODE, WriteMode.CHANGE_LOG);
         SchemaManager schemaManager = new SchemaManager(tablePath);
-        Schema schema =
+        TableSchema tableSchema =
                 schemaManager.commitNewVersion(
                         new UpdateSchema(
                                 ROW_TYPE,
@@ -179,6 +179,6 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
                                 conf.toMap(),
                                 ""));
         return new ChangelogValueCountFileStoreTable(
-                tablePath.getName(), schemaManager, schema, "user");
+                tablePath.getName(), schemaManager, tableSchema, "user");
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTableTest.java
@@ -25,8 +25,8 @@ import org.apache.flink.table.store.file.FileStoreOptions;
 import org.apache.flink.table.store.file.WriteMode;
 import org.apache.flink.table.store.file.predicate.Predicate;
 import org.apache.flink.table.store.file.predicate.PredicateBuilder;
-import org.apache.flink.table.store.file.schema.Schema;
 import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.schema.UpdateSchema;
 import org.apache.flink.table.store.table.sink.TableWrite;
 import org.apache.flink.table.store.table.source.Split;
@@ -169,7 +169,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         conf.set(FileStoreOptions.FILE_FORMAT, "avro");
         conf.set(FileStoreOptions.WRITE_MODE, WriteMode.CHANGE_LOG);
         SchemaManager schemaManager = new SchemaManager(tablePath);
-        Schema schema =
+        TableSchema tableSchema =
                 schemaManager.commitNewVersion(
                         new UpdateSchema(
                                 ROW_TYPE,
@@ -178,6 +178,6 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
                                 conf.toMap(),
                                 ""));
         return new ChangelogWithKeyFileStoreTable(
-                tablePath.getName(), schemaManager, schema, "user");
+                tablePath.getName(), schemaManager, tableSchema, "user");
     }
 }

--- a/flink-table-store-hive/src/main/java/org/apache/flink/table/store/mapred/TableStoreInputFormat.java
+++ b/flink-table-store-hive/src/main/java/org/apache/flink/table/store/mapred/TableStoreInputFormat.java
@@ -24,7 +24,7 @@ import org.apache.flink.table.store.SearchArgumentToPredicateConverter;
 import org.apache.flink.table.store.TableStoreJobConf;
 import org.apache.flink.table.store.file.FileStoreOptions;
 import org.apache.flink.table.store.file.predicate.Predicate;
-import org.apache.flink.table.store.file.schema.Schema;
+import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.table.FileStoreTable;
 import org.apache.flink.table.store.table.FileStoreTableFactory;
 import org.apache.flink.table.store.table.source.TableScan;
@@ -77,7 +77,7 @@ public class TableStoreInputFormat implements InputFormat<Void, RowDataContainer
         return FileStoreTableFactory.create(conf, wrapper.getFileStoreUser());
     }
 
-    private Optional<Predicate> createPredicate(Schema schema, JobConf jobConf) {
+    private Optional<Predicate> createPredicate(TableSchema tableSchema, JobConf jobConf) {
         String hiveFilter = jobConf.get(TableScanDesc.FILTER_EXPR_CONF_STR);
         if (hiveFilter == null) {
             return Optional.empty();
@@ -88,7 +88,7 @@ public class TableStoreInputFormat implements InputFormat<Void, RowDataContainer
         SearchArgument sarg = ConvertAstToSearchArg.create(jobConf, exprNodeDesc);
         SearchArgumentToPredicateConverter converter =
                 new SearchArgumentToPredicateConverter(
-                        sarg, schema.fieldNames(), schema.logicalRowType().getChildren());
+                        sarg, tableSchema.fieldNames(), tableSchema.logicalRowType().getChildren());
         return converter.convert();
     }
 }

--- a/flink-table-store-hive/src/test/java/org/apache/flink/table/store/hive/HiveTableSchemaTest.java
+++ b/flink-table-store-hive/src/test/java/org/apache/flink/table/store/hive/HiveTableSchemaTest.java
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /** Tests for {@link HiveSchema}. */
-public class HiveSchemaTest {
+public class HiveTableSchemaTest {
 
     private static final RowType ROW_TYPE =
             new RowType(

--- a/tools/maven/suppressions.xml
+++ b/tools/maven/suppressions.xml
@@ -80,6 +80,6 @@ under the License.
 			files="[\\/]target[\\/]"
 			checks=".*"/>
 		<suppress
-			files="org[\\/]apache[\\/]flink[\\/]formats[\\/]avro[\\/]glue[\\/]tableSchema[\\/]registry[\\/]User.java"
+			files="org[\\/]apache[\\/]flink[\\/]formats[\\/]avro[\\/]glue[\\/]schema[\\/]registry[\\/]User.java"
 			checks=".*"/>
 </suppressions>

--- a/tools/maven/suppressions.xml
+++ b/tools/maven/suppressions.xml
@@ -80,6 +80,6 @@ under the License.
 			files="[\\/]target[\\/]"
 			checks=".*"/>
 		<suppress
-			files="org[\\/]apache[\\/]flink[\\/]formats[\\/]avro[\\/]glue[\\/]schema[\\/]registry[\\/]User.java"
+			files="org[\\/]apache[\\/]flink[\\/]formats[\\/]avro[\\/]glue[\\/]tableSchema[\\/]registry[\\/]User.java"
 			checks=".*"/>
 </suppressions>


### PR DESCRIPTION
There are some systems that use schema as a concept of database, so the Schema class will be very confuse in this case, it is better to rename it as TableSchema.