### PR TITLE
[FLINK-28264] Refactor split and read in table store

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/ContinuousFileSplitEnumerator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/ContinuousFileSplitEnumerator.java
@@ -95,7 +95,7 @@ public class ContinuousFileSplitEnumerator
     }
 
     private void addSplit(FileStoreSourceSplit split) {
-        bucketSplits.computeIfAbsent(split.bucket(), i -> new LinkedList<>()).add(split);
+        bucketSplits.computeIfAbsent(split.split().bucket(), i -> new LinkedList<>()).add(split);
     }
 
     @Override

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSource.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSource.java
@@ -80,7 +80,7 @@ public class FileStoreSource
 
     @Override
     public SourceReader<RowData, FileStoreSourceSplit> createReader(SourceReaderContext context) {
-        TableRead read = table.newRead().withIncremental(isContinuous);
+        TableRead read = table.newRead();
         if (projectedFields != null) {
             read.withProjection(projectedFields);
         }

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplit.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplit.java
@@ -19,10 +19,8 @@
 package org.apache.flink.table.store.connector.source;
 
 import org.apache.flink.api.connector.source.SourceSplit;
-import org.apache.flink.table.data.binary.BinaryRowData;
-import org.apache.flink.table.store.file.data.DataFileMeta;
+import org.apache.flink.table.store.table.source.Split;
 
-import java.util.List;
 import java.util.Objects;
 
 /** {@link SourceSplit} of file store. */
@@ -31,42 +29,22 @@ public class FileStoreSourceSplit implements SourceSplit {
     /** The unique ID of the split. Unique within the scope of this source. */
     private final String id;
 
-    private final BinaryRowData partition;
-
-    private final int bucket;
-
-    private final List<DataFileMeta> files;
+    private final Split split;
 
     private final long recordsToSkip;
 
-    public FileStoreSourceSplit(
-            String id, BinaryRowData partition, int bucket, List<DataFileMeta> files) {
-        this(id, partition, bucket, files, 0);
+    public FileStoreSourceSplit(String id, Split split) {
+        this(id, split, 0);
     }
 
-    public FileStoreSourceSplit(
-            String id,
-            BinaryRowData partition,
-            int bucket,
-            List<DataFileMeta> files,
-            long recordsToSkip) {
+    public FileStoreSourceSplit(String id, Split split, long recordsToSkip) {
         this.id = id;
-        this.partition = partition;
-        this.bucket = bucket;
-        this.files = files;
+        this.split = split;
         this.recordsToSkip = recordsToSkip;
     }
 
-    public BinaryRowData partition() {
-        return partition;
-    }
-
-    public int bucket() {
-        return bucket;
-    }
-
-    public List<DataFileMeta> files() {
-        return files;
+    public Split split() {
+        return split;
     }
 
     public long recordsToSkip() {
@@ -79,7 +57,7 @@ public class FileStoreSourceSplit implements SourceSplit {
     }
 
     public FileStoreSourceSplit updateWithRecordsToSkip(long recordsToSkip) {
-        return new FileStoreSourceSplit(id, partition, bucket, files, recordsToSkip);
+        return new FileStoreSourceSplit(id, split, recordsToSkip);
     }
 
     @Override
@@ -90,16 +68,14 @@ public class FileStoreSourceSplit implements SourceSplit {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        FileStoreSourceSplit split = (FileStoreSourceSplit) o;
-        return bucket == split.bucket
-                && recordsToSkip == split.recordsToSkip
-                && Objects.equals(id, split.id)
-                && Objects.equals(partition, split.partition)
-                && Objects.equals(files, split.files);
+        FileStoreSourceSplit other = (FileStoreSourceSplit) o;
+        return Objects.equals(id, other.id)
+                && Objects.equals(this.split, other.split)
+                && recordsToSkip == other.recordsToSkip;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, partition, bucket, files, recordsToSkip);
+        return Objects.hash(id, split, recordsToSkip);
     }
 }

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitGenerator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitGenerator.java
@@ -37,10 +37,7 @@ public class FileStoreSourceSplitGenerator {
 
     public List<FileStoreSourceSplit> createSplits(TableScan.Plan plan) {
         return plan.splits.stream()
-                .map(
-                        s ->
-                                new FileStoreSourceSplit(
-                                        getNextId(), s.partition(), s.bucket(), s.files()))
+                .map(s -> new FileStoreSourceSplit(getNextId(), s))
                 .collect(Collectors.toList());
     }
 

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitReader.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitReader.java
@@ -123,9 +123,7 @@ public class FileStoreSourceSplitReader
         }
 
         currentSplitId = nextSplit.splitId();
-        currentReader =
-                tableRead.createReader(
-                        nextSplit.partition(), nextSplit.bucket(), nextSplit.files());
+        currentReader = tableRead.createReader(nextSplit.split());
         currentNumRead = nextSplit.recordsToSkip();
         if (currentNumRead > 0) {
             seek(currentNumRead);

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/StoreSinkTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/StoreSinkTest.java
@@ -89,8 +89,9 @@ public class StoreSinkTest {
 
     @Before
     public void before() throws Exception {
+        Path path = new Path(tempFolder.newFolder().toURI().toString());
         TableSchema tableSchema =
-                new SchemaManager(new Path(tempFolder.newFolder().toURI().toString()))
+                new SchemaManager(path)
                         .commitNewVersion(
                                 new UpdateSchema(
                                         RowType.of(
@@ -107,7 +108,7 @@ public class StoreSinkTest {
 
         RowType partitionType = tableSchema.logicalPartitionType();
         fileStore = new TestFileStore(hasPk, partitionType);
-        table = new TestFileStoreTable(fileStore, tableSchema);
+        table = new TestFileStoreTable(path, fileStore, tableSchema);
     }
 
     @Parameterized.Parameters(name = "hasPk-{0}, partitioned-{1}")

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/TestFileStoreTable.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/TestFileStoreTable.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.store.connector.sink;
 
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.store.file.KeyValue;
 import org.apache.flink.table.store.file.schema.TableSchema;
@@ -37,17 +38,19 @@ import org.apache.flink.types.RowKind;
 /** {@link FileStoreTable} for tests. */
 public class TestFileStoreTable implements FileStoreTable {
 
+    private final Path path;
     private final TestFileStore store;
     private final TableSchema tableSchema;
 
-    public TestFileStoreTable(TestFileStore store, TableSchema tableSchema) {
+    public TestFileStoreTable(Path path, TestFileStore store, TableSchema tableSchema) {
+        this.path = path;
         this.store = store;
         this.tableSchema = tableSchema;
     }
 
     @Override
-    public String name() {
-        return "test";
+    public Path location() {
+        return path;
     }
 
     @Override

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceReaderTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceReaderTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.util.Collections;
 
+import static org.apache.flink.table.store.connector.source.FileStoreSourceSplitSerializerTest.newSourceSplit;
 import static org.apache.flink.table.store.file.mergetree.compact.CompactManagerTest.row;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -63,6 +64,6 @@ public class FileStoreSourceReaderTest {
     }
 
     private static FileStoreSourceSplit createTestFileSplit() {
-        return new FileStoreSourceSplit("id1", row(1), 0, Collections.emptyList());
+        return newSourceSplit("id1", row(1), 0, Collections.emptyList());
     }
 }

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitReaderTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitReaderTest.java
@@ -44,6 +44,7 @@ import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.flink.table.store.connector.source.FileStoreSourceSplitSerializerTest.newSourceSplit;
 import static org.apache.flink.table.store.file.mergetree.compact.CompactManagerTest.row;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -95,7 +96,7 @@ public class FileStoreSourceSplitReaderTest {
         List<Tuple2<Long, Long>> input = kvs();
         List<DataFileMeta> files = rw.writeFiles(row(1), 0, input);
 
-        assignSplit(reader, new FileStoreSourceSplit("id1", row(1), 0, files, skip));
+        assignSplit(reader, newSourceSplit("id1", row(1), 0, files, skip));
 
         RecordsWithSplitIds<RecordAndPosition<RowData>> records = reader.fetch();
 
@@ -131,8 +132,7 @@ public class FileStoreSourceSplitReaderTest {
     @Test
     public void testPrimaryKeyWithDelete() throws Exception {
         TestChangelogDataReadWrite rw = new TestChangelogDataReadWrite(tempDir.toString(), service);
-        FileStoreSourceSplitReader reader =
-                new FileStoreSourceSplitReader(rw.createReadWithKey().withIncremental(true));
+        FileStoreSourceSplitReader reader = new FileStoreSourceSplitReader(rw.createReadWithKey());
 
         List<Tuple2<Long, Long>> input = kvs();
         RecordWriter<KeyValue> writer = rw.createMergeTreeWriter(row(1), 0);
@@ -150,7 +150,7 @@ public class FileStoreSourceSplitReaderTest {
         List<DataFileMeta> files = writer.prepareCommit().newFiles();
         writer.close();
 
-        assignSplit(reader, new FileStoreSourceSplit("id1", row(1), 0, files));
+        assignSplit(reader, newSourceSplit("id1", row(1), 0, files, true));
         RecordsWithSplitIds<RecordAndPosition<RowData>> records = reader.fetch();
 
         List<Tuple2<RowKind, Long>> expected =
@@ -180,7 +180,7 @@ public class FileStoreSourceSplitReaderTest {
         List<DataFileMeta> files2 = rw.writeFiles(row(1), 0, input2);
         files.addAll(files2);
 
-        assignSplit(reader, new FileStoreSourceSplit("id1", row(1), 0, files));
+        assignSplit(reader, newSourceSplit("id1", row(1), 0, files));
 
         RecordsWithSplitIds<RecordAndPosition<RowData>> records = reader.fetch();
         assertRecords(
@@ -212,7 +212,7 @@ public class FileStoreSourceSplitReaderTest {
         List<Tuple2<Long, Long>> input = kvs();
         List<DataFileMeta> files = rw.writeFiles(row(1), 0, input);
 
-        assignSplit(reader, new FileStoreSourceSplit("id1", row(1), 0, files, 3));
+        assignSplit(reader, newSourceSplit("id1", row(1), 0, files, 3));
 
         RecordsWithSplitIds<RecordAndPosition<RowData>> records = reader.fetch();
         assertRecords(
@@ -242,7 +242,7 @@ public class FileStoreSourceSplitReaderTest {
         List<DataFileMeta> files2 = rw.writeFiles(row(1), 0, input2);
         files.addAll(files2);
 
-        assignSplit(reader, new FileStoreSourceSplit("id1", row(1), 0, files, 7));
+        assignSplit(reader, newSourceSplit("id1", row(1), 0, files, 7));
 
         RecordsWithSplitIds<RecordAndPosition<RowData>> records = reader.fetch();
         assertRecords(
@@ -268,11 +268,11 @@ public class FileStoreSourceSplitReaderTest {
 
         List<Tuple2<Long, Long>> input1 = kvs();
         List<DataFileMeta> files1 = rw.writeFiles(row(1), 0, input1);
-        assignSplit(reader, new FileStoreSourceSplit("id1", row(1), 0, files1));
+        assignSplit(reader, newSourceSplit("id1", row(1), 0, files1));
 
         List<Tuple2<Long, Long>> input2 = kvs();
         List<DataFileMeta> files2 = rw.writeFiles(row(2), 1, input2);
-        assignSplit(reader, new FileStoreSourceSplit("id2", row(2), 1, files2));
+        assignSplit(reader, newSourceSplit("id2", row(2), 1, files2));
 
         RecordsWithSplitIds<RecordAndPosition<RowData>> records = reader.fetch();
         assertRecords(

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitStateTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitStateTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 
 import static org.apache.flink.table.store.connector.source.FileStoreSourceSplitSerializerTest.newFile;
+import static org.apache.flink.table.store.connector.source.FileStoreSourceSplitSerializerTest.newSourceSplit;
 import static org.apache.flink.table.store.file.mergetree.compact.CompactManagerTest.row;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -66,7 +67,7 @@ public class FileStoreSourceSplitStateTest {
     }
 
     private static FileStoreSourceSplit getTestSplit(long recordsToSkip) {
-        return new FileStoreSourceSplit(
+        return newSourceSplit(
                 "id", row(1), 2, Arrays.asList(newFile(0), newFile(1)), recordsToSkip);
     }
 }

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/PendingSplitsCheckpointSerializerTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/PendingSplitsCheckpointSerializerTest.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import static org.apache.flink.table.store.connector.source.FileStoreSourceSplitSerializerTest.newFile;
+import static org.apache.flink.table.store.connector.source.FileStoreSourceSplitSerializerTest.newSourceSplit;
 import static org.apache.flink.table.store.file.mergetree.compact.CompactManagerTest.row;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -82,15 +83,15 @@ public class PendingSplitsCheckpointSerializerTest {
     // ------------------------------------------------------------------------
 
     private static FileStoreSourceSplit testSplit1() {
-        return new FileStoreSourceSplit("id1", row(1), 2, Arrays.asList(newFile(0), newFile(1)));
+        return newSourceSplit("id1", row(1), 2, Arrays.asList(newFile(0), newFile(1)));
     }
 
     private static FileStoreSourceSplit testSplit2() {
-        return new FileStoreSourceSplit("id2", row(2), 3, Arrays.asList(newFile(2), newFile(3)));
+        return newSourceSplit("id2", row(2), 3, Arrays.asList(newFile(2), newFile(3)));
     }
 
     private static FileStoreSourceSplit testSplit3() {
-        return new FileStoreSourceSplit("id3", row(3), 4, Arrays.asList(newFile(5), newFile(6)));
+        return newSourceSplit("id3", row(3), 4, Arrays.asList(newFile(5), newFile(6)));
     }
 
     private static PendingSplitsCheckpoint serializeAndDeserialize(

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/StaticFileStoreSplitEnumeratorTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/StaticFileStoreSplitEnumeratorTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 
 import static org.apache.flink.table.store.connector.source.FileStoreSourceSplitSerializerTest.newFile;
+import static org.apache.flink.table.store.connector.source.FileStoreSourceSplitSerializerTest.newSourceSplit;
 import static org.apache.flink.table.store.file.mergetree.compact.CompactManagerTest.row;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -96,7 +97,7 @@ public class StaticFileStoreSplitEnumeratorTest {
     // ------------------------------------------------------------------------
 
     private static FileStoreSourceSplit createRandomSplit() {
-        return new FileStoreSourceSplit("split", row(1), 2, Arrays.asList(newFile(0), newFile(1)));
+        return newSourceSplit("split", row(1), 2, Arrays.asList(newFile(0), newFile(1)));
     }
 
     private static StaticFileStoreSplitEnumerator createEnumerator(

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/TestChangelogDataReadWrite.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/TestChangelogDataReadWrite.java
@@ -95,7 +95,7 @@ public class TestChangelogDataReadWrite {
     }
 
     public TableRead createReadWithValueCount() {
-        return createRead(it -> new ValueCountRowDataRecordIterator(it, null));
+        return createRead(ValueCountRowDataRecordIterator::new);
     }
 
     private TableRead createRead(
@@ -115,12 +115,6 @@ public class TestChangelogDataReadWrite {
             @Override
             public TableRead withProjection(int[][] projection) {
                 throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public TableRead withIncremental(boolean isIncremental) {
-                read.withDropDelete(!isIncremental);
-                return this;
             }
 
             @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValue.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValue.java
@@ -59,6 +59,11 @@ public class KeyValue {
         return this;
     }
 
+    public KeyValue replaceKey(RowData key) {
+        this.key = key;
+        return this;
+    }
+
     public RowData key() {
         return key;
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileReader.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileReader.java
@@ -134,6 +134,7 @@ public class DataFileReader {
         private final FileFormat fileFormat;
         private final FileStorePathFactory pathFactory;
 
+        private final int[][] fullKeyProjection;
         private int[][] keyProjection;
         private int[][] valueProjection;
         private RowType projectedKeyType;
@@ -153,7 +154,8 @@ public class DataFileReader {
             this.fileFormat = fileFormat;
             this.pathFactory = pathFactory;
 
-            this.keyProjection = Projection.range(0, keyType.getFieldCount()).toNestedIndexes();
+            this.fullKeyProjection = Projection.range(0, keyType.getFieldCount()).toNestedIndexes();
+            this.keyProjection = fullKeyProjection;
             this.valueProjection = Projection.range(0, valueType.getFieldCount()).toNestedIndexes();
             applyProjection();
         }
@@ -171,6 +173,13 @@ public class DataFileReader {
         }
 
         public DataFileReader create(BinaryRowData partition, int bucket) {
+            return create(partition, bucket, true);
+        }
+
+        public DataFileReader create(BinaryRowData partition, int bucket, boolean projectKeys) {
+            int[][] keyProjection = projectKeys ? this.keyProjection : fullKeyProjection;
+            RowType projectedKeyType = projectKeys ? this.projectedKeyType : keyType;
+
             RowType recordType = KeyValue.schema(keyType, valueType);
             int[][] projection =
                     KeyValue.project(keyProjection, valueProjection, keyType.getFieldCount());

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AbstractFileStoreScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AbstractFileStoreScan.java
@@ -40,9 +40,8 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -181,7 +180,7 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
             throw new RuntimeException("Failed to read ManifestEntry list concurrently", e);
         }
 
-        Map<ManifestEntry.Identifier, ManifestEntry> map = new HashMap<>();
+        LinkedHashMap<ManifestEntry.Identifier, ManifestEntry> map = new LinkedHashMap<>();
         for (ManifestEntry entry : entries) {
             ManifestEntry.Identifier identifier = entry.identifier();
             switch (entry.kind()) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreRead.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreRead.java
@@ -18,12 +18,10 @@
 
 package org.apache.flink.table.store.file.operation;
 
-import org.apache.flink.table.data.binary.BinaryRowData;
-import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.utils.RecordReader;
+import org.apache.flink.table.store.table.source.Split;
 
 import java.io.IOException;
-import java.util.List;
 
 /**
  * Read operation which provides {@link RecordReader} creation.
@@ -32,7 +30,6 @@ import java.util.List;
  */
 public interface FileStoreRead<T> {
 
-    /** Create a {@link RecordReader} from partition and bucket and files. */
-    RecordReader<T> createReader(BinaryRowData partition, int bucket, List<DataFileMeta> files)
-            throws IOException;
+    /** Create a {@link RecordReader} from split. */
+    RecordReader<T> createReader(Split split) throws IOException;
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreRead.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreRead.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.store.file.operation;
 
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.store.file.KeyValue;
 import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.data.DataFileReader;
@@ -30,7 +29,9 @@ import org.apache.flink.table.store.file.mergetree.compact.IntervalPartition;
 import org.apache.flink.table.store.file.mergetree.compact.MergeFunction;
 import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
+import org.apache.flink.table.store.file.utils.ProjectKeyRecordReader;
 import org.apache.flink.table.store.file.utils.RecordReader;
+import org.apache.flink.table.store.table.source.Split;
 import org.apache.flink.table.types.logical.RowType;
 
 import java.io.IOException;
@@ -48,8 +49,7 @@ public class KeyValueFileStoreRead implements FileStoreRead<KeyValue> {
     private final Comparator<RowData> keyComparator;
     private final MergeFunction mergeFunction;
 
-    private boolean keyProjected;
-    private boolean dropDelete = true;
+    private int[][] keyProjectedFields;
 
     public KeyValueFileStoreRead(
             SchemaManager schemaManager,
@@ -65,18 +65,11 @@ public class KeyValueFileStoreRead implements FileStoreRead<KeyValue> {
                         schemaManager, schemaId, keyType, valueType, fileFormat, pathFactory);
         this.keyComparator = keyComparator;
         this.mergeFunction = mergeFunction;
-
-        this.keyProjected = false;
-    }
-
-    public KeyValueFileStoreRead withDropDelete(boolean dropDelete) {
-        this.dropDelete = dropDelete;
-        return this;
     }
 
     public KeyValueFileStoreRead withKeyProjection(int[][] projectedFields) {
         dataFileReaderFactory.withKeyProjection(projectedFields);
-        keyProjected = true;
+        this.keyProjectedFields = projectedFields;
         return this;
     }
 
@@ -85,43 +78,34 @@ public class KeyValueFileStoreRead implements FileStoreRead<KeyValue> {
         return this;
     }
 
-    /**
-     * The resulting reader has the following characteristics:
-     *
-     * <ul>
-     *   <li>If {@link KeyValueFileStoreRead#withKeyProjection} is called, key-values produced by
-     *       this reader may be unordered and may contain duplicated keys.
-     *   <li>If {@link KeyValueFileStoreRead#withKeyProjection} is not called, key-values produced
-     *       by this reader is guaranteed to be ordered by keys and does not contain duplicated
-     *       keys.
-     * </ul>
-     */
     @Override
-    public RecordReader<KeyValue> createReader(
-            BinaryRowData partition, int bucket, List<DataFileMeta> files) throws IOException {
-        DataFileReader dataFileReader = dataFileReaderFactory.create(partition, bucket);
-        if (keyProjected) {
-            // key projection has been applied, so data file readers will not return key-values in
-            // order, we have to return the raw file contents without merging
+    public RecordReader<KeyValue> createReader(Split split) throws IOException {
+        if (split.isIncremental()) {
+            DataFileReader dataFileReader =
+                    dataFileReaderFactory.create(split.partition(), split.bucket(), true);
+            // Return the raw file contents without merging
             List<ConcatRecordReader.ReaderSupplier<KeyValue>> suppliers = new ArrayList<>();
-            for (DataFileMeta file : files) {
+            for (DataFileMeta file : split.files()) {
                 suppliers.add(() -> dataFileReader.read(file.fileName()));
-            }
-
-            if (dropDelete) {
-                throw new UnsupportedOperationException(
-                        "The key is projected, there is no ability to merge records, so the deleted message cannot be dropped.");
             }
             return ConcatRecordReader.create(suppliers);
         } else {
-            // key projection is not applied, so data file readers will return key-values in order,
-            // in this case merge tree can merge records with same key for us
-            return new MergeTreeReader(
-                    new IntervalPartition(files, keyComparator).partition(),
-                    dropDelete,
-                    dataFileReader,
-                    keyComparator,
-                    mergeFunction.copy());
+            // in this case merge tree should merge records with same key
+            // Do not project key in MergeTreeReader.
+            DataFileReader dataFileReader =
+                    dataFileReaderFactory.create(split.partition(), split.bucket(), false);
+            MergeTreeReader reader =
+                    new MergeTreeReader(
+                            new IntervalPartition(split.files(), keyComparator).partition(),
+                            true,
+                            dataFileReader,
+                            keyComparator,
+                            mergeFunction.copy());
+
+            // project key using ProjectKeyRecordReader
+            return keyProjectedFields == null
+                    ? reader
+                    : new ProjectKeyRecordReader(reader, keyProjectedFields);
         }
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/ProjectKeyRecordReader.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/ProjectKeyRecordReader.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.utils;
+
+import org.apache.flink.table.data.utils.ProjectedRowData;
+import org.apache.flink.table.store.file.KeyValue;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+/** A {@link RecordReader} with key projection. */
+public class ProjectKeyRecordReader implements RecordReader<KeyValue> {
+
+    private final RecordReader<KeyValue> reader;
+    private final ProjectedRowData projectedRow;
+
+    public ProjectKeyRecordReader(RecordReader<KeyValue> reader, int[][] keyProjectedFields) {
+        this.reader = reader;
+        this.projectedRow = ProjectedRowData.from(keyProjectedFields);
+    }
+
+    @Nullable
+    @Override
+    public RecordIterator<KeyValue> readBatch() throws IOException {
+        RecordIterator<KeyValue> batch = reader.readBatch();
+        if (batch == null) {
+            return null;
+        }
+
+        return new ProjectedIterator(batch, projectedRow);
+    }
+
+    @Override
+    public void close() throws IOException {
+        reader.close();
+    }
+
+    /** A {@link RecordIterator} with key projection. */
+    public static class ProjectedIterator implements RecordIterator<KeyValue> {
+
+        private final RecordIterator<KeyValue> iterator;
+        private final ProjectedRowData projectedRow;
+
+        public ProjectedIterator(RecordIterator<KeyValue> iterator, ProjectedRowData projectedRow) {
+            this.iterator = iterator;
+            this.projectedRow = projectedRow;
+        }
+
+        @Override
+        public KeyValue next() throws IOException {
+            KeyValue kv = iterator.next();
+            if (kv == null) {
+                return null;
+            }
+            return kv.replaceKey(projectedRow.replaceRow(kv.key()));
+        }
+
+        @Override
+        public void releaseBatch() {
+            iterator.releaseBatch();
+        }
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AbstractFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AbstractFileStoreTable.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.store.table;
 
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.store.file.FileStore;
 import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
@@ -29,19 +30,19 @@ public abstract class AbstractFileStoreTable implements FileStoreTable {
 
     private static final long serialVersionUID = 1L;
 
-    private final String name;
+    private final Path path;
     protected final TableSchema tableSchema;
 
-    public AbstractFileStoreTable(String name, TableSchema tableSchema) {
-        this.name = name;
+    public AbstractFileStoreTable(Path path, TableSchema tableSchema) {
+        this.path = path;
         this.tableSchema = tableSchema;
     }
 
     protected abstract FileStore<?> store();
 
     @Override
-    public String name() {
-        return name;
+    public Path location() {
+        return path;
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTable.java
@@ -18,12 +18,11 @@
 
 package org.apache.flink.table.store.table;
 
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.store.file.AppendOnlyFileStore;
 import org.apache.flink.table.store.file.FileStoreOptions;
 import org.apache.flink.table.store.file.WriteMode;
-import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.operation.AppendOnlyFileStoreRead;
 import org.apache.flink.table.store.file.operation.AppendOnlyFileStoreScan;
 import org.apache.flink.table.store.file.predicate.Predicate;
@@ -37,6 +36,7 @@ import org.apache.flink.table.store.table.sink.SinkRecord;
 import org.apache.flink.table.store.table.sink.SinkRecordConverter;
 import org.apache.flink.table.store.table.sink.TableWrite;
 import org.apache.flink.table.store.table.source.AppendOnlySplitGenerator;
+import org.apache.flink.table.store.table.source.Split;
 import org.apache.flink.table.store.table.source.SplitGenerator;
 import org.apache.flink.table.store.table.source.TableRead;
 import org.apache.flink.table.store.table.source.TableScan;
@@ -44,7 +44,6 @@ import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
-import java.util.List;
 
 /** {@link FileStoreTable} for {@link WriteMode#APPEND_ONLY} write mode. */
 public class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
@@ -54,8 +53,8 @@ public class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
     private final AppendOnlyFileStore store;
 
     AppendOnlyFileStoreTable(
-            String name, SchemaManager schemaManager, TableSchema tableSchema, String user) {
-        super(name, tableSchema);
+            Path path, SchemaManager schemaManager, TableSchema tableSchema, String user) {
+        super(path, tableSchema);
         this.store =
                 new AppendOnlyFileStore(
                         schemaManager,
@@ -94,15 +93,8 @@ public class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
             }
 
             @Override
-            public TableRead withIncremental(boolean isIncremental) {
-                return this;
-            }
-
-            @Override
-            public RecordReader<RowData> createReader(
-                    BinaryRowData partition, int bucket, List<DataFileMeta> files)
-                    throws IOException {
-                return read.createReader(partition, bucket, files);
+            public RecordReader<RowData> createReader(Split split) throws IOException {
+                return read.createReader(split);
             }
         };
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.store.table;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.file.FileStoreOptions;
 import org.apache.flink.table.store.file.KeyValue;
@@ -61,8 +62,8 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
     private final KeyValueFileStore store;
 
     ChangelogWithKeyFileStoreTable(
-            String name, SchemaManager schemaManager, TableSchema tableSchema, String user) {
-        super(name, tableSchema);
+            Path path, SchemaManager schemaManager, TableSchema tableSchema, String user) {
+        super(path, tableSchema);
         RowType rowType = tableSchema.logicalRowType();
 
         // add _KEY_ prefix to avoid conflict with value
@@ -155,12 +156,6 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
             @Override
             public TableRead withProjection(int[][] projection) {
                 read.withValueProjection(projection);
-                return this;
-            }
-
-            @Override
-            public TableRead withIncremental(boolean isIncremental) {
-                read.withDropDelete(!isIncremental);
                 return this;
             }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/FileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/FileStoreTable.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.store.table;
 
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
 import org.apache.flink.table.store.table.sink.TableCommit;
@@ -34,7 +35,7 @@ import java.io.Serializable;
  */
 public interface FileStoreTable extends Serializable {
 
-    String name();
+    Path location();
 
     TableSchema schema();
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/FileStoreTableFactory.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/FileStoreTableFactory.java
@@ -38,7 +38,6 @@ public class FileStoreTableFactory {
 
     public static FileStoreTable create(Configuration conf, String user) {
         Path tablePath = FileStoreOptions.path(conf);
-        String name = tablePath.getName();
         SchemaManager schemaManager = new SchemaManager(tablePath);
         TableSchema tableSchema =
                 schemaManager

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/FileStoreTableFactory.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/FileStoreTableFactory.java
@@ -56,13 +56,14 @@ public class FileStoreTableFactory {
         tableSchema = tableSchema.copy(newOptions);
 
         if (conf.get(FileStoreOptions.WRITE_MODE) == WriteMode.APPEND_ONLY) {
-            return new AppendOnlyFileStoreTable(name, schemaManager, tableSchema, user);
+            return new AppendOnlyFileStoreTable(tablePath, schemaManager, tableSchema, user);
         } else {
             if (tableSchema.primaryKeys().isEmpty()) {
                 return new ChangelogValueCountFileStoreTable(
-                        name, schemaManager, tableSchema, user);
+                        tablePath, schemaManager, tableSchema, user);
             } else {
-                return new ChangelogWithKeyFileStoreTable(name, schemaManager, tableSchema, user);
+                return new ChangelogWithKeyFileStoreTable(
+                        tablePath, schemaManager, tableSchema, user);
             }
         }
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/KeyValueTableRead.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/KeyValueTableRead.java
@@ -19,16 +19,13 @@
 package org.apache.flink.table.store.table.source;
 
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.store.file.KeyValue;
-import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.operation.KeyValueFileStoreRead;
 import org.apache.flink.table.store.file.utils.RecordReader;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.List;
 
 /**
  * An abstraction layer above {@link KeyValueFileStoreRead} to provide reading of {@link RowData}.
@@ -42,9 +39,8 @@ public abstract class KeyValueTableRead implements TableRead {
     }
 
     @Override
-    public RecordReader<RowData> createReader(
-            BinaryRowData partition, int bucket, List<DataFileMeta> files) throws IOException {
-        return new RowDataRecordReader(read.createReader(partition, bucket, files));
+    public RecordReader<RowData> createReader(Split split) throws IOException {
+        return new RowDataRecordReader(read.createReader(split));
     }
 
     protected abstract RecordReader.RecordIterator<RowData> rowDataRecordIteratorFromKv(

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/TableRead.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/TableRead.java
@@ -19,14 +19,11 @@
 package org.apache.flink.table.store.table.source;
 
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.binary.BinaryRowData;
-import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.operation.FileStoreRead;
 import org.apache.flink.table.store.file.utils.RecordReader;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
 
 /** An abstraction layer above {@link FileStoreRead} to provide reading of {@link RowData}. */
 public interface TableRead {
@@ -41,8 +38,5 @@ public interface TableRead {
 
     TableRead withProjection(int[][] projection);
 
-    TableRead withIncremental(boolean isIncremental);
-
-    RecordReader<RowData> createReader(
-            BinaryRowData partition, int bucket, List<DataFileMeta> files) throws IOException;
+    RecordReader<RowData> createReader(Split split) throws IOException;
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/ValueCountRowDataRecordIterator.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/ValueCountRowDataRecordIterator.java
@@ -19,12 +19,9 @@
 package org.apache.flink.table.store.table.source;
 
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.utils.ProjectedRowData;
 import org.apache.flink.table.store.file.KeyValue;
 import org.apache.flink.table.store.file.utils.RecordReader;
 import org.apache.flink.types.RowKind;
-
-import javax.annotation.Nullable;
 
 import java.io.IOException;
 
@@ -35,16 +32,11 @@ import java.io.IOException;
  */
 public class ValueCountRowDataRecordIterator extends ResetRowKindRecordIterator {
 
-    private final @Nullable ProjectedRowData projectedRowData;
-
     private RowData rowData;
     private long count;
 
-    public ValueCountRowDataRecordIterator(
-            RecordReader.RecordIterator<KeyValue> kvIterator, @Nullable int[][] projection) {
+    public ValueCountRowDataRecordIterator(RecordReader.RecordIterator<KeyValue> kvIterator) {
         super(kvIterator);
-        this.projectedRowData = projection == null ? null : ProjectedRowData.from(projection);
-
         this.rowData = null;
         this.count = 0;
     }
@@ -61,8 +53,7 @@ public class ValueCountRowDataRecordIterator extends ResetRowKindRecordIterator 
                     return null;
                 }
 
-                rowData =
-                        projectedRowData == null ? kv.key() : projectedRowData.replaceRow(kv.key());
+                rowData = kv.key();
                 long value = kv.value().getLong(0);
                 if (value < 0) {
                     rowData.setRowKind(RowKind.DELETE);

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -43,6 +43,7 @@ import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 import org.apache.flink.table.store.file.utils.RecordReaderIterator;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
 import org.apache.flink.table.store.file.writer.RecordWriter;
+import org.apache.flink.table.store.table.source.Split;
 import org.apache.flink.table.types.logical.RowType;
 
 import org.slf4j.Logger;
@@ -292,9 +293,11 @@ public class TestFileStore extends KeyValueFileStore {
                 RecordReaderIterator<KeyValue> iterator =
                         new RecordReaderIterator<>(
                                 read.createReader(
-                                        entryWithPartition.getKey(),
-                                        entryWithBucket.getKey(),
-                                        entryWithBucket.getValue()));
+                                        new Split(
+                                                entryWithPartition.getKey(),
+                                                entryWithBucket.getKey(),
+                                                entryWithBucket.getValue(),
+                                                false)));
                 while (iterator.hasNext()) {
                     kvs.add(iterator.next().copy(keySerializer, valueSerializer));
                 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreReadTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreReadTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.store.file.mergetree.compact.MergeFunction;
 import org.apache.flink.table.store.file.mergetree.compact.ValueCountMergeFunction;
 import org.apache.flink.table.store.file.utils.RecordReader;
 import org.apache.flink.table.store.file.utils.RecordReaderIterator;
+import org.apache.flink.table.store.table.source.Split;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -192,7 +193,6 @@ public class KeyValueFileStoreReadTest {
         KeyValueFileStoreRead read = store.newRead();
         if (keyProjection != null) {
             read.withKeyProjection(keyProjection);
-            read.withDropDelete(false);
         }
         if (valueProjection != null) {
             read.withValueProjection(valueProjection);
@@ -203,11 +203,13 @@ public class KeyValueFileStoreReadTest {
                 filesGroupedByPartition.entrySet()) {
             RecordReader<KeyValue> reader =
                     read.createReader(
-                            entry.getKey(),
-                            0,
-                            entry.getValue().stream()
-                                    .map(ManifestEntry::file)
-                                    .collect(Collectors.toList()));
+                            new Split(
+                                    entry.getKey(),
+                                    0,
+                                    entry.getValue().stream()
+                                            .map(ManifestEntry::file)
+                                            .collect(Collectors.toList()),
+                                    false));
             RecordReaderIterator<KeyValue> actualIterator = new RecordReaderIterator<>(reader);
             while (actualIterator.hasNext()) {
                 result.add(

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTableTest.java
@@ -98,7 +98,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         FileStoreTable table = createFileStoreTable();
 
         List<Split> splits = table.newScan().withIncremental(true).plan().splits;
-        TableRead read = table.newRead().withIncremental(true);
+        TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_ROW_TO_STRING))
                 .isEqualTo(Arrays.asList("+1|11|101", "+1|12|102"));
         assertThat(getResult(read, splits, binaryRow(2), 0, STREAMING_ROW_TO_STRING))
@@ -111,7 +111,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         FileStoreTable table = createFileStoreTable();
 
         List<Split> splits = table.newScan().withIncremental(true).plan().splits;
-        TableRead read = table.newRead().withIncremental(true).withProjection(PROJECTION);
+        TableRead read = table.newRead().withProjection(PROJECTION);
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_PROJECTED_ROW_TO_STRING))
                 .isEqualTo(Arrays.asList("+101|11", "+102|12"));
         assertThat(getResult(read, splits, binaryRow(2), 0, STREAMING_PROJECTED_ROW_TO_STRING))
@@ -127,7 +127,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         Predicate predicate = builder.equal(2, 101L);
         List<Split> splits =
                 table.newScan().withIncremental(true).withFilter(predicate).plan().splits;
-        TableRead read = table.newRead().withIncremental(true);
+        TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_ROW_TO_STRING))
                 .isEqualTo(
                         Arrays.asList(
@@ -175,7 +175,6 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                                 Collections.emptyList(),
                                 conf.toMap(),
                                 ""));
-        return new AppendOnlyFileStoreTable(
-                tablePath.getName(), schemaManager, tableSchema, "user");
+        return new AppendOnlyFileStoreTable(tablePath, schemaManager, tableSchema, "user");
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTableTest.java
@@ -97,7 +97,7 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
         FileStoreTable table = createFileStoreTable();
 
         List<Split> splits = table.newScan().withIncremental(true).plan().splits;
-        TableRead read = table.newRead().withIncremental(true);
+        TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_ROW_TO_STRING))
                 .isEqualTo(Arrays.asList("-1|10|100", "+1|11|101"));
         assertThat(getResult(read, splits, binaryRow(2), 0, STREAMING_ROW_TO_STRING))
@@ -110,7 +110,7 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
         FileStoreTable table = createFileStoreTable();
 
         List<Split> splits = table.newScan().withIncremental(true).plan().splits;
-        TableRead read = table.newRead().withIncremental(true).withProjection(PROJECTION);
+        TableRead read = table.newRead().withProjection(PROJECTION);
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_PROJECTED_ROW_TO_STRING))
                 .isEqualTo(Arrays.asList("-100|10", "+101|11"));
         assertThat(getResult(read, splits, binaryRow(2), 0, STREAMING_PROJECTED_ROW_TO_STRING))
@@ -126,7 +126,7 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
         Predicate predicate = builder.equal(2, 201L);
         List<Split> splits =
                 table.newScan().withIncremental(true).withFilter(predicate).plan().splits;
-        TableRead read = table.newRead().withIncremental(true);
+        TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_ROW_TO_STRING)).isEmpty();
         assertThat(getResult(read, splits, binaryRow(2), 0, STREAMING_ROW_TO_STRING))
                 .isEqualTo(
@@ -178,7 +178,6 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
                                 Collections.emptyList(),
                                 conf.toMap(),
                                 ""));
-        return new ChangelogValueCountFileStoreTable(
-                tablePath.getName(), schemaManager, tableSchema, "user");
+        return new ChangelogValueCountFileStoreTable(tablePath, schemaManager, tableSchema, "user");
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTableTest.java
@@ -97,7 +97,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         FileStoreTable table = createFileStoreTable();
 
         List<Split> splits = table.newScan().withIncremental(true).plan().splits;
-        TableRead read = table.newRead().withIncremental(true);
+        TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_ROW_TO_STRING))
                 .isEqualTo(Collections.singletonList("-1|11|1001"));
         assertThat(getResult(read, splits, binaryRow(2), 0, STREAMING_ROW_TO_STRING))
@@ -110,7 +110,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         FileStoreTable table = createFileStoreTable();
 
         List<Split> splits = table.newScan().withIncremental(true).plan().splits;
-        TableRead read = table.newRead().withIncremental(true).withProjection(PROJECTION);
+        TableRead read = table.newRead().withProjection(PROJECTION);
 
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_PROJECTED_ROW_TO_STRING))
                 .isEqualTo(Collections.singletonList("-1001|11"));
@@ -127,7 +127,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         Predicate predicate = PredicateBuilder.and(builder.equal(2, 201L), builder.equal(1, 21));
         List<Split> splits =
                 table.newScan().withIncremental(true).withFilter(predicate).plan().splits;
-        TableRead read = table.newRead().withIncremental(true);
+        TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_ROW_TO_STRING)).isEmpty();
         assertThat(getResult(read, splits, binaryRow(2), 0, STREAMING_ROW_TO_STRING))
                 .isEqualTo(
@@ -177,7 +177,6 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
                                 Arrays.asList("pt", "a"),
                                 conf.toMap(),
                                 ""));
-        return new ChangelogWithKeyFileStoreTable(
-                tablePath.getName(), schemaManager, tableSchema, "user");
+        return new ChangelogWithKeyFileStoreTable(tablePath, schemaManager, tableSchema, "user");
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/WritePreemptMemoryTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/WritePreemptMemoryTest.java
@@ -103,7 +103,6 @@ public class WritePreemptMemoryTest extends FileStoreTableTestBase {
                                 Arrays.asList("pt", "a"),
                                 conf.toMap(),
                                 ""));
-        return new ChangelogWithKeyFileStoreTable(
-                tablePath.getName(), schemaManager, schema, "user");
+        return new ChangelogWithKeyFileStoreTable(tablePath, schemaManager, schema, "user");
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/source/SplitTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/source/SplitTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.store.table.source;
 
-import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.table.store.file.data.DataFileMeta;
@@ -45,7 +44,7 @@ public class SplitTest {
         for (int i = 0; i < ThreadLocalRandom.current().nextInt(10); i++) {
             files.add(gen.next().meta);
         }
-        Split split = new Split(data.partition, data.bucket, files, new Path("/tmp/test"));
+        Split split = new Split(data.partition, data.bucket, files, false);
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         split.serialize(new DataOutputViewStreamWrapper(out));

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/source/ValueCountRowDataRecordIteratorTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/source/ValueCountRowDataRecordIteratorTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.store.table.source;
 
+import org.apache.flink.table.data.utils.ProjectedRowData;
+import org.apache.flink.table.store.file.utils.ProjectKeyRecordReader;
 import org.apache.flink.table.store.file.utils.ReusingTestData;
 import org.apache.flink.types.RowKind;
 
@@ -48,7 +50,7 @@ public class ValueCountRowDataRecordIteratorTest extends RowDataRecordIteratorTe
 
         testIterator(
                 input,
-                kvIterator -> new ValueCountRowDataRecordIterator(kvIterator, null),
+                ValueCountRowDataRecordIterator::new,
                 (rowData, idx) -> {
                     assertThat(rowData.getArity()).isEqualTo(1);
                     assertThat(rowData.getInt(0)).isEqualTo(expectedValues.get(idx));
@@ -75,7 +77,10 @@ public class ValueCountRowDataRecordIteratorTest extends RowDataRecordIteratorTe
                 input,
                 kvIterator ->
                         new ValueCountRowDataRecordIterator(
-                                kvIterator, new int[][] {new int[] {0}, new int[] {0}}),
+                                new ProjectKeyRecordReader.ProjectedIterator(
+                                        kvIterator,
+                                        ProjectedRowData.from(
+                                                new int[][] {new int[] {0}, new int[] {0}}))),
                 (rowData, idx) -> {
                     assertThat(rowData.getArity()).isEqualTo(2);
                     assertThat(rowData.getInt(0)).isEqualTo(expectedValues.get(idx));

--- a/flink-table-store-hive/src/main/java/org/apache/flink/table/store/mapred/TableStoreInputFormat.java
+++ b/flink-table-store-hive/src/main/java/org/apache/flink/table/store/mapred/TableStoreInputFormat.java
@@ -55,7 +55,7 @@ public class TableStoreInputFormat implements InputFormat<Void, RowDataContainer
         TableScan scan = table.newScan();
         createPredicate(table.schema(), jobConf).ifPresent(scan::withFilter);
         return scan.plan().splits.stream()
-                .map(TableStoreInputSplit::create)
+                .map(split -> TableStoreInputSplit.create(table.location().toString(), split))
                 .toArray(TableStoreInputSplit[]::new);
     }
 
@@ -65,9 +65,7 @@ public class TableStoreInputFormat implements InputFormat<Void, RowDataContainer
         FileStoreTable table = createFileStoreTable(jobConf);
         TableStoreInputSplit split = (TableStoreInputSplit) inputSplit;
         long splitLength = split.getLength();
-        return new TableStoreRecordReader(
-                table.newRead().createReader(split.partition(), split.bucket(), split.files()),
-                splitLength);
+        return new TableStoreRecordReader(table.newRead().createReader(split.split()), splitLength);
     }
 
     private FileStoreTable createFileStoreTable(JobConf jobConf) {

--- a/flink-table-store-hive/src/test/java/org/apache/flink/table/store/mapred/TableStoreInputSplitTest.java
+++ b/flink-table-store-hive/src/test/java/org/apache/flink/table/store/mapred/TableStoreInputSplitTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.store.mapred;
 
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.store.file.data.DataFileTestDataGenerator;
+import org.apache.flink.table.store.table.source.Split;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -52,13 +53,15 @@ public class TableStoreInputSplitTest {
         BinaryRowData wantedPartition = generated.get(0).partition;
         TableStoreInputSplit split =
                 new TableStoreInputSplit(
-                        wantedPartition,
-                        0,
-                        generated.stream()
-                                .filter(d -> d.partition.equals(wantedPartition))
-                                .map(d -> d.meta)
-                                .collect(Collectors.toList()),
-                        tempDir.toString());
+                        tempDir.toString(),
+                        new Split(
+                                wantedPartition,
+                                0,
+                                generated.stream()
+                                        .filter(d -> d.partition.equals(wantedPartition))
+                                        .map(d -> d.meta)
+                                        .collect(Collectors.toList()),
+                                false));
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         DataOutputStream output = new DataOutputStream(baos);

--- a/flink-table-store-hive/src/test/java/org/apache/flink/table/store/mapred/TableStoreRecordReaderTest.java
+++ b/flink-table-store-hive/src/test/java/org/apache/flink/table/store/mapred/TableStoreRecordReaderTest.java
@@ -142,7 +142,8 @@ public class TableStoreRecordReaderTest {
         for (Split split : table.newScan().plan().splits) {
             if (split.partition().equals(partition) && split.bucket() == bucket) {
                 return Tuple2.of(
-                        table.newRead().createReader(partition, bucket, split.files()),
+                        table.newRead()
+                                .createReader(new Split(partition, bucket, split.files(), false)),
                         split.files().stream().mapToLong(DataFileMeta::fileSize).sum());
             }
         }

--- a/flink-table-store-spark/src/main/java/org/apache/flink/table/store/spark/SparkReaderFactory.java
+++ b/flink-table-store-spark/src/main/java/org/apache/flink/table/store/spark/SparkReaderFactory.java
@@ -21,7 +21,6 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.file.utils.RecordReader;
 import org.apache.flink.table.store.file.utils.RecordReaderIterator;
 import org.apache.flink.table.store.table.FileStoreTable;
-import org.apache.flink.table.store.table.source.Split;
 import org.apache.flink.table.store.utils.TypeUtils;
 import org.apache.flink.table.types.logical.RowType;
 
@@ -52,13 +51,12 @@ public class SparkReaderFactory implements PartitionReaderFactory {
 
     @Override
     public PartitionReader<InternalRow> createReader(InputPartition partition) {
-        Split split = ((SparkInputPartition) partition).split();
         RecordReader<RowData> reader;
         try {
             reader =
                     table.newRead()
                             .withProjection(projectedFields)
-                            .createReader(split.partition(), split.bucket(), split.files());
+                            .createReader(((SparkInputPartition) partition).split());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/flink-table-store-spark/src/main/java/org/apache/flink/table/store/spark/SparkScan.java
+++ b/flink-table-store-spark/src/main/java/org/apache/flink/table/store/spark/SparkScan.java
@@ -57,7 +57,7 @@ public class SparkScan implements Scan, SupportsReportStatistics {
     @Override
     public String description() {
         // TODO add filters
-        return String.format("tablestore(%s)", table.name());
+        return String.format("tablestore(%s)", table.location().getName());
     }
 
     @Override

--- a/flink-table-store-spark/src/main/java/org/apache/flink/table/store/spark/SparkTable.java
+++ b/flink-table-store-spark/src/main/java/org/apache/flink/table/store/spark/SparkTable.java
@@ -47,7 +47,7 @@ public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
 
     @Override
     public String name() {
-        return table.name();
+        return table.location().getName();
     }
 
     @Override


### PR DESCRIPTION
Refactor split and read, for better Hybrid reading. The full and incremental read paths should be different, otherwise it is easy to get bugs.

* Add boolean isIncremental to Split
* Use Split in Flink Source Split and Hive Split
* Introduce FileStoreRead.createReader(Split)
* In KeyValueFileStoreRead, remove withDropDelete
* In KeyValueFileStoreRead, Create ConcatRecordReader or MergeTreeReader by Split.isIncremental
* Do key projection in KeyValueFileStoreRead.createReader