### PR TITLE
[FLINK-28255] Add extraFiles to DataFileMeta

### DIFF
--- a/flink-table-store-common/src/main/java/org/apache/flink/table/store/utils/RowDataUtils.java
+++ b/flink-table-store-common/src/main/java/org/apache/flink/table/store/utils/RowDataUtils.java
@@ -43,7 +43,9 @@ import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.TimestampType;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /** Utils for {@link RowData} structures. */
@@ -255,5 +257,17 @@ public class RowDataUtils {
             default:
                 throw new UnsupportedOperationException("Unsupported type: " + fieldType);
         }
+    }
+
+    public static ArrayData toStringArrayData(List<String> list) {
+        return new GenericArrayData(list.stream().map(StringData::fromString).toArray());
+    }
+
+    public static List<String> fromStringArrayData(ArrayData arrayData) {
+        List<String> list = new ArrayList<>(arrayData.size());
+        for (int i = 0; i < arrayData.size(); i++) {
+            list.add(arrayData.isNullAt(i) ? null : arrayData.getString(i).toString());
+        }
+        return list;
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileMetaSerializer.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileMetaSerializer.java
@@ -26,6 +26,8 @@ import org.apache.flink.table.store.file.utils.ObjectSerializer;
 
 import static org.apache.flink.table.store.file.utils.SerializationUtils.deserializeBinaryRow;
 import static org.apache.flink.table.store.file.utils.SerializationUtils.serializeBinaryRow;
+import static org.apache.flink.table.store.utils.RowDataUtils.fromStringArrayData;
+import static org.apache.flink.table.store.utils.RowDataUtils.toStringArrayData;
 
 /** Serializer for {@link DataFileMeta}. */
 public class DataFileMetaSerializer extends ObjectSerializer<DataFileMeta> {
@@ -49,7 +51,8 @@ public class DataFileMetaSerializer extends ObjectSerializer<DataFileMeta> {
                 meta.minSequenceNumber(),
                 meta.maxSequenceNumber(),
                 meta.schemaId(),
-                meta.level());
+                meta.level(),
+                toStringArrayData(meta.extraFiles()));
     }
 
     @Override
@@ -65,6 +68,7 @@ public class DataFileMetaSerializer extends ObjectSerializer<DataFileMeta> {
                 row.getLong(7),
                 row.getLong(8),
                 row.getLong(9),
-                row.getInt(10));
+                row.getInt(10),
+                fromStringArrayData(row.getArray(11)));
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/FileStorePathFactory.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/FileStorePathFactory.java
@@ -33,8 +33,6 @@ import org.apache.flink.util.Preconditions;
 
 import javax.annotation.concurrent.ThreadSafe;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -130,28 +128,5 @@ public class FileStorePathFactory {
     @VisibleForTesting
     public String uuid() {
         return uuid;
-    }
-
-    /** Cache for storing {@link DataFilePathFactory}s. */
-    public static class DataFilePathFactoryCache {
-
-        private final FileStorePathFactory pathFactory;
-        private final Map<BinaryRowData, Map<Integer, DataFilePathFactory>> cache;
-
-        public DataFilePathFactoryCache(FileStorePathFactory pathFactory) {
-            this.pathFactory = pathFactory;
-            this.cache = new HashMap<>();
-        }
-
-        public DataFilePathFactory getDataFilePathFactory(BinaryRowData partition, int bucket) {
-            return cache.compute(partition, (p, m) -> m == null ? new HashMap<>() : m)
-                    .compute(
-                            bucket,
-                            (b, f) ->
-                                    f == null
-                                            ? pathFactory.createDataFilePathFactory(
-                                                    partition, bucket)
-                                            : f);
-        }
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/SerializationUtils.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/SerializationUtils.java
@@ -24,6 +24,7 @@ import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.runtime.typeutils.BinaryRowDataSerializer;
 import org.apache.flink.table.types.logical.VarBinaryType;
+import org.apache.flink.table.types.logical.VarCharType;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -58,9 +59,14 @@ public class SerializationUtils {
         return buf;
     }
 
-    /** Create a bytes type VarBinaryType(Integer.MAX_VALUE). */
+    /** Create a bytes type VarBinaryType(VarBinaryType.MAX_LENGTH). */
     public static VarBinaryType newBytesType(boolean isNullable) {
-        return new VarBinaryType(isNullable, Integer.MAX_VALUE);
+        return new VarBinaryType(isNullable, VarBinaryType.MAX_LENGTH);
+    }
+
+    /** Create a varchar type VarCharType(VarCharType.MAX_LENGTH). */
+    public static VarCharType newStringType(boolean isNullable) {
+        return new VarCharType(isNullable, VarCharType.MAX_LENGTH);
     }
 
     /**

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -350,8 +350,6 @@ public class TestFileStore extends KeyValueFileStore {
         FileStorePathFactory pathFactory = pathFactory();
         ManifestList manifestList = manifestListFactory().create();
         FileStoreScan scan = newScan();
-        FileStorePathFactory.DataFilePathFactoryCache dataFilePathFactoryCache =
-                new FileStorePathFactory.DataFilePathFactoryCache(pathFactory);
 
         SnapshotManager snapshotManager = snapshotManager();
         Long latestSnapshotId = snapshotManager.latestSnapshotId();
@@ -387,9 +385,9 @@ public class TestFileStore extends KeyValueFileStore {
             List<ManifestEntry> entries = scan.withManifestList(manifests).plan().files();
             for (ManifestEntry entry : entries) {
                 result.add(
-                        dataFilePathFactoryCache
-                                .getDataFilePathFactory(entry.partition(), entry.bucket())
-                                .toPath(entry.file().fileName()));
+                        new Path(
+                                pathFactory.bucketPath(entry.partition(), entry.bucket()),
+                                entry.file().fileName()));
             }
         }
         return result;

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileMetaSerializerTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileMetaSerializerTest.java
@@ -20,6 +20,8 @@ package org.apache.flink.table.store.file.data;
 
 import org.apache.flink.table.store.file.utils.ObjectSerializerTestBase;
 
+import java.util.Arrays;
+
 /** Tests for {@link DataFileMetaSerializer}. */
 public class DataFileMetaSerializerTest extends ObjectSerializerTestBase<DataFileMeta> {
 
@@ -32,6 +34,6 @@ public class DataFileMetaSerializerTest extends ObjectSerializerTestBase<DataFil
 
     @Override
     protected DataFileMeta object() {
-        return gen.next().meta;
+        return gen.next().meta.copy(Arrays.asList("extra1", "extra2"));
     }
 }


### PR DESCRIPTION
See [FLINK-28244](https://issues.apache.org/jira/browse/FLINK-28244)
 ```
class DataFileMeta {
    String fileName;
    .....
    // store the name of extra files, extra files including changelog_file,
   // primary_key_index_file,secondary_index_file, and etc...
    List<String> extraFiles;
}
```
Extra files can help us for many uses, including index files, changelog files and etc...