### PR TITLE
[FLINK-27897] SearchArgumentToPredicateConverter can now keep partial results and throw away unsupported filters

### DIFF
--- a/flink-table-store-hive/src/test/java/org/apache/flink/table/store/SearchArgumentToPredicateConverterTest.java
+++ b/flink-table-store-hive/src/test/java/org/apache/flink/table/store/SearchArgumentToPredicateConverterTest.java
@@ -105,7 +105,6 @@ public class SearchArgumentToPredicateConverterTest {
                     DataTypes.INT().getLogicalType(),
                     DataTypes.BIGINT().getLogicalType(),
                     DataTypes.DOUBLE().getLogicalType());
-    private static final LogicalType BIGINT_TYPE = DataTypes.BIGINT().getLogicalType();
     private static final PredicateBuilder BUILDER =
             new PredicateBuilder(
                     RowType.of(
@@ -318,6 +317,33 @@ public class SearchArgumentToPredicateConverterTest {
         Predicate expected =
                 PredicateBuilder.or(
                         BUILDER.equal(1, 100L), BUILDER.equal(1, 200L), BUILDER.equal(1, 300L));
+        assertExpected(sarg, expected);
+    }
+
+    @Test
+    public void testUnsupported() {
+        SearchArgument.Builder builder = SearchArgumentFactory.newBuilder();
+        SearchArgument sarg =
+                builder.nullSafeEquals("f_bigint", PredicateLeaf.Type.LONG, 100L).build();
+        assertExpected(sarg, null);
+    }
+
+    @Test
+    public void testKeepPartialResult() {
+        SearchArgument.Builder builder = SearchArgumentFactory.newBuilder();
+        SearchArgument sarg =
+                builder.startAnd()
+                        .startNot()
+                        .nullSafeEquals("f_bigint", PredicateLeaf.Type.LONG, 100L)
+                        .end()
+                        .lessThanEquals("f_bigint", PredicateLeaf.Type.LONG, 200L)
+                        .startNot()
+                        .lessThan("f_bigint", PredicateLeaf.Type.LONG, 0L)
+                        .end()
+                        .end()
+                        .build();
+        Predicate expected =
+                PredicateBuilder.and(BUILDER.lessOrEqual(1, 200L), BUILDER.greaterOrEqual(1, 0L));
         assertExpected(sarg, expected);
     }
 


### PR DESCRIPTION
For example: `SLECT * FROM T WHERE a = 1 and ${unsupported_filters};`

According to the reasonable path, the condition `a=1` should be able to be pushed down to the table store, but currently the whole will throw `UnsupportedOperationException`, resulting in `a=1` not being pushed down.