### PR TITLE
[FLINK-28282] Planner free in flink-table-store-codegen

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,70 @@
+runner.dialect = scala212
+
+# Version is required to make sure IntelliJ picks the right version
+version = 3.4.3
+preset = default
+
+# Max column
+maxColumn = 100
+
+# This parameter simply says the .stripMargin method was not redefined by the user to assign
+# special meaning to indentation preceding the | character. Hence, that indentation can be modified.
+assumeStandardLibraryStripMargin = true
+align.stripMargin = true
+
+# Align settings
+align.preset = none
+align.closeParenSite = false
+align.openParenCallSite = false
+danglingParentheses.defnSite = false
+danglingParentheses.callSite = false
+danglingParentheses.ctrlSite = true
+danglingParentheses.tupleSite = false
+align.openParenCallSite = false
+align.openParenDefnSite = false
+align.openParenTupleSite = false
+
+# Newlines
+newlines.alwaysBeforeElseAfterCurlyIf = false
+newlines.beforeCurlyLambdaParams = multiline # Newline before lambda params
+newlines.afterCurlyLambdaParams = squash # No newline after lambda params
+newlines.inInterpolation = "avoid"
+newlines.avoidInResultType = true
+optIn.annotationNewlines = true
+
+# Scaladoc
+docstrings.style = Asterisk # Javadoc style
+docstrings.removeEmpty = true
+docstrings.oneline = fold
+docstrings.forceBlankLineBefore = true
+
+# Indentation
+indent.extendSite = 2 # This makes sure extend is not indented as the ctor parameters
+
+# Rewrites
+rewrite.rules = [AvoidInfix, Imports, RedundantBraces, SortModifiers]
+
+# Imports
+rewrite.imports.sort = scalastyle
+rewrite.imports.groups = [
+    ["org.apache.flink\\..*"],
+    ["org.apache.flink.shaded\\..*"],
+    [".*"],
+    ["javax\\..*"],
+    ["java\\..*"],
+    ["scala\\..*"]
+]
+rewrite.imports.contiguousGroups = no
+importSelectors = singleline # Imports in a single line, like IntelliJ
+
+# Remove redundant braces in string interpolation.
+rewrite.redundantBraces.stringInterpolation = true
+rewrite.redundantBraces.defnBodies = false
+rewrite.redundantBraces.generalExpressions = false
+rewrite.redundantBraces.ifElseExpressions = false
+rewrite.redundantBraces.methodBodies = false
+rewrite.redundantBraces.includeUnitMethods = false
+rewrite.redundantBraces.maxBreaks = 1
+
+# Remove trailing commas
+rewrite.trailingCommas.style = "never"

--- a/flink-table-store-codegen/pom.xml
+++ b/flink-table-store-codegen/pom.xml
@@ -40,25 +40,61 @@ under the License.
 
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+            <artifactId>flink-table-common</artifactId>
             <version>${flink.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-runtime</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-reflect</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-compiler</artifactId>
+            <version>${scala.version}</version>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <!-- Scala Compiler -->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
                 <executions>
+                    <!-- Run scala compiler in the process-resources phase, so that dependencies on
+                        scala classes can be resolved later in the (Java) compile phase -->
                     <execution>
-                        <id>forbid-direct-table-planner-dependencies</id>
+                        <id>scala-compile-first</id>
+                        <phase>process-resources</phase>
                         <goals>
-                            <goal>enforce</goal>
+                            <goal>add-source</goal>
+                            <goal>compile</goal>
                         </goals>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
+                    </execution>
+
+                    <!-- Run scala compiler in the process-test-resources phase, so that dependencies on
+                         scala classes can be resolved later in the (Java) test-compile phase -->
+                    <execution>
+                        <id>scala-test-compile</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>
@@ -77,20 +113,9 @@ under the License.
                             <minimizeJar>true</minimizeJar>
                             <artifactSet>
                                 <includes combine.children="append">
-                                    <include>org.apache.flink:flink-table-planner_${scala.binary.version}</include>
                                     <include>org.scala-lang:*</include>
                                 </includes>
                             </artifactSet>
-                            <filters>
-                                <filter>
-                                    <artifact>org.apache.flink:flink-table-planner_${scala.binary.version}</artifact>
-                                    <includes>
-                                        <include>org/apache/flink/table/planner/**</include>
-                                        <include>org/apache/calcite/**</include>
-                                        <include>scala/**</include>
-                                    </includes>
-                                </filter>
-                            </filters>
                         </configuration>
                     </execution>
                 </executions>

--- a/flink-table-store-codegen/src/main/java/org/apache/flink/table/store/codegen/CodeGeneratorImpl.java
+++ b/flink-table-store-codegen/src/main/java/org/apache/flink/table/store/codegen/CodeGeneratorImpl.java
@@ -18,12 +18,6 @@
 
 package org.apache.flink.table.store.codegen;
 
-import org.apache.flink.table.api.TableConfig;
-import org.apache.flink.table.planner.codegen.CodeGeneratorContext;
-import org.apache.flink.table.planner.codegen.ProjectionCodeGenerator;
-import org.apache.flink.table.planner.codegen.sort.ComparatorCodeGenerator;
-import org.apache.flink.table.planner.codegen.sort.SortCodeGenerator;
-import org.apache.flink.table.planner.plan.nodes.exec.spec.SortSpec;
 import org.apache.flink.table.runtime.generated.GeneratedNormalizedKeyComputer;
 import org.apache.flink.table.runtime.generated.GeneratedProjection;
 import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
@@ -38,17 +32,16 @@ public class CodeGeneratorImpl implements CodeGenerator {
 
     @Override
     public GeneratedProjection generateProjection(
-            TableConfig tableConfig, String name, RowType inputType, int[] inputMapping) {
+            String name, RowType inputType, int[] inputMapping) {
         RowType outputType = TypeUtils.project(inputType, inputMapping);
         return ProjectionCodeGenerator.generateProjection(
-                CodeGeneratorContext.apply(tableConfig), name, inputType, outputType, inputMapping);
+                new CodeGeneratorContext(), name, inputType, outputType, inputMapping);
     }
 
     @Override
     public GeneratedNormalizedKeyComputer generateNormalizedKeyComputer(
-            TableConfig tableConfig, List<LogicalType> fieldTypes, String name) {
+            List<LogicalType> fieldTypes, String name) {
         return new SortCodeGenerator(
-                        tableConfig,
                         RowType.of(fieldTypes.toArray(new LogicalType[0])),
                         getAscendingSortSpec(fieldTypes.size()))
                 .generateNormalizedKeyComputer(name);
@@ -56,9 +49,8 @@ public class CodeGeneratorImpl implements CodeGenerator {
 
     @Override
     public GeneratedRecordComparator generateRecordComparator(
-            TableConfig tableConfig, List<LogicalType> fieldTypes, String name) {
+            List<LogicalType> fieldTypes, String name) {
         return ComparatorCodeGenerator.gen(
-                tableConfig,
                 name,
                 RowType.of(fieldTypes.toArray(new LogicalType[0])),
                 getAscendingSortSpec(fieldTypes.size()));

--- a/flink-table-store-codegen/src/main/java/org/apache/flink/table/store/codegen/SortSpec.java
+++ b/flink-table-store-codegen/src/main/java/org/apache/flink/table/store/codegen/SortSpec.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.codegen;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** {@link SortSpec} describes how the data will be sorted. */
+public class SortSpec {
+
+    /** SortSpec does not require sort. */
+    public static final SortSpec ANY = new SortSpec(new SortFieldSpec[0]);
+
+    private final SortFieldSpec[] fieldSpecs;
+
+    public SortSpec(SortFieldSpec[] fieldSpecs) {
+        this.fieldSpecs = checkNotNull(fieldSpecs);
+    }
+
+    /** Gets all {@link SortFieldSpec} in the SortSpec. */
+    public SortFieldSpec[] getFieldSpecs() {
+        return fieldSpecs;
+    }
+
+    /** Gets {@link SortFieldSpec} of field at given index. */
+    public SortFieldSpec getFieldSpec(int index) {
+        return fieldSpecs[index];
+    }
+
+    /** Gets num of field in the spec. */
+    public int getFieldSize() {
+        return fieldSpecs.length;
+    }
+
+    public static SortSpecBuilder builder() {
+        return new SortSpecBuilder();
+    }
+
+    /** SortSpec builder. */
+    public static class SortSpecBuilder {
+
+        private final List<SortFieldSpec> fieldSpecs = new LinkedList<>();
+
+        public SortSpecBuilder addField(
+                int fieldIndex, boolean isAscendingOrder, boolean nullIsLast) {
+            fieldSpecs.add(new SortFieldSpec(fieldIndex, isAscendingOrder, nullIsLast));
+            return this;
+        }
+
+        public SortSpec build() {
+            return new SortSpec(fieldSpecs.toArray(new SortFieldSpec[0]));
+        }
+    }
+
+    /** Sort info for a Field. */
+    public static class SortFieldSpec {
+
+        /** 0-based index of field being sorted. */
+        private final int fieldIndex;
+
+        /** in ascending order or not. */
+        private final boolean isAscendingOrder;
+
+        /** put null at last or not. */
+        private final boolean nullIsLast;
+
+        public SortFieldSpec(int fieldIndex, boolean isAscendingOrder, boolean nullIsLast) {
+            this.fieldIndex = fieldIndex;
+            this.isAscendingOrder = isAscendingOrder;
+            this.nullIsLast = nullIsLast;
+        }
+
+        public int getFieldIndex() {
+            return fieldIndex;
+        }
+
+        public boolean getIsAscendingOrder() {
+            return isAscendingOrder;
+        }
+
+        public boolean getNullIsLast() {
+            return nullIsLast;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            SortFieldSpec that = (SortFieldSpec) o;
+            return fieldIndex == that.fieldIndex
+                    && isAscendingOrder == that.isAscendingOrder
+                    && nullIsLast == that.nullIsLast;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(fieldIndex, isAscendingOrder, nullIsLast);
+        }
+
+        @Override
+        public String toString() {
+            return "SortField{"
+                    + "fieldIndex="
+                    + fieldIndex
+                    + ", isAscendingOrder="
+                    + isAscendingOrder
+                    + ", nullIsLast="
+                    + nullIsLast
+                    + '}';
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SortSpec sortSpec = (SortSpec) o;
+        return Arrays.equals(fieldSpecs, sortSpec.fieldSpecs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(fieldSpecs);
+    }
+
+    @Override
+    public String toString() {
+        return "Sort{" + "fields=" + Arrays.toString(fieldSpecs) + '}';
+    }
+}

--- a/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/CodeGenException.scala
+++ b/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/CodeGenException.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.store.codegen
+
+/** Exception for all errors occurring during code generation. */
+class CodeGenException(msg: String) extends RuntimeException(msg)

--- a/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/CodeGenException.scala
+++ b/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/CodeGenException.scala
@@ -1,20 +1,20 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+                                    * Licensed to the Apache Software Foundation (ASF) under one
+                                    * or more contributor license agreements.  See the NOTICE file
+                                    * distributed with this work for additional information
+                                    * regarding copyright ownership.  The ASF licenses this file
+                                    * to you under the Apache License, Version 2.0 (the
+                                    * "License"); you may not use this file except in compliance
+                                    * with the License.  You may obtain a copy of the License at
+                                    *
+                                    *     http://www.apache.org/licenses/LICENSE-2.0
+                                    *
+                                    * Unless required by applicable law or agreed to in writing, software
+                                    * distributed under the License is distributed on an "AS IS" BASIS,
+                                    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                    * See the License for the specific language governing permissions and
+                                    * limitations under the License.
+                                    */
 package org.apache.flink.table.store.codegen
 
 /** Exception for all errors occurring during code generation. */

--- a/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/CodeGenException.scala
+++ b/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/CodeGenException.scala
@@ -1,20 +1,20 @@
 /*
-                                    * Licensed to the Apache Software Foundation (ASF) under one
-                                    * or more contributor license agreements.  See the NOTICE file
-                                    * distributed with this work for additional information
-                                    * regarding copyright ownership.  The ASF licenses this file
-                                    * to you under the Apache License, Version 2.0 (the
-                                    * "License"); you may not use this file except in compliance
-                                    * with the License.  You may obtain a copy of the License at
-                                    *
-                                    *     http://www.apache.org/licenses/LICENSE-2.0
-                                    *
-                                    * Unless required by applicable law or agreed to in writing, software
-                                    * distributed under the License is distributed on an "AS IS" BASIS,
-                                    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                    * See the License for the specific language governing permissions and
-                                    * limitations under the License.
-                                    */
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.flink.table.store.codegen
 
 /** Exception for all errors occurring during code generation. */

--- a/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/CodeGeneratorContext.scala
+++ b/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/CodeGeneratorContext.scala
@@ -1,21 +1,20 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+                                    * Licensed to the Apache Software Foundation (ASF) under one
+                                    * or more contributor license agreements.  See the NOTICE file
+                                    * distributed with this work for additional information
+                                    * regarding copyright ownership.  The ASF licenses this file
+                                    * to you under the Apache License, Version 2.0 (the
+                                    * "License"); you may not use this file except in compliance
+                                    * with the License.  You may obtain a copy of the License at
+                                    *
+                                    *     http://www.apache.org/licenses/LICENSE-2.0
+                                    *
+                                    * Unless required by applicable law or agreed to in writing, software
+                                    * distributed under the License is distributed on an "AS IS" BASIS,
+                                    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                    * See the License for the specific language governing permissions and
+                                    * limitations under the License.
+                                    */
 package org.apache.flink.table.store.codegen
 
 import org.apache.flink.table.runtime.typeutils.InternalSerializers
@@ -39,17 +38,17 @@ class CodeGeneratorContext {
   // set of member statements that will be added only once
   // we use a LinkedHashSet to keep the insertion order
   private val reusableMemberStatements: mutable.LinkedHashSet[String] =
-  mutable.LinkedHashSet[String]()
+    mutable.LinkedHashSet[String]()
 
   // set of constructor statements that will be added only once
   // we use a LinkedHashSet to keep the insertion order
   private val reusableInitStatements: mutable.LinkedHashSet[String] =
-  mutable.LinkedHashSet[String]()
+    mutable.LinkedHashSet[String]()
 
   // map of type serializer that will be added only once
   // LogicalType -> reused_term
   private val reusableTypeSerializers: mutable.Map[LogicalType, String] =
-  mutable.Map[LogicalType, String]()
+    mutable.Map[LogicalType, String]()
 
   // local variable statements.
   private val reusableLocalVariableStatements = mutable.LinkedHashSet[String]()
@@ -94,25 +93,25 @@ class CodeGeneratorContext {
    *   the generated unique field term
    */
   def addReusableObject(
-                         obj: AnyRef,
-                         fieldNamePrefix: String,
-                         fieldTypeTerm: String = null): String = {
+      obj: AnyRef,
+      fieldNamePrefix: String,
+      fieldTypeTerm: String = null): String = {
     addReusableObjectWithName(obj, newName(fieldNamePrefix), fieldTypeTerm)
   }
 
   def addReusableObjectWithName(
-                                 obj: AnyRef,
-                                 fieldTerm: String,
-                                 fieldTypeTerm: String = null): String = {
+      obj: AnyRef,
+      fieldTerm: String,
+      fieldTypeTerm: String = null): String = {
     val clsName = Option(fieldTypeTerm).getOrElse(obj.getClass.getCanonicalName)
     addReusableObjectInternal(obj, fieldTerm, clsName)
     fieldTerm
   }
 
   private def addReusableObjectInternal(
-                                         obj: AnyRef,
-                                         fieldTerm: String,
-                                         fieldTypeTerm: String): Unit = {
+      obj: AnyRef,
+      fieldTerm: String,
+      fieldTypeTerm: String): Unit = {
     val idx = references.length
     // make a deep copy of the object
     val byteArray = InstantiationUtil.serializeObject(obj)

--- a/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/CodeGeneratorContext.scala
+++ b/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/CodeGeneratorContext.scala
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.codegen
+
+import org.apache.flink.table.runtime.typeutils.InternalSerializers
+import org.apache.flink.table.store.codegen.GenerateUtils.{newName, newNames}
+import org.apache.flink.table.types.logical.LogicalType
+import org.apache.flink.util.InstantiationUtil
+
+import scala.collection.mutable
+
+/**
+ * The context for code generator, maintaining various reusable statements that could be insert into
+ * different code sections in the final generated class.
+ */
+class CodeGeneratorContext {
+
+  val classLoader: ClassLoader = Thread.currentThread().getContextClassLoader
+
+  // holding a list of objects that could be used passed into generated class
+  val references: mutable.ArrayBuffer[AnyRef] = new mutable.ArrayBuffer[AnyRef]()
+
+  // set of member statements that will be added only once
+  // we use a LinkedHashSet to keep the insertion order
+  private val reusableMemberStatements: mutable.LinkedHashSet[String] =
+  mutable.LinkedHashSet[String]()
+
+  // set of constructor statements that will be added only once
+  // we use a LinkedHashSet to keep the insertion order
+  private val reusableInitStatements: mutable.LinkedHashSet[String] =
+  mutable.LinkedHashSet[String]()
+
+  // map of type serializer that will be added only once
+  // LogicalType -> reused_term
+  private val reusableTypeSerializers: mutable.Map[LogicalType, String] =
+  mutable.Map[LogicalType, String]()
+
+  // local variable statements.
+  private val reusableLocalVariableStatements = mutable.LinkedHashSet[String]()
+
+  /**
+   * Adds multiple pairs of local variables. The local variable statements will be placed in methods
+   * or class member area depends on whether the method length excess max code length.
+   *
+   * @param fieldTypeAndNames
+   *   pairs of local variables with left is field type term and right is field name
+   * @return
+   *   the new generated unique field names for each variable pairs
+   */
+  def addReusableLocalVariables(fieldTypeAndNames: (String, String)*): Seq[String] = {
+    val fieldTerms = newNames(fieldTypeAndNames.map(_._2): _*)
+    fieldTypeAndNames.map(_._1).zip(fieldTerms).foreach {
+      case (fieldTypeTerm, fieldTerm) =>
+        reusableLocalVariableStatements.add(s"$fieldTypeTerm $fieldTerm;")
+    }
+    fieldTerms
+  }
+
+  /**
+   * Adds a reusable member field statement to the member area.
+   *
+   * @param memberStatement
+   *   the member field declare statement
+   */
+  def addReusableMember(memberStatement: String): Unit = {
+    reusableMemberStatements.add(memberStatement)
+  }
+
+  /**
+   * Adds a reusable Object to the member area of the generated class
+   * @param obj
+   *   the object to be added to the generated class
+   * @param fieldNamePrefix
+   *   prefix field name of the generated member field term
+   * @param fieldTypeTerm
+   *   field type class name
+   * @return
+   *   the generated unique field term
+   */
+  def addReusableObject(
+                         obj: AnyRef,
+                         fieldNamePrefix: String,
+                         fieldTypeTerm: String = null): String = {
+    addReusableObjectWithName(obj, newName(fieldNamePrefix), fieldTypeTerm)
+  }
+
+  def addReusableObjectWithName(
+                                 obj: AnyRef,
+                                 fieldTerm: String,
+                                 fieldTypeTerm: String = null): String = {
+    val clsName = Option(fieldTypeTerm).getOrElse(obj.getClass.getCanonicalName)
+    addReusableObjectInternal(obj, fieldTerm, clsName)
+    fieldTerm
+  }
+
+  private def addReusableObjectInternal(
+                                         obj: AnyRef,
+                                         fieldTerm: String,
+                                         fieldTypeTerm: String): Unit = {
+    val idx = references.length
+    // make a deep copy of the object
+    val byteArray = InstantiationUtil.serializeObject(obj)
+    val objCopy: AnyRef =
+      InstantiationUtil.deserializeObject(byteArray, classLoader)
+    references += objCopy
+
+    reusableMemberStatements.add(s"private transient $fieldTypeTerm $fieldTerm;")
+    reusableInitStatements.add(s"$fieldTerm = ((($fieldTypeTerm) references[$idx]));")
+  }
+
+  /**
+   * @return
+   *   code block of statements that need to be placed in the member area of the class (e.g. member
+   *   variables and their initialization)
+   */
+  def reuseMemberCode(): String = {
+    reusableMemberStatements.mkString("\n")
+  }
+
+  /** @return code block of statements that need to be placed in the constructor */
+  def reuseInitCode(): String = {
+    reusableInitStatements.mkString("\n")
+  }
+
+  /**
+   * @return
+   *   code block of statements that will be placed in the member area of the class if generated
+   *   code is split or in local variables of method
+   */
+  def reuseLocalVariableCode(): String = {
+    reusableLocalVariableStatements.mkString("\n")
+  }
+
+  /**
+   * Adds a reusable TypeSerializer to the member area of the generated class.
+   *
+   * @param t
+   *   the internal type which used to generate internal type serializer
+   * @return
+   *   member variable term
+   */
+  def addReusableTypeSerializer(t: LogicalType): String = {
+    // if type serializer has been used before, we can reuse the code that
+    // has already been generated
+    reusableTypeSerializers.get(t) match {
+      case Some(term) => term
+
+      case None =>
+        val term = newName("typeSerializer")
+        val ser = InternalSerializers.create(t)
+        addReusableObjectInternal(ser, term, ser.getClass.getCanonicalName)
+        reusableTypeSerializers(t) = term
+        term
+    }
+  }
+}

--- a/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/CodeGeneratorContext.scala
+++ b/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/CodeGeneratorContext.scala
@@ -1,20 +1,20 @@
 /*
-                                    * Licensed to the Apache Software Foundation (ASF) under one
-                                    * or more contributor license agreements.  See the NOTICE file
-                                    * distributed with this work for additional information
-                                    * regarding copyright ownership.  The ASF licenses this file
-                                    * to you under the Apache License, Version 2.0 (the
-                                    * "License"); you may not use this file except in compliance
-                                    * with the License.  You may obtain a copy of the License at
-                                    *
-                                    *     http://www.apache.org/licenses/LICENSE-2.0
-                                    *
-                                    * Unless required by applicable law or agreed to in writing, software
-                                    * distributed under the License is distributed on an "AS IS" BASIS,
-                                    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                    * See the License for the specific language governing permissions and
-                                    * limitations under the License.
-                                    */
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.flink.table.store.codegen
 
 import org.apache.flink.table.runtime.typeutils.InternalSerializers

--- a/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/ComparatorCodeGenerator.scala
+++ b/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/ComparatorCodeGenerator.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.store.codegen
+
+import org.apache.flink.table.runtime.generated.{GeneratedRecordComparator, RecordComparator}
+import org.apache.flink.table.store.codegen.GenerateUtils.{ROW_DATA, newName}
+import org.apache.flink.table.types.logical.RowType
+
+/** A code generator for generating [[RecordComparator]]. */
+object ComparatorCodeGenerator {
+
+  /**
+   * Generates a [[RecordComparator]] that can be passed to a Java compiler.
+   *
+   * @param name
+   *   Class name of the function. Does not need to be unique but has to be a valid Java class
+   *   identifier.
+   * @param inputType
+   *   input type.
+   * @param sortSpec
+   *   sort specification.
+   * @return
+   *   A GeneratedRecordComparator
+   */
+  def gen(
+      name: String,
+      inputType: RowType,
+      sortSpec: SortSpec): GeneratedRecordComparator = {
+    val className = newName(name)
+    val baseClass = classOf[RecordComparator]
+
+    val ctx = new CodeGeneratorContext()
+    val compareCode = GenerateUtils.generateRowCompare(ctx, inputType, sortSpec, "o1", "o2")
+
+    val code =
+      s"""
+      public class $className implements ${baseClass.getCanonicalName} {
+
+        private final Object[] references;
+        ${ctx.reuseMemberCode()}
+
+        public $className(Object[] references) {
+          this.references = references;
+          ${ctx.reuseInitCode()}
+        }
+
+        @Override
+        public int compare($ROW_DATA o1, $ROW_DATA o2) {
+          $compareCode
+          return 0;
+        }
+
+      }
+      """.stripMargin
+
+    new GeneratedRecordComparator(className, code, ctx.references.toArray)
+  }
+
+}

--- a/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/ComparatorCodeGenerator.scala
+++ b/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/ComparatorCodeGenerator.scala
@@ -1,24 +1,24 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+                                    * Licensed to the Apache Software Foundation (ASF) under one
+                                    * or more contributor license agreements.  See the NOTICE file
+                                    * distributed with this work for additional information
+                                    * regarding copyright ownership.  The ASF licenses this file
+                                    * to you under the Apache License, Version 2.0 (the
+                                    * "License"); you may not use this file except in compliance
+                                    * with the License.  You may obtain a copy of the License at
+                                    *
+                                    *     http://www.apache.org/licenses/LICENSE-2.0
+                                    *
+                                    * Unless required by applicable law or agreed to in writing, software
+                                    * distributed under the License is distributed on an "AS IS" BASIS,
+                                    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                    * See the License for the specific language governing permissions and
+                                    * limitations under the License.
+                                    */
 package org.apache.flink.table.store.codegen
 
 import org.apache.flink.table.runtime.generated.{GeneratedRecordComparator, RecordComparator}
-import org.apache.flink.table.store.codegen.GenerateUtils.{ROW_DATA, newName}
+import org.apache.flink.table.store.codegen.GenerateUtils.{newName, ROW_DATA}
 import org.apache.flink.table.types.logical.RowType
 
 /** A code generator for generating [[RecordComparator]]. */
@@ -37,10 +37,7 @@ object ComparatorCodeGenerator {
    * @return
    *   A GeneratedRecordComparator
    */
-  def gen(
-      name: String,
-      inputType: RowType,
-      sortSpec: SortSpec): GeneratedRecordComparator = {
+  def gen(name: String, inputType: RowType, sortSpec: SortSpec): GeneratedRecordComparator = {
     val className = newName(name)
     val baseClass = classOf[RecordComparator]
 

--- a/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/ComparatorCodeGenerator.scala
+++ b/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/ComparatorCodeGenerator.scala
@@ -1,20 +1,20 @@
 /*
-                                    * Licensed to the Apache Software Foundation (ASF) under one
-                                    * or more contributor license agreements.  See the NOTICE file
-                                    * distributed with this work for additional information
-                                    * regarding copyright ownership.  The ASF licenses this file
-                                    * to you under the Apache License, Version 2.0 (the
-                                    * "License"); you may not use this file except in compliance
-                                    * with the License.  You may obtain a copy of the License at
-                                    *
-                                    *     http://www.apache.org/licenses/LICENSE-2.0
-                                    *
-                                    * Unless required by applicable law or agreed to in writing, software
-                                    * distributed under the License is distributed on an "AS IS" BASIS,
-                                    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                    * See the License for the specific language governing permissions and
-                                    * limitations under the License.
-                                    */
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.flink.table.store.codegen
 
 import org.apache.flink.table.runtime.generated.{GeneratedRecordComparator, RecordComparator}

--- a/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/ExprCodeGenerator.scala
+++ b/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/ExprCodeGenerator.scala
@@ -1,20 +1,20 @@
 /*
-                                    * Licensed to the Apache Software Foundation (ASF) under one
-                                    * or more contributor license agreements.  See the NOTICE file
-                                    * distributed with this work for additional information
-                                    * regarding copyright ownership.  The ASF licenses this file
-                                    * to you under the Apache License, Version 2.0 (the
-                                    * "License"); you may not use this file except in compliance
-                                    * with the License.  You may obtain a copy of the License at
-                                    *
-                                    *     http://www.apache.org/licenses/LICENSE-2.0
-                                    *
-                                    * Unless required by applicable law or agreed to in writing, software
-                                    * distributed under the License is distributed on an "AS IS" BASIS,
-                                    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                    * See the License for the specific language governing permissions and
-                                    * limitations under the License.
-                                    */
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.flink.table.store.codegen
 
 import org.apache.flink.table.data.RowData

--- a/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/ExprCodeGenerator.scala
+++ b/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/ExprCodeGenerator.scala
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.store.codegen
+
+import org.apache.flink.table.data.RowData
+import org.apache.flink.table.data.binary.BinaryRowData
+import org.apache.flink.table.runtime.types.PlannerTypeUtils.isInteroperable
+import org.apache.flink.table.store.codegen.GenerateUtils.{DEFAULT_OUT_RECORD_TERM, DEFAULT_OUT_RECORD_WRITER_TERM, generateRecordStatement, rowSetField}
+import org.apache.flink.table.store.codegen.GeneratedExpression.{NEVER_NULL, NO_CODE}
+import org.apache.flink.table.types.logical._
+
+class ExprCodeGenerator(ctx: CodeGeneratorContext) {
+
+  /**
+   * Generates an expression from a sequence of other expressions. The evaluation result may be
+   * stored in the variable outRecordTerm.
+   *
+   * @param fieldExprs
+   *   field expressions to be converted
+   * @param returnType
+   *   conversion target type. Type must have the same arity than fieldExprs.
+   * @param outRow
+   *   the result term
+   * @param outRowWriter
+   *   the result writer term for BinaryRowData.
+   * @param reusedOutRow
+   *   If objects or variables can be reused, they will be added to reusable code sections
+   *   internally.
+   * @param outRowAlreadyExists
+   *   Don't need addReusableRecord if out row already exists.
+   * @return
+   *   instance of GeneratedExpression
+   */
+  def generateResultExpression(
+      fieldExprs: Seq[GeneratedExpression],
+      returnType: RowType,
+      returnTypeClazz: Class[_ <: RowData],
+      outRow: String = DEFAULT_OUT_RECORD_TERM,
+      outRowWriter: Option[String] = Some(DEFAULT_OUT_RECORD_WRITER_TERM),
+      reusedOutRow: Boolean = true,
+      outRowAlreadyExists: Boolean = false): GeneratedExpression = {
+    val fieldExprIdxToOutputRowPosMap = fieldExprs.indices.map(i => i -> i).toMap
+    generateResultExpression(
+      fieldExprs,
+      fieldExprIdxToOutputRowPosMap,
+      returnType,
+      returnTypeClazz,
+      outRow,
+      outRowWriter,
+      reusedOutRow,
+      outRowAlreadyExists)
+  }
+
+  /**
+   * Generates an expression from a sequence of other expressions. The evaluation result may be
+   * stored in the variable outRecordTerm.
+   *
+   * @param fieldExprs
+   *   field expressions to be converted
+   * @param fieldExprIdxToOutputRowPosMap
+   *   Mapping index of fieldExpr in `fieldExprs` to position of output row.
+   * @param returnType
+   *   conversion target type. Type must have the same arity than fieldExprs.
+   * @param outRow
+   *   the result term
+   * @param outRowWriter
+   *   the result writer term for BinaryRowData.
+   * @param reusedOutRow
+   *   If objects or variables can be reused, they will be added to reusable code sections
+   *   internally.
+   * @param outRowAlreadyExists
+   *   Don't need addReusableRecord if out row already exists.
+   * @return
+   *   instance of GeneratedExpression
+   */
+  def generateResultExpression(
+      fieldExprs: Seq[GeneratedExpression],
+      fieldExprIdxToOutputRowPosMap: Map[Int, Int],
+      returnType: RowType,
+      returnTypeClazz: Class[_ <: RowData],
+      outRow: String,
+      outRowWriter: Option[String],
+      reusedOutRow: Boolean,
+      outRowAlreadyExists: Boolean): GeneratedExpression = {
+    // initial type check
+    if (returnType.getFieldCount != fieldExprs.length) {
+      throw new CodeGenException(
+        s"Arity [${returnType.getFieldCount}] of result type [$returnType] does not match " +
+          s"number [${fieldExprs.length}] of expressions [$fieldExprs].")
+    }
+    if (fieldExprIdxToOutputRowPosMap.size != fieldExprs.length) {
+      throw new CodeGenException(
+        s"Size [${returnType.getFieldCount}] of fieldExprIdxToOutputRowPosMap does not match " +
+          s"number [${fieldExprs.length}] of expressions [$fieldExprs].")
+    }
+    // type check
+    fieldExprs.zipWithIndex.foreach {
+      // timestamp type(Include TimeIndicator) and generic type can compatible with each other.
+      case (fieldExpr, i)
+          if fieldExpr.resultType.isInstanceOf[TypeInformationRawType[_]] ||
+            fieldExpr.resultType.isInstanceOf[TimestampType] =>
+        if (
+          returnType.getTypeAt(i).getClass != fieldExpr.resultType.getClass
+          && !returnType.getTypeAt(i).isInstanceOf[TypeInformationRawType[_]]
+        ) {
+          throw new CodeGenException(
+            s"Incompatible types of expression and result type, Expression[$fieldExpr] type is " +
+              s"[${fieldExpr.resultType}], result type is [${returnType.getTypeAt(i)}]")
+        }
+      case (fieldExpr, i) if !isInteroperable(fieldExpr.resultType, returnType.getTypeAt(i)) =>
+        throw new CodeGenException(
+          s"Incompatible types of expression and result type. Expression[$fieldExpr] type is " +
+            s"[${fieldExpr.resultType}], result type is [${returnType.getTypeAt(i)}]")
+      case _ => // ok
+    }
+
+    val setFieldsCode = fieldExprs.zipWithIndex
+      .map {
+        case (fieldExpr, index) =>
+          val pos = fieldExprIdxToOutputRowPosMap.getOrElse(
+            index,
+            throw new CodeGenException(s"Illegal field expr index: $index"))
+          rowSetField(ctx, returnTypeClazz, outRow, pos.toString, fieldExpr, outRowWriter)
+      }
+      .mkString("\n")
+
+    val outRowInitCode = if (!outRowAlreadyExists) {
+      val initCode = generateRecordStatement(returnType, returnTypeClazz, outRow, outRowWriter, ctx)
+      if (reusedOutRow) {
+        NO_CODE
+      } else {
+        initCode
+      }
+    } else {
+      NO_CODE
+    }
+
+    val code = if (returnTypeClazz == classOf[BinaryRowData] && outRowWriter.isDefined) {
+      val writer = outRowWriter.get
+      val resetWriter = s"$writer.reset();"
+      val completeWriter: String = s"$writer.complete();"
+      s"""
+         |$outRowInitCode
+         |$resetWriter
+         |$setFieldsCode
+         |$completeWriter
+        """.stripMargin
+    } else {
+      s"""
+         |$outRowInitCode
+         |$setFieldsCode
+        """.stripMargin
+    }
+    GeneratedExpression(outRow, NEVER_NULL, code, returnType)
+  }
+}

--- a/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/ExprCodeGenerator.scala
+++ b/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/ExprCodeGenerator.scala
@@ -1,27 +1,27 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+                                    * Licensed to the Apache Software Foundation (ASF) under one
+                                    * or more contributor license agreements.  See the NOTICE file
+                                    * distributed with this work for additional information
+                                    * regarding copyright ownership.  The ASF licenses this file
+                                    * to you under the Apache License, Version 2.0 (the
+                                    * "License"); you may not use this file except in compliance
+                                    * with the License.  You may obtain a copy of the License at
+                                    *
+                                    *     http://www.apache.org/licenses/LICENSE-2.0
+                                    *
+                                    * Unless required by applicable law or agreed to in writing, software
+                                    * distributed under the License is distributed on an "AS IS" BASIS,
+                                    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                    * See the License for the specific language governing permissions and
+                                    * limitations under the License.
+                                    */
 package org.apache.flink.table.store.codegen
 
 import org.apache.flink.table.data.RowData
 import org.apache.flink.table.data.binary.BinaryRowData
 import org.apache.flink.table.runtime.types.PlannerTypeUtils.isInteroperable
-import org.apache.flink.table.store.codegen.GenerateUtils.{DEFAULT_OUT_RECORD_TERM, DEFAULT_OUT_RECORD_WRITER_TERM, generateRecordStatement, rowSetField}
 import org.apache.flink.table.store.codegen.GeneratedExpression.{NEVER_NULL, NO_CODE}
+import org.apache.flink.table.store.codegen.GenerateUtils.{generateRecordStatement, rowSetField, DEFAULT_OUT_RECORD_TERM, DEFAULT_OUT_RECORD_WRITER_TERM}
 import org.apache.flink.table.types.logical._
 
 class ExprCodeGenerator(ctx: CodeGeneratorContext) {

--- a/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/GenerateUtils.scala
+++ b/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/GenerateUtils.scala
@@ -1,0 +1,815 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.codegen
+
+import org.apache.flink.api.common.ExecutionConfig
+import org.apache.flink.api.common.typeinfo.{AtomicType => AtomicTypeInfo}
+import org.apache.flink.core.memory.MemorySegment
+import org.apache.flink.table.data.binary.{BinaryRawValueData, BinaryRowData, BinaryStringData}
+import org.apache.flink.table.data._
+import org.apache.flink.table.data.utils.JoinedRowData
+import org.apache.flink.table.data.writer.BinaryRowWriter
+import org.apache.flink.table.types.logical.LogicalTypeRoot._
+import org.apache.flink.table.types.logical._
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.{getFieldCount, getFieldTypes, getPrecision, getScale}
+
+import java.lang.{Boolean => JBoolean, Byte => JByte, Double => JDouble, Float => JFloat, Integer => JInt, Long => JLong, Object => JObject, Short => JShort}
+import java.util.concurrent.atomic.AtomicLong
+import scala.annotation.tailrec
+import scala.collection.mutable
+
+/** Utilities to generate code for general purpose. */
+object GenerateUtils {
+
+  val DEFAULT_INPUT1_TERM = "in1"
+
+  val DEFAULT_OUT_RECORD_TERM = "out"
+
+  val DEFAULT_OUT_RECORD_WRITER_TERM = "outWriter"
+
+  val BINARY_RAW_VALUE: String = className[BinaryRawValueData[_]]
+
+  val ARRAY_DATA: String = className[ArrayData]
+
+  val ROW_DATA: String = className[RowData]
+
+  val BINARY_STRING: String = className[BinaryStringData]
+
+  val SEGMENT: String = className[MemorySegment]
+
+  /** Retrieve the canonical name of a class type. */
+  def className[T](implicit m: Manifest[T]): String = {
+    val name = m.runtimeClass.getCanonicalName
+    if (name == null) {
+      throw new CodeGenException(
+        s"Class '${m.runtimeClass.getName}' does not have a canonical name. " +
+          s"Make sure it is statically accessible.")
+    }
+    name
+  }
+
+  /** Gets the default value for a primitive type, and null for generic types */
+  @tailrec
+  def primitiveDefaultValue(t: LogicalType): String = t.getTypeRoot match {
+    // ordered by type root definition
+    case CHAR | VARCHAR => s"$BINARY_STRING.EMPTY_UTF8"
+    case BOOLEAN => "false"
+    case TINYINT | SMALLINT | INTEGER | DATE | TIME_WITHOUT_TIME_ZONE | INTERVAL_YEAR_MONTH => "-1"
+    case BIGINT | INTERVAL_DAY_TIME => "-1L"
+    case FLOAT => "-1.0f"
+    case DOUBLE => "-1.0d"
+
+    case DISTINCT_TYPE => primitiveDefaultValue(t.asInstanceOf[DistinctType].getSourceType)
+
+    case _ => "null"
+  }
+
+  @tailrec
+  def generateFieldAccess(
+      ctx: CodeGeneratorContext,
+      inputType: LogicalType,
+      inputTerm: String,
+      index: Int): GeneratedExpression = inputType.getTypeRoot match {
+    // ordered by type root definition
+    case ROW | STRUCTURED_TYPE =>
+      val fieldType = getFieldTypes(inputType).get(index)
+      val resultTypeTerm = primitiveTypeTermForType(fieldType)
+      val defaultValue = primitiveDefaultValue(fieldType)
+      val readCode = rowFieldReadAccess(index.toString, inputTerm, fieldType)
+      val Seq(fieldTerm, nullTerm) =
+        ctx.addReusableLocalVariables((resultTypeTerm, "field"), ("boolean", "isNull"))
+
+      val inputCode =
+        s"""
+           |$nullTerm = $inputTerm.isNullAt($index);
+           |$fieldTerm = $defaultValue;
+           |if (!$nullTerm) {
+           |  $fieldTerm = $readCode;
+           |}
+           """.stripMargin.trim
+
+      GeneratedExpression(fieldTerm, nullTerm, inputCode, fieldType)
+
+    case DISTINCT_TYPE =>
+      generateFieldAccess(ctx, inputType.asInstanceOf[DistinctType].getSourceType, inputTerm, index)
+
+    case _ =>
+      val fieldTypeTerm = boxedTypeTermForType(inputType)
+      val inputCode = s"($fieldTypeTerm) $inputTerm"
+      generateInputFieldUnboxing(ctx, inputType, inputCode, inputCode)
+  }
+
+  /** Generates code for comparing two fields. */
+  @tailrec
+  def generateCompare(
+      ctx: CodeGeneratorContext,
+      t: LogicalType,
+      nullsIsLast: Boolean,
+      leftTerm: String,
+      rightTerm: String): String = t.getTypeRoot match {
+    // ordered by type root definition
+    case CHAR | VARCHAR | DECIMAL | TIMESTAMP_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
+      s"$leftTerm.compareTo($rightTerm)"
+    case BOOLEAN =>
+      s"($leftTerm == $rightTerm ? 0 : ($leftTerm ? 1 : -1))"
+    case BINARY | VARBINARY =>
+      val sortUtil =
+        classOf[org.apache.flink.table.runtime.operators.sort.SortUtil].getCanonicalName
+      s"$sortUtil.compareBinary($leftTerm, $rightTerm)"
+    case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | DATE | TIME_WITHOUT_TIME_ZONE |
+        INTERVAL_YEAR_MONTH | INTERVAL_DAY_TIME =>
+      s"($leftTerm > $rightTerm ? 1 : $leftTerm < $rightTerm ? -1 : 0)"
+    case TIMESTAMP_WITH_TIME_ZONE | MULTISET | MAP =>
+      throw new UnsupportedOperationException() // TODO support MULTISET and MAP?
+    case ARRAY =>
+      val at = t.asInstanceOf[ArrayType]
+      val compareFunc = newName("compareArray")
+      val compareCode = generateArrayCompare(ctx, nullsIsLast = false, at, "a", "b")
+      val funcCode: String =
+        s"""
+          public int $compareFunc($ARRAY_DATA a, $ARRAY_DATA b) {
+            $compareCode
+            return 0;
+          }
+        """
+      ctx.addReusableMember(funcCode)
+      s"$compareFunc($leftTerm, $rightTerm)"
+    case ROW | STRUCTURED_TYPE =>
+      val fieldCount = getFieldCount(t)
+      val comparisons = generateRowCompare(
+        ctx,
+        t,
+        getAscendingSortSpec((0 until fieldCount).toArray),
+        "a",
+        "b")
+      val compareFunc = newName("compareRow")
+      val funcCode: String =
+        s"""
+          public int $compareFunc($ROW_DATA a, $ROW_DATA b) {
+            $comparisons
+            return 0;
+          }
+        """
+      ctx.addReusableMember(funcCode)
+      s"$compareFunc($leftTerm, $rightTerm)"
+    case DISTINCT_TYPE =>
+      generateCompare(
+        ctx,
+        t.asInstanceOf[DistinctType].getSourceType,
+        nullsIsLast,
+        leftTerm,
+        rightTerm)
+    case RAW =>
+      t match {
+        case rawType: RawType[_] =>
+          val clazz = rawType.getOriginatingClass
+          if (!classOf[Comparable[_]].isAssignableFrom(clazz)) {
+            throw new CodeGenException(
+              s"Raw type class '$clazz' must implement ${className[Comparable[_]]} to be used " +
+                s"in a comparison of two '${rawType.asSummaryString()}' types.")
+          }
+          val serializer = rawType.getTypeSerializer
+          val serializerTerm = ctx.addReusableObject(serializer, "serializer")
+          s"((${className[Comparable[_]]}) $leftTerm.toObject($serializerTerm))" +
+            s".compareTo($rightTerm.toObject($serializerTerm))"
+
+        case rawType: TypeInformationRawType[_] =>
+          val serializer = rawType.getTypeInformation.createSerializer(new ExecutionConfig)
+          val ser = ctx.addReusableObject(serializer, "serializer")
+          val comp = ctx.addReusableObject(
+            rawType.getTypeInformation
+              .asInstanceOf[AtomicTypeInfo[_]]
+              .createComparator(true, new ExecutionConfig),
+            "comparator")
+          s"$comp.compare($leftTerm.toObject($ser), $rightTerm.toObject($ser))"
+      }
+    case NULL | SYMBOL | UNRESOLVED =>
+      throw new IllegalArgumentException("Illegal type: " + t)
+  }
+
+  /** Generates code for comparing array. */
+  def generateArrayCompare(
+      ctx: CodeGeneratorContext,
+      nullsIsLast: Boolean,
+      arrayType: ArrayType,
+      leftTerm: String,
+      rightTerm: String): String = {
+    val nullIsLastRet = if (nullsIsLast) 1 else -1
+    val elementType = arrayType.getElementType
+    val fieldA = newName("fieldA")
+    val isNullA = newName("isNullA")
+    val lengthA = newName("lengthA")
+    val fieldB = newName("fieldB")
+    val isNullB = newName("isNullB")
+    val lengthB = newName("lengthB")
+    val minLength = newName("minLength")
+    val i = newName("i")
+    val comp = newName("comp")
+    val typeTerm = primitiveTypeTermForType(elementType)
+    s"""
+        int $lengthA = a.size();
+        int $lengthB = b.size();
+        int $minLength = ($lengthA > $lengthB) ? $lengthB : $lengthA;
+        for (int $i = 0; $i < $minLength; $i++) {
+          boolean $isNullA = a.isNullAt($i);
+          boolean $isNullB = b.isNullAt($i);
+          if ($isNullA && $isNullB) {
+            // Continue to compare the next element
+          } else if ($isNullA) {
+            return $nullIsLastRet;
+          } else if ($isNullB) {
+            return ${-nullIsLastRet};
+          } else {
+            $typeTerm $fieldA = ${rowFieldReadAccess(i, leftTerm, elementType)};
+            $typeTerm $fieldB = ${rowFieldReadAccess(i, rightTerm, elementType)};
+            int $comp = ${generateCompare(ctx, elementType, nullsIsLast, fieldA, fieldB)};
+            if ($comp != 0) {
+              return $comp;
+            }
+          }
+        }
+
+        if ($lengthA < $lengthB) {
+          return -1;
+        } else if ($lengthA > $lengthB) {
+          return 1;
+        }
+      """
+  }
+
+  /** Generates code for comparing row keys. */
+  def generateRowCompare(
+      ctx: CodeGeneratorContext,
+      inputType: LogicalType,
+      sortSpec: SortSpec,
+      leftTerm: String,
+      rightTerm: String): String = {
+
+    val fieldTypes = getFieldTypes(inputType)
+    val compares = new mutable.ArrayBuffer[String]
+    sortSpec.getFieldSpecs.foreach {
+      fieldSpec =>
+        val index = fieldSpec.getFieldIndex
+        val symbol = if (fieldSpec.getIsAscendingOrder) "" else "-"
+        val nullIsLastRet = if (fieldSpec.getNullIsLast) 1 else -1
+        val t = fieldTypes.get(index)
+
+        val typeTerm = primitiveTypeTermForType(t)
+        val fieldA = newName("fieldA")
+        val isNullA = newName("isNullA")
+        val fieldB = newName("fieldB")
+        val isNullB = newName("isNullB")
+        val comp = newName("comp")
+
+        val code =
+          s"""
+             |boolean $isNullA = $leftTerm.isNullAt($index);
+             |boolean $isNullB = $rightTerm.isNullAt($index);
+             |if ($isNullA && $isNullB) {
+             |  // Continue to compare the next element
+             |} else if ($isNullA) {
+             |  return $nullIsLastRet;
+             |} else if ($isNullB) {
+             |  return ${-nullIsLastRet};
+             |} else {
+             |  $typeTerm $fieldA = ${rowFieldReadAccess(index, leftTerm, t)};
+             |  $typeTerm $fieldB = ${rowFieldReadAccess(index, rightTerm, t)};
+             |  int $comp = ${generateCompare(ctx, t, fieldSpec.getNullIsLast, fieldA, fieldB)};
+             |  if ($comp != 0) {
+             |    return $symbol$comp;
+             |  }
+             |}
+         """.stripMargin
+        compares += code
+    }
+    compares.mkString
+  }
+
+  // when casting we first need to unbox Primitives, for example,
+  // float a = 1.0f;
+  // byte b = (byte) a;
+  // works, but for boxed types we need this:
+  // Float a = 1.0f;
+  // Byte b = (byte)(float) a;
+  @tailrec
+  def primitiveTypeTermForType(t: LogicalType): String = t.getTypeRoot match {
+    // ordered by type root definition
+    case BOOLEAN => "boolean"
+    case TINYINT => "byte"
+    case SMALLINT => "short"
+    case INTEGER | DATE | TIME_WITHOUT_TIME_ZONE | INTERVAL_YEAR_MONTH => "int"
+    case BIGINT | INTERVAL_DAY_TIME => "long"
+    case FLOAT => "float"
+    case DOUBLE => "double"
+    case DISTINCT_TYPE => primitiveTypeTermForType(t.asInstanceOf[DistinctType].getSourceType)
+    case _ => boxedTypeTermForType(t)
+  }
+
+  @tailrec
+  def boxedTypeTermForType(t: LogicalType): String = t.getTypeRoot match {
+    // ordered by type root definition
+    case CHAR | VARCHAR => BINARY_STRING
+    case BOOLEAN => className[JBoolean]
+    case BINARY | VARBINARY => "byte[]"
+    case DECIMAL => className[DecimalData]
+    case TINYINT => className[JByte]
+    case SMALLINT => className[JShort]
+    case INTEGER | DATE | TIME_WITHOUT_TIME_ZONE | INTERVAL_YEAR_MONTH => className[JInt]
+    case BIGINT | INTERVAL_DAY_TIME => className[JLong]
+    case FLOAT => className[JFloat]
+    case DOUBLE => className[JDouble]
+    case TIMESTAMP_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE => className[TimestampData]
+    case TIMESTAMP_WITH_TIME_ZONE =>
+      throw new UnsupportedOperationException("Unsupported type: " + t)
+    case ARRAY => className[ArrayData]
+    case MULTISET | MAP => className[MapData]
+    case ROW | STRUCTURED_TYPE => className[RowData]
+    case DISTINCT_TYPE => boxedTypeTermForType(t.asInstanceOf[DistinctType].getSourceType)
+    case NULL => className[JObject] // special case for untyped null literals
+    case RAW => className[BinaryRawValueData[_]]
+    case SYMBOL | UNRESOLVED =>
+      throw new IllegalArgumentException("Illegal type: " + t)
+  }
+
+  def rowFieldReadAccess(index: Int, rowTerm: String, fieldType: LogicalType): String =
+    rowFieldReadAccess(index.toString, rowTerm, fieldType)
+
+  @tailrec
+  def rowFieldReadAccess(indexTerm: String, rowTerm: String, t: LogicalType): String =
+    t.getTypeRoot match {
+      // ordered by type root definition
+      case CHAR | VARCHAR =>
+        s"(($BINARY_STRING) $rowTerm.getString($indexTerm))"
+      case BOOLEAN =>
+        s"$rowTerm.getBoolean($indexTerm)"
+      case BINARY | VARBINARY =>
+        s"$rowTerm.getBinary($indexTerm)"
+      case DECIMAL =>
+        s"$rowTerm.getDecimal($indexTerm, ${getPrecision(t)}, ${getScale(t)})"
+      case TINYINT =>
+        s"$rowTerm.getByte($indexTerm)"
+      case SMALLINT =>
+        s"$rowTerm.getShort($indexTerm)"
+      case INTEGER | DATE | TIME_WITHOUT_TIME_ZONE | INTERVAL_YEAR_MONTH =>
+        s"$rowTerm.getInt($indexTerm)"
+      case BIGINT | INTERVAL_DAY_TIME =>
+        s"$rowTerm.getLong($indexTerm)"
+      case FLOAT =>
+        s"$rowTerm.getFloat($indexTerm)"
+      case DOUBLE =>
+        s"$rowTerm.getDouble($indexTerm)"
+      case TIMESTAMP_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
+        s"$rowTerm.getTimestamp($indexTerm, ${getPrecision(t)})"
+      case TIMESTAMP_WITH_TIME_ZONE =>
+        throw new UnsupportedOperationException("Unsupported type: " + t)
+      case ARRAY =>
+        s"$rowTerm.getArray($indexTerm)"
+      case MULTISET | MAP =>
+        s"$rowTerm.getMap($indexTerm)"
+      case ROW | STRUCTURED_TYPE =>
+        s"$rowTerm.getRow($indexTerm, ${getFieldCount(t)})"
+      case DISTINCT_TYPE =>
+        rowFieldReadAccess(indexTerm, rowTerm, t.asInstanceOf[DistinctType].getSourceType)
+      case RAW =>
+        s"(($BINARY_RAW_VALUE) $rowTerm.getRawValue($indexTerm))"
+      case NULL | SYMBOL | UNRESOLVED =>
+        throw new IllegalArgumentException("Illegal type: " + t)
+    }
+
+  /**
+   * Converts the external boxed format to an internal mostly primitive field representation.
+   * Wrapper types can autoboxed to their corresponding primitive type (Integer -> int).
+   *
+   * @param ctx
+   *   code generator context which maintains various code statements.
+   * @param inputType
+   *   type of field
+   * @param inputTerm
+   *   expression term of field to be unboxed
+   * @param inputUnboxingTerm
+   *   unboxing/conversion term
+   * @return
+   *   internal unboxed field representation
+   */
+  def generateInputFieldUnboxing(
+                                  ctx: CodeGeneratorContext,
+                                  inputType: LogicalType,
+                                  inputTerm: String,
+                                  inputUnboxingTerm: String): GeneratedExpression = {
+
+    val resultTypeTerm = primitiveTypeTermForType(inputType)
+    val defaultValue = primitiveDefaultValue(inputType)
+
+    val Seq(resultTerm, nullTerm) =
+      ctx.addReusableLocalVariables((resultTypeTerm, "result"), ("boolean", "isNull"))
+
+    val wrappedCode =
+      s"""
+         |$nullTerm = $inputTerm == null;
+         |$resultTerm = $defaultValue;
+         |if (!$nullTerm) {
+         |  $resultTerm = $inputUnboxingTerm;
+         |}
+         |""".stripMargin.trim
+
+    GeneratedExpression(resultTerm, nullTerm, wrappedCode, inputType)
+  }
+
+  private val nameCounter = new AtomicLong
+
+  def newName(name: String): String = {
+    s"$name$$${nameCounter.getAndIncrement}"
+  }
+
+  def newNames(names: String*): Seq[String] = {
+    require(names.toSet.size == names.length, "Duplicated names")
+    val newId = nameCounter.getAndIncrement
+    names.map(name => s"$name$$$newId")
+  }
+
+  def getAscendingSortSpec(fields: Array[Int]): SortSpec = {
+    val originalOrders = fields.map(_ => true)
+    val nullsIsLast = getNullDefaultOrders(originalOrders)
+    deduplicateSortKeys(fields, originalOrders, nullsIsLast)
+  }
+
+  private def deduplicateSortKeys(
+                                   keys: Array[Int],
+                                   orders: Array[Boolean],
+                                   nullsIsLast: Array[Boolean]): SortSpec = {
+    val builder = SortSpec.builder()
+    val keySet = new mutable.HashSet[Int]
+    for (i <- keys.indices) {
+      if (keySet.add(keys(i))) {
+        builder.addField(keys(i), orders(i), nullsIsLast(i))
+      }
+    }
+    builder.build()
+  }
+
+  /** Returns the default null direction if not specified. */
+  def getNullDefaultOrders(ascendings: Array[Boolean]): Array[Boolean] = {
+    ascendings.map(asc => !asc)
+  }
+
+  def rowSetField(
+                   ctx: CodeGeneratorContext,
+                   rowClass: Class[_ <: RowData],
+                   rowTerm: String,
+                   indexTerm: String,
+                   fieldExpr: GeneratedExpression,
+                   binaryRowWriterTerm: Option[String]): String = {
+
+    val fieldType = fieldExpr.resultType
+    val fieldTerm = fieldExpr.resultTerm
+
+    if (rowClass == classOf[BinaryRowData]) {
+      binaryRowWriterTerm match {
+        case Some(writer) =>
+          // use writer to set field
+          val writeField = binaryWriterWriteField(ctx, indexTerm, fieldTerm, writer, fieldType)
+          s"""
+             |${fieldExpr.code}
+             |if (${fieldExpr.nullTerm}) {
+             |  ${binaryWriterWriteNull(indexTerm, writer, fieldType)};
+             |} else {
+             |  $writeField;
+             |}
+           """.stripMargin
+
+        case None =>
+          // directly set field to BinaryRowData, this depends on all the fields are fixed length
+          val writeField = binaryRowFieldSetAccess(indexTerm, rowTerm, fieldType, fieldTerm)
+
+          s"""
+             |${fieldExpr.code}
+             |if (${fieldExpr.nullTerm}) {
+             |  ${binaryRowSetNull(indexTerm, rowTerm, fieldType)};
+             |} else {
+             |  $writeField;
+             |}
+           """.stripMargin
+      }
+    } else if (rowClass == classOf[GenericRowData] || rowClass == classOf[BoxedWrapperRowData]) {
+      val writeField = if (rowClass == classOf[GenericRowData]) {
+        s"$rowTerm.setField($indexTerm, $fieldTerm)"
+      } else {
+        boxedWrapperRowFieldSetAccess(rowTerm, indexTerm, fieldTerm, fieldType)
+      }
+      val setNullField = if (rowClass == classOf[GenericRowData]) {
+        s"$rowTerm.setField($indexTerm, null)"
+      } else {
+        s"$rowTerm.setNullAt($indexTerm)"
+      }
+
+      if (fieldType.isNullable) {
+        s"""
+           |${fieldExpr.code}
+           |if (${fieldExpr.nullTerm}) {
+           |  $setNullField;
+           |} else {
+           |  $writeField;
+           |}
+          """.stripMargin
+      } else {
+        s"""
+           |${fieldExpr.code}
+           |$writeField;
+         """.stripMargin
+      }
+    } else {
+      throw new UnsupportedOperationException("Not support set field for " + rowClass)
+    }
+  }
+
+  def binaryWriterWriteField(
+                              ctx: CodeGeneratorContext,
+                              index: Int,
+                              fieldValTerm: String,
+                              writerTerm: String,
+                              fieldType: LogicalType): String =
+    binaryWriterWriteField(
+      t => ctx.addReusableTypeSerializer(t),
+      index.toString,
+      fieldValTerm,
+      writerTerm,
+      fieldType)
+
+  def binaryWriterWriteField(
+                              ctx: CodeGeneratorContext,
+                              indexTerm: String,
+                              fieldValTerm: String,
+                              writerTerm: String,
+                              t: LogicalType): String =
+    binaryWriterWriteField(
+      t => ctx.addReusableTypeSerializer(t),
+      indexTerm,
+      fieldValTerm,
+      writerTerm,
+      t)
+
+  @tailrec
+  def binaryWriterWriteField(
+                              addSerializer: LogicalType => String,
+                              indexTerm: String,
+                              fieldValTerm: String,
+                              writerTerm: String,
+                              t: LogicalType): String = t.getTypeRoot match {
+    // ordered by type root definition
+    case CHAR | VARCHAR =>
+      s"$writerTerm.writeString($indexTerm, $fieldValTerm)"
+    case BOOLEAN =>
+      s"$writerTerm.writeBoolean($indexTerm, $fieldValTerm)"
+    case BINARY | VARBINARY =>
+      s"$writerTerm.writeBinary($indexTerm, $fieldValTerm)"
+    case DECIMAL =>
+      s"$writerTerm.writeDecimal($indexTerm, $fieldValTerm, ${getPrecision(t)})"
+    case TINYINT =>
+      s"$writerTerm.writeByte($indexTerm, $fieldValTerm)"
+    case SMALLINT =>
+      s"$writerTerm.writeShort($indexTerm, $fieldValTerm)"
+    case INTEGER | DATE | TIME_WITHOUT_TIME_ZONE | INTERVAL_YEAR_MONTH =>
+      s"$writerTerm.writeInt($indexTerm, $fieldValTerm)"
+    case BIGINT | INTERVAL_DAY_TIME =>
+      s"$writerTerm.writeLong($indexTerm, $fieldValTerm)"
+    case FLOAT =>
+      s"$writerTerm.writeFloat($indexTerm, $fieldValTerm)"
+    case DOUBLE =>
+      s"$writerTerm.writeDouble($indexTerm, $fieldValTerm)"
+    case TIMESTAMP_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
+      s"$writerTerm.writeTimestamp($indexTerm, $fieldValTerm, ${getPrecision(t)})"
+    case TIMESTAMP_WITH_TIME_ZONE =>
+      throw new UnsupportedOperationException("Unsupported type: " + t)
+    case ARRAY =>
+      val ser = addSerializer(t)
+      s"$writerTerm.writeArray($indexTerm, $fieldValTerm, $ser)"
+    case MULTISET | MAP =>
+      val ser = addSerializer(t)
+      s"$writerTerm.writeMap($indexTerm, $fieldValTerm, $ser)"
+    case ROW | STRUCTURED_TYPE =>
+      val ser = addSerializer(t)
+      s"$writerTerm.writeRow($indexTerm, $fieldValTerm, $ser)"
+    case DISTINCT_TYPE =>
+      binaryWriterWriteField(
+        addSerializer,
+        indexTerm,
+        fieldValTerm,
+        writerTerm,
+        t.asInstanceOf[DistinctType].getSourceType)
+    case RAW =>
+      val ser = addSerializer(t)
+      s"$writerTerm.writeRawValue($indexTerm, $fieldValTerm, $ser)"
+    case NULL | SYMBOL | UNRESOLVED =>
+      throw new IllegalArgumentException("Illegal type: " + t);
+  }
+
+  def binaryWriterWriteNull(index: Int, writerTerm: String, t: LogicalType): String =
+    binaryWriterWriteNull(index.toString, writerTerm, t)
+
+  @tailrec
+  def binaryWriterWriteNull(indexTerm: String, writerTerm: String, t: LogicalType): String =
+    t.getTypeRoot match {
+      // ordered by type root definition
+      case DECIMAL if !DecimalData.isCompact(getPrecision(t)) =>
+        s"$writerTerm.writeDecimal($indexTerm, null, ${getPrecision(t)})"
+      case TIMESTAMP_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE
+        if !TimestampData.isCompact(getPrecision(t)) =>
+        s"$writerTerm.writeTimestamp($indexTerm, null, ${getPrecision(t)})"
+      case DISTINCT_TYPE =>
+        binaryWriterWriteNull(indexTerm, writerTerm, t.asInstanceOf[DistinctType].getSourceType)
+      case _ =>
+        s"$writerTerm.setNullAt($indexTerm)"
+    }
+
+  @tailrec
+  def boxedWrapperRowFieldSetAccess(
+                                     rowTerm: String,
+                                     indexTerm: String,
+                                     fieldTerm: String,
+                                     t: LogicalType): String = t.getTypeRoot match {
+    // ordered by type root definition
+    case BOOLEAN =>
+      s"$rowTerm.setBoolean($indexTerm, $fieldTerm)"
+    case TINYINT =>
+      s"$rowTerm.setByte($indexTerm, $fieldTerm)"
+    case SMALLINT =>
+      s"$rowTerm.setShort($indexTerm, $fieldTerm)"
+    case INTEGER | DATE | TIME_WITHOUT_TIME_ZONE | INTERVAL_YEAR_MONTH =>
+      s"$rowTerm.setInt($indexTerm, $fieldTerm)"
+    case BIGINT | INTERVAL_DAY_TIME =>
+      s"$rowTerm.setLong($indexTerm, $fieldTerm)"
+    case FLOAT =>
+      s"$rowTerm.setFloat($indexTerm, $fieldTerm)"
+    case DOUBLE =>
+      s"$rowTerm.setDouble($indexTerm, $fieldTerm)"
+    case DISTINCT_TYPE =>
+      boxedWrapperRowFieldSetAccess(
+        rowTerm,
+        indexTerm,
+        fieldTerm,
+        t.asInstanceOf[DistinctType].getSourceType)
+    case _ =>
+      s"$rowTerm.setNonPrimitiveValue($indexTerm, $fieldTerm)"
+  }
+
+  // -------------------------- BinaryArray Set Access -------------------------------
+
+  @tailrec
+  def binaryArraySetNull(index: Int, arrayTerm: String, t: LogicalType): String =
+    t.getTypeRoot match {
+      // ordered by type root definition
+      case BOOLEAN =>
+        s"$arrayTerm.setNullBoolean($index)"
+      case TINYINT =>
+        s"$arrayTerm.setNullByte($index)"
+      case SMALLINT =>
+        s"$arrayTerm.setNullShort($index)"
+      case INTEGER | DATE | TIME_WITHOUT_TIME_ZONE | INTERVAL_YEAR_MONTH =>
+        s"$arrayTerm.setNullInt($index)"
+      case FLOAT =>
+        s"$arrayTerm.setNullFloat($index)"
+      case DOUBLE =>
+        s"$arrayTerm.setNullDouble($index)"
+      case DISTINCT_TYPE =>
+        binaryArraySetNull(index, arrayTerm, t)
+      case _ =>
+        s"$arrayTerm.setNullLong($index)"
+    }
+
+  def binaryRowFieldSetAccess(
+                               index: Int,
+                               binaryRowTerm: String,
+                               fieldType: LogicalType,
+                               fieldValTerm: String): String =
+    binaryRowFieldSetAccess(index.toString, binaryRowTerm, fieldType, fieldValTerm)
+
+  @tailrec
+  def binaryRowFieldSetAccess(
+                               index: String,
+                               binaryRowTerm: String,
+                               t: LogicalType,
+                               fieldValTerm: String): String = t.getTypeRoot match {
+    // ordered by type root definition
+    case BOOLEAN =>
+      s"$binaryRowTerm.setBoolean($index, $fieldValTerm)"
+    case DECIMAL =>
+      s"$binaryRowTerm.setDecimal($index, $fieldValTerm, ${getPrecision(t)})"
+    case TINYINT =>
+      s"$binaryRowTerm.setByte($index, $fieldValTerm)"
+    case SMALLINT =>
+      s"$binaryRowTerm.setShort($index, $fieldValTerm)"
+    case INTEGER | DATE | TIME_WITHOUT_TIME_ZONE | INTERVAL_YEAR_MONTH =>
+      s"$binaryRowTerm.setInt($index, $fieldValTerm)"
+    case BIGINT | INTERVAL_DAY_TIME =>
+      s"$binaryRowTerm.setLong($index, $fieldValTerm)"
+    case FLOAT =>
+      s"$binaryRowTerm.setFloat($index, $fieldValTerm)"
+    case DOUBLE =>
+      s"$binaryRowTerm.setDouble($index, $fieldValTerm)"
+    case TIMESTAMP_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
+      s"$binaryRowTerm.setTimestamp($index, $fieldValTerm, ${getPrecision(t)})"
+    case DISTINCT_TYPE =>
+      binaryRowFieldSetAccess(
+        index,
+        binaryRowTerm,
+        t.asInstanceOf[DistinctType].getSourceType,
+        fieldValTerm)
+    case _ =>
+      throw new CodeGenException(
+        "Fail to find binary row field setter method of LogicalType " + t + ".")
+  }
+
+  def binaryRowSetNull(index: Int, rowTerm: String, t: LogicalType): String =
+    binaryRowSetNull(index.toString, rowTerm, t)
+
+  @tailrec
+  def binaryRowSetNull(indexTerm: String, rowTerm: String, t: LogicalType): String =
+    t.getTypeRoot match {
+      // ordered by type root definition
+      case DECIMAL if !DecimalData.isCompact(getPrecision(t)) =>
+        s"$rowTerm.setDecimal($indexTerm, null, ${getPrecision(t)})"
+      case TIMESTAMP_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE
+        if !TimestampData.isCompact(getPrecision(t)) =>
+        s"$rowTerm.setTimestamp($indexTerm, null, ${getPrecision(t)})"
+      case DISTINCT_TYPE =>
+        binaryRowSetNull(indexTerm, rowTerm, t.asInstanceOf[DistinctType].getSourceType)
+      case _ =>
+        s"$rowTerm.setNullAt($indexTerm)"
+    }
+
+  /**
+   * Generates a record declaration statement, and add it to reusable member. The record can be any
+   * type of RowData or other types.
+   *
+   * @param t
+   *   the record type
+   * @param clazz
+   *   the specified class of the type (only used when RowType)
+   * @param recordTerm
+   *   the record term to be declared
+   * @param recordWriterTerm
+   *   the record writer term (only used when BinaryRowData type)
+   * @param ctx
+   *   the code generator context
+   * @return
+   *   the record initialization statement
+   */
+  @tailrec
+  def generateRecordStatement(
+                               t: LogicalType,
+                               clazz: Class[_],
+                               recordTerm: String,
+                               recordWriterTerm: Option[String] = None,
+                               ctx: CodeGeneratorContext): String = t.getTypeRoot match {
+    // ordered by type root definition
+    case ROW | STRUCTURED_TYPE if clazz == classOf[BinaryRowData] =>
+      val writerTerm = recordWriterTerm.getOrElse(
+        throw new CodeGenException("No writer is specified when writing BinaryRowData record.")
+      )
+      val binaryRowWriter = className[BinaryRowWriter]
+      val typeTerm = clazz.getCanonicalName
+      ctx.addReusableMember(s"$typeTerm $recordTerm = new $typeTerm(${getFieldCount(t)});")
+      ctx.addReusableMember(s"$binaryRowWriter $writerTerm = new $binaryRowWriter($recordTerm);")
+      s"""
+         |$recordTerm = new $typeTerm(${getFieldCount(t)});
+         |$writerTerm = new $binaryRowWriter($recordTerm);
+         |""".stripMargin.trim
+    case ROW | STRUCTURED_TYPE
+      if clazz == classOf[GenericRowData] ||
+        clazz == classOf[BoxedWrapperRowData] =>
+      val typeTerm = clazz.getCanonicalName
+      ctx.addReusableMember(s"$typeTerm $recordTerm = new $typeTerm(${getFieldCount(t)});")
+      s"$recordTerm = new $typeTerm(${getFieldCount(t)});"
+    case ROW | STRUCTURED_TYPE if clazz == classOf[JoinedRowData] =>
+      val typeTerm = clazz.getCanonicalName
+      ctx.addReusableMember(s"$typeTerm $recordTerm = new $typeTerm();")
+      s"$recordTerm = new $typeTerm();"
+    case DISTINCT_TYPE =>
+      generateRecordStatement(
+        t.asInstanceOf[DistinctType].getSourceType,
+        clazz,
+        recordTerm,
+        recordWriterTerm,
+        ctx)
+    case _ =>
+      val typeTerm = boxedTypeTermForType(t)
+      ctx.addReusableMember(s"$typeTerm $recordTerm = new $typeTerm();")
+      s"$recordTerm = new $typeTerm();"
+  }
+}

--- a/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/GenerateUtils.scala
+++ b/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/GenerateUtils.scala
@@ -1,20 +1,20 @@
 /*
-                                    * Licensed to the Apache Software Foundation (ASF) under one
-                                    * or more contributor license agreements.  See the NOTICE file
-                                    * distributed with this work for additional information
-                                    * regarding copyright ownership.  The ASF licenses this file
-                                    * to you under the Apache License, Version 2.0 (the
-                                    * "License"); you may not use this file except in compliance
-                                    * with the License.  You may obtain a copy of the License at
-                                    *
-                                    *     http://www.apache.org/licenses/LICENSE-2.0
-                                    *
-                                    * Unless required by applicable law or agreed to in writing, software
-                                    * distributed under the License is distributed on an "AS IS" BASIS,
-                                    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                    * See the License for the specific language governing permissions and
-                                    * limitations under the License.
-                                    */
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.flink.table.store.codegen
 
 import org.apache.flink.api.common.ExecutionConfig

--- a/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/GenerateUtils.scala
+++ b/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/GenerateUtils.scala
@@ -1,36 +1,36 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+                                    * Licensed to the Apache Software Foundation (ASF) under one
+                                    * or more contributor license agreements.  See the NOTICE file
+                                    * distributed with this work for additional information
+                                    * regarding copyright ownership.  The ASF licenses this file
+                                    * to you under the Apache License, Version 2.0 (the
+                                    * "License"); you may not use this file except in compliance
+                                    * with the License.  You may obtain a copy of the License at
+                                    *
+                                    *     http://www.apache.org/licenses/LICENSE-2.0
+                                    *
+                                    * Unless required by applicable law or agreed to in writing, software
+                                    * distributed under the License is distributed on an "AS IS" BASIS,
+                                    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                    * See the License for the specific language governing permissions and
+                                    * limitations under the License.
+                                    */
 package org.apache.flink.table.store.codegen
 
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeinfo.{AtomicType => AtomicTypeInfo}
 import org.apache.flink.core.memory.MemorySegment
-import org.apache.flink.table.data.binary.{BinaryRawValueData, BinaryRowData, BinaryStringData}
 import org.apache.flink.table.data._
+import org.apache.flink.table.data.binary.{BinaryRawValueData, BinaryRowData, BinaryStringData}
 import org.apache.flink.table.data.utils.JoinedRowData
 import org.apache.flink.table.data.writer.BinaryRowWriter
-import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical._
+import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.{getFieldCount, getFieldTypes, getPrecision, getScale}
 
 import java.lang.{Boolean => JBoolean, Byte => JByte, Double => JDouble, Float => JFloat, Integer => JInt, Long => JLong, Object => JObject, Short => JShort}
 import java.util.concurrent.atomic.AtomicLong
+
 import scala.annotation.tailrec
 import scala.collection.mutable
 
@@ -152,12 +152,8 @@ object GenerateUtils {
       s"$compareFunc($leftTerm, $rightTerm)"
     case ROW | STRUCTURED_TYPE =>
       val fieldCount = getFieldCount(t)
-      val comparisons = generateRowCompare(
-        ctx,
-        t,
-        getAscendingSortSpec((0 until fieldCount).toArray),
-        "a",
-        "b")
+      val comparisons =
+        generateRowCompare(ctx, t, getAscendingSortSpec((0 until fieldCount).toArray), "a", "b")
       val compareFunc = newName("compareRow")
       val funcCode: String =
         s"""
@@ -408,10 +404,10 @@ object GenerateUtils {
    *   internal unboxed field representation
    */
   def generateInputFieldUnboxing(
-                                  ctx: CodeGeneratorContext,
-                                  inputType: LogicalType,
-                                  inputTerm: String,
-                                  inputUnboxingTerm: String): GeneratedExpression = {
+      ctx: CodeGeneratorContext,
+      inputType: LogicalType,
+      inputTerm: String,
+      inputUnboxingTerm: String): GeneratedExpression = {
 
     val resultTypeTerm = primitiveTypeTermForType(inputType)
     val defaultValue = primitiveDefaultValue(inputType)
@@ -450,9 +446,9 @@ object GenerateUtils {
   }
 
   private def deduplicateSortKeys(
-                                   keys: Array[Int],
-                                   orders: Array[Boolean],
-                                   nullsIsLast: Array[Boolean]): SortSpec = {
+      keys: Array[Int],
+      orders: Array[Boolean],
+      nullsIsLast: Array[Boolean]): SortSpec = {
     val builder = SortSpec.builder()
     val keySet = new mutable.HashSet[Int]
     for (i <- keys.indices) {
@@ -469,12 +465,12 @@ object GenerateUtils {
   }
 
   def rowSetField(
-                   ctx: CodeGeneratorContext,
-                   rowClass: Class[_ <: RowData],
-                   rowTerm: String,
-                   indexTerm: String,
-                   fieldExpr: GeneratedExpression,
-                   binaryRowWriterTerm: Option[String]): String = {
+      ctx: CodeGeneratorContext,
+      rowClass: Class[_ <: RowData],
+      rowTerm: String,
+      indexTerm: String,
+      fieldExpr: GeneratedExpression,
+      binaryRowWriterTerm: Option[String]): String = {
 
     val fieldType = fieldExpr.resultType
     val fieldTerm = fieldExpr.resultTerm
@@ -539,11 +535,11 @@ object GenerateUtils {
   }
 
   def binaryWriterWriteField(
-                              ctx: CodeGeneratorContext,
-                              index: Int,
-                              fieldValTerm: String,
-                              writerTerm: String,
-                              fieldType: LogicalType): String =
+      ctx: CodeGeneratorContext,
+      index: Int,
+      fieldValTerm: String,
+      writerTerm: String,
+      fieldType: LogicalType): String =
     binaryWriterWriteField(
       t => ctx.addReusableTypeSerializer(t),
       index.toString,
@@ -552,11 +548,11 @@ object GenerateUtils {
       fieldType)
 
   def binaryWriterWriteField(
-                              ctx: CodeGeneratorContext,
-                              indexTerm: String,
-                              fieldValTerm: String,
-                              writerTerm: String,
-                              t: LogicalType): String =
+      ctx: CodeGeneratorContext,
+      indexTerm: String,
+      fieldValTerm: String,
+      writerTerm: String,
+      t: LogicalType): String =
     binaryWriterWriteField(
       t => ctx.addReusableTypeSerializer(t),
       indexTerm,
@@ -566,11 +562,11 @@ object GenerateUtils {
 
   @tailrec
   def binaryWriterWriteField(
-                              addSerializer: LogicalType => String,
-                              indexTerm: String,
-                              fieldValTerm: String,
-                              writerTerm: String,
-                              t: LogicalType): String = t.getTypeRoot match {
+      addSerializer: LogicalType => String,
+      indexTerm: String,
+      fieldValTerm: String,
+      writerTerm: String,
+      t: LogicalType): String = t.getTypeRoot match {
     // ordered by type root definition
     case CHAR | VARCHAR =>
       s"$writerTerm.writeString($indexTerm, $fieldValTerm)"
@@ -629,7 +625,7 @@ object GenerateUtils {
       case DECIMAL if !DecimalData.isCompact(getPrecision(t)) =>
         s"$writerTerm.writeDecimal($indexTerm, null, ${getPrecision(t)})"
       case TIMESTAMP_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE
-        if !TimestampData.isCompact(getPrecision(t)) =>
+          if !TimestampData.isCompact(getPrecision(t)) =>
         s"$writerTerm.writeTimestamp($indexTerm, null, ${getPrecision(t)})"
       case DISTINCT_TYPE =>
         binaryWriterWriteNull(indexTerm, writerTerm, t.asInstanceOf[DistinctType].getSourceType)
@@ -639,10 +635,10 @@ object GenerateUtils {
 
   @tailrec
   def boxedWrapperRowFieldSetAccess(
-                                     rowTerm: String,
-                                     indexTerm: String,
-                                     fieldTerm: String,
-                                     t: LogicalType): String = t.getTypeRoot match {
+      rowTerm: String,
+      indexTerm: String,
+      fieldTerm: String,
+      t: LogicalType): String = t.getTypeRoot match {
     // ordered by type root definition
     case BOOLEAN =>
       s"$rowTerm.setBoolean($indexTerm, $fieldTerm)"
@@ -693,18 +689,18 @@ object GenerateUtils {
     }
 
   def binaryRowFieldSetAccess(
-                               index: Int,
-                               binaryRowTerm: String,
-                               fieldType: LogicalType,
-                               fieldValTerm: String): String =
+      index: Int,
+      binaryRowTerm: String,
+      fieldType: LogicalType,
+      fieldValTerm: String): String =
     binaryRowFieldSetAccess(index.toString, binaryRowTerm, fieldType, fieldValTerm)
 
   @tailrec
   def binaryRowFieldSetAccess(
-                               index: String,
-                               binaryRowTerm: String,
-                               t: LogicalType,
-                               fieldValTerm: String): String = t.getTypeRoot match {
+      index: String,
+      binaryRowTerm: String,
+      t: LogicalType,
+      fieldValTerm: String): String = t.getTypeRoot match {
     // ordered by type root definition
     case BOOLEAN =>
       s"$binaryRowTerm.setBoolean($index, $fieldValTerm)"
@@ -745,7 +741,7 @@ object GenerateUtils {
       case DECIMAL if !DecimalData.isCompact(getPrecision(t)) =>
         s"$rowTerm.setDecimal($indexTerm, null, ${getPrecision(t)})"
       case TIMESTAMP_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE
-        if !TimestampData.isCompact(getPrecision(t)) =>
+          if !TimestampData.isCompact(getPrecision(t)) =>
         s"$rowTerm.setTimestamp($indexTerm, null, ${getPrecision(t)})"
       case DISTINCT_TYPE =>
         binaryRowSetNull(indexTerm, rowTerm, t.asInstanceOf[DistinctType].getSourceType)
@@ -772,11 +768,11 @@ object GenerateUtils {
    */
   @tailrec
   def generateRecordStatement(
-                               t: LogicalType,
-                               clazz: Class[_],
-                               recordTerm: String,
-                               recordWriterTerm: Option[String] = None,
-                               ctx: CodeGeneratorContext): String = t.getTypeRoot match {
+      t: LogicalType,
+      clazz: Class[_],
+      recordTerm: String,
+      recordWriterTerm: Option[String] = None,
+      ctx: CodeGeneratorContext): String = t.getTypeRoot match {
     // ordered by type root definition
     case ROW | STRUCTURED_TYPE if clazz == classOf[BinaryRowData] =>
       val writerTerm = recordWriterTerm.getOrElse(
@@ -791,8 +787,8 @@ object GenerateUtils {
          |$writerTerm = new $binaryRowWriter($recordTerm);
          |""".stripMargin.trim
     case ROW | STRUCTURED_TYPE
-      if clazz == classOf[GenericRowData] ||
-        clazz == classOf[BoxedWrapperRowData] =>
+        if clazz == classOf[GenericRowData] ||
+          clazz == classOf[BoxedWrapperRowData] =>
       val typeTerm = clazz.getCanonicalName
       ctx.addReusableMember(s"$typeTerm $recordTerm = new $typeTerm(${getFieldCount(t)});")
       s"$recordTerm = new $typeTerm(${getFieldCount(t)});"

--- a/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/GeneratedExpression.scala
+++ b/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/GeneratedExpression.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.codegen
+
+import org.apache.flink.table.types.logical.LogicalType
+
+/**
+ * Describes a generated expression.
+ *
+ * @param resultTerm
+ *   term to access the result of the expression
+ * @param nullTerm
+ *   boolean term that indicates if expression is null
+ * @param code
+ *   code necessary to produce resultTerm and nullTerm
+ * @param resultType
+ *   type of the resultTerm
+ */
+case class GeneratedExpression(
+  resultTerm: String,
+  nullTerm: String,
+  code: String,
+  resultType: LogicalType
+)
+
+object GeneratedExpression {
+  val ALWAYS_NULL = "true"
+  val NEVER_NULL = "false"
+  val NO_CODE = ""
+}

--- a/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/GeneratedExpression.scala
+++ b/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/GeneratedExpression.scala
@@ -1,21 +1,20 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+                                    * Licensed to the Apache Software Foundation (ASF) under one
+                                    * or more contributor license agreements.  See the NOTICE file
+                                    * distributed with this work for additional information
+                                    * regarding copyright ownership.  The ASF licenses this file
+                                    * to you under the Apache License, Version 2.0 (the
+                                    * "License"); you may not use this file except in compliance
+                                    * with the License.  You may obtain a copy of the License at
+                                    *
+                                    *     http://www.apache.org/licenses/LICENSE-2.0
+                                    *
+                                    * Unless required by applicable law or agreed to in writing, software
+                                    * distributed under the License is distributed on an "AS IS" BASIS,
+                                    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                    * See the License for the specific language governing permissions and
+                                    * limitations under the License.
+                                    */
 package org.apache.flink.table.store.codegen
 
 import org.apache.flink.table.types.logical.LogicalType
@@ -33,10 +32,10 @@ import org.apache.flink.table.types.logical.LogicalType
  *   type of the resultTerm
  */
 case class GeneratedExpression(
-  resultTerm: String,
-  nullTerm: String,
-  code: String,
-  resultType: LogicalType
+    resultTerm: String,
+    nullTerm: String,
+    code: String,
+    resultType: LogicalType
 )
 
 object GeneratedExpression {

--- a/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/GeneratedExpression.scala
+++ b/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/GeneratedExpression.scala
@@ -1,20 +1,20 @@
 /*
-                                    * Licensed to the Apache Software Foundation (ASF) under one
-                                    * or more contributor license agreements.  See the NOTICE file
-                                    * distributed with this work for additional information
-                                    * regarding copyright ownership.  The ASF licenses this file
-                                    * to you under the Apache License, Version 2.0 (the
-                                    * "License"); you may not use this file except in compliance
-                                    * with the License.  You may obtain a copy of the License at
-                                    *
-                                    *     http://www.apache.org/licenses/LICENSE-2.0
-                                    *
-                                    * Unless required by applicable law or agreed to in writing, software
-                                    * distributed under the License is distributed on an "AS IS" BASIS,
-                                    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                    * See the License for the specific language governing permissions and
-                                    * limitations under the License.
-                                    */
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.flink.table.store.codegen
 
 import org.apache.flink.table.types.logical.LogicalType

--- a/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/ProjectionCodeGenerator.scala
+++ b/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/ProjectionCodeGenerator.scala
@@ -1,20 +1,20 @@
 /*
-                                    * Licensed to the Apache Software Foundation (ASF) under one
-                                    * or more contributor license agreements.  See the NOTICE file
-                                    * distributed with this work for additional information
-                                    * regarding copyright ownership.  The ASF licenses this file
-                                    * to you under the Apache License, Version 2.0 (the
-                                    * "License"); you may not use this file except in compliance
-                                    * with the License.  You may obtain a copy of the License at
-                                    *
-                                    *     http://www.apache.org/licenses/LICENSE-2.0
-                                    *
-                                    * Unless required by applicable law or agreed to in writing, software
-                                    * distributed under the License is distributed on an "AS IS" BASIS,
-                                    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                    * See the License for the specific language governing permissions and
-                                    * limitations under the License.
-                                    */
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.flink.table.store.codegen
 
 import org.apache.flink.table.data.RowData

--- a/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/ProjectionCodeGenerator.scala
+++ b/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/ProjectionCodeGenerator.scala
@@ -1,27 +1,27 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+                                    * Licensed to the Apache Software Foundation (ASF) under one
+                                    * or more contributor license agreements.  See the NOTICE file
+                                    * distributed with this work for additional information
+                                    * regarding copyright ownership.  The ASF licenses this file
+                                    * to you under the Apache License, Version 2.0 (the
+                                    * "License"); you may not use this file except in compliance
+                                    * with the License.  You may obtain a copy of the License at
+                                    *
+                                    *     http://www.apache.org/licenses/LICENSE-2.0
+                                    *
+                                    * Unless required by applicable law or agreed to in writing, software
+                                    * distributed under the License is distributed on an "AS IS" BASIS,
+                                    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                    * See the License for the specific language governing permissions and
+                                    * limitations under the License.
+                                    */
 package org.apache.flink.table.store.codegen
 
 import org.apache.flink.table.data.RowData
 import org.apache.flink.table.data.binary.BinaryRowData
 import org.apache.flink.table.runtime.generated.{GeneratedProjection, Projection}
-import org.apache.flink.table.store.codegen.GenerateUtils.{DEFAULT_INPUT1_TERM, DEFAULT_OUT_RECORD_TERM, DEFAULT_OUT_RECORD_WRITER_TERM, ROW_DATA, generateRecordStatement, newName}
 import org.apache.flink.table.store.codegen.GeneratedExpression.{NEVER_NULL, NO_CODE}
+import org.apache.flink.table.store.codegen.GenerateUtils.{generateRecordStatement, newName, DEFAULT_INPUT1_TERM, DEFAULT_OUT_RECORD_TERM, DEFAULT_OUT_RECORD_WRITER_TERM, ROW_DATA}
 import org.apache.flink.table.types.logical.RowType
 
 /**

--- a/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/ProjectionCodeGenerator.scala
+++ b/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/ProjectionCodeGenerator.scala
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.store.codegen
+
+import org.apache.flink.table.data.RowData
+import org.apache.flink.table.data.binary.BinaryRowData
+import org.apache.flink.table.runtime.generated.{GeneratedProjection, Projection}
+import org.apache.flink.table.store.codegen.GenerateUtils.{DEFAULT_INPUT1_TERM, DEFAULT_OUT_RECORD_TERM, DEFAULT_OUT_RECORD_WRITER_TERM, ROW_DATA, generateRecordStatement, newName}
+import org.apache.flink.table.store.codegen.GeneratedExpression.{NEVER_NULL, NO_CODE}
+import org.apache.flink.table.types.logical.RowType
+
+/**
+ * CodeGenerator for projection, Take out some fields of [[RowData]] to generate a new [[RowData]].
+ */
+object ProjectionCodeGenerator {
+
+  def generateProjectionExpression(
+      ctx: CodeGeneratorContext,
+      inType: RowType,
+      outType: RowType,
+      inputMapping: Array[Int],
+      outClass: Class[_ <: RowData] = classOf[BinaryRowData],
+      inputTerm: String = DEFAULT_INPUT1_TERM,
+      outRecordTerm: String = DEFAULT_OUT_RECORD_TERM,
+      outRecordWriterTerm: String = DEFAULT_OUT_RECORD_WRITER_TERM,
+      reusedOutRecord: Boolean = true): GeneratedExpression = {
+    val exprGenerator = new ExprCodeGenerator(ctx)
+    val accessExprs =
+      inputMapping.map(idx => GenerateUtils.generateFieldAccess(ctx, inType, inputTerm, idx))
+    val expression = exprGenerator.generateResultExpression(
+      accessExprs,
+      outType,
+      outClass,
+      outRow = outRecordTerm,
+      outRowWriter = Option(outRecordWriterTerm),
+      reusedOutRow = reusedOutRecord)
+
+    val outRowInitCode = {
+      val initCode =
+        generateRecordStatement(outType, outClass, outRecordTerm, Some(outRecordWriterTerm), ctx)
+      if (reusedOutRecord) {
+        NO_CODE
+      } else {
+        initCode
+      }
+    }
+
+    val code =
+      s"""
+         |$outRowInitCode
+         |${expression.code}
+        """.stripMargin
+    GeneratedExpression(outRecordTerm, NEVER_NULL, code, outType)
+  }
+
+  /**
+   * CodeGenerator for projection.
+   * @param reusedOutRecord
+   *   If objects or variables can be reused, they will be added a reusable output record to the
+   *   member area of the generated class. If not they will be as temp variables.
+   * @return
+   */
+  def generateProjection(
+      ctx: CodeGeneratorContext,
+      name: String,
+      inType: RowType,
+      outType: RowType,
+      inputMapping: Array[Int],
+      outClass: Class[_ <: RowData] = classOf[BinaryRowData],
+      inputTerm: String = DEFAULT_INPUT1_TERM,
+      outRecordTerm: String = DEFAULT_OUT_RECORD_TERM,
+      outRecordWriterTerm: String = DEFAULT_OUT_RECORD_WRITER_TERM,
+      reusedOutRecord: Boolean = true): GeneratedProjection = {
+    val className = newName(name)
+    val baseClass = classOf[Projection[_, _]]
+
+    val expression = generateProjectionExpression(
+      ctx,
+      inType,
+      outType,
+      inputMapping,
+      outClass,
+      inputTerm,
+      outRecordTerm,
+      outRecordWriterTerm,
+      reusedOutRecord)
+
+    val code =
+      s"""
+         |public class $className implements ${baseClass.getCanonicalName}<$ROW_DATA, ${outClass.getCanonicalName}> {
+         |
+         |  ${ctx.reuseMemberCode()}
+         |
+         |  public $className(Object[] references) throws Exception {
+         |    ${ctx.reuseInitCode()}
+         |  }
+         |
+         |  @Override
+         |  public ${outClass.getCanonicalName} apply($ROW_DATA $inputTerm) {
+         |    ${ctx.reuseLocalVariableCode()}
+         |    ${expression.code}
+         |    return ${expression.resultTerm};
+         |  }
+         |}
+        """.stripMargin
+
+    new GeneratedProjection(className, code, ctx.references.toArray)
+  }
+
+  /** For java invoke. */
+  def generateProjection(
+      ctx: CodeGeneratorContext,
+      name: String,
+      inputType: RowType,
+      outputType: RowType,
+      inputMapping: Array[Int]): GeneratedProjection =
+    generateProjection(
+      ctx,
+      name,
+      inputType,
+      outputType,
+      inputMapping,
+      inputTerm = DEFAULT_INPUT1_TERM)
+}

--- a/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/SortCodeGenerator.scala
+++ b/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/SortCodeGenerator.scala
@@ -1,30 +1,30 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+                                    * Licensed to the Apache Software Foundation (ASF) under one
+                                    * or more contributor license agreements.  See the NOTICE file
+                                    * distributed with this work for additional information
+                                    * regarding copyright ownership.  The ASF licenses this file
+                                    * to you under the Apache License, Version 2.0 (the
+                                    * "License"); you may not use this file except in compliance
+                                    * with the License.  You may obtain a copy of the License at
+                                    *
+                                    *     http://www.apache.org/licenses/LICENSE-2.0
+                                    *
+                                    * Unless required by applicable law or agreed to in writing, software
+                                    * distributed under the License is distributed on an "AS IS" BASIS,
+                                    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                    * See the License for the specific language governing permissions and
+                                    * limitations under the License.
+                                    */
 package org.apache.flink.table.store.codegen
 
-import org.apache.flink.table.data.binary.BinaryRowData
 import org.apache.flink.table.data.{DecimalData, TimestampData}
+import org.apache.flink.table.data.binary.BinaryRowData
 import org.apache.flink.table.runtime.generated.{GeneratedNormalizedKeyComputer, NormalizedKeyComputer, RecordComparator}
 import org.apache.flink.table.runtime.operators.sort.SortUtil
 import org.apache.flink.table.runtime.types.PlannerTypeUtils
-import org.apache.flink.table.store.codegen.GenerateUtils.{ROW_DATA, SEGMENT, newName}
-import org.apache.flink.table.types.logical.LogicalTypeRoot._
+import org.apache.flink.table.store.codegen.GenerateUtils.{newName, ROW_DATA, SEGMENT}
 import org.apache.flink.table.types.logical.{DecimalType, LogicalType, RowType, TimestampType}
+import org.apache.flink.table.types.logical.LogicalTypeRoot._
 
 import scala.collection.mutable
 
@@ -36,9 +36,7 @@ import scala.collection.mutable
  * @param sortSpec
  *   sort specification.
  */
-class SortCodeGenerator(
-    val input: RowType,
-    val sortSpec: SortSpec) {
+class SortCodeGenerator(val input: RowType, val sortSpec: SortSpec) {
 
   private val MAX_NORMALIZED_KEY_LEN = 16
 

--- a/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/SortCodeGenerator.scala
+++ b/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/SortCodeGenerator.scala
@@ -1,20 +1,20 @@
 /*
-                                    * Licensed to the Apache Software Foundation (ASF) under one
-                                    * or more contributor license agreements.  See the NOTICE file
-                                    * distributed with this work for additional information
-                                    * regarding copyright ownership.  The ASF licenses this file
-                                    * to you under the Apache License, Version 2.0 (the
-                                    * "License"); you may not use this file except in compliance
-                                    * with the License.  You may obtain a copy of the License at
-                                    *
-                                    *     http://www.apache.org/licenses/LICENSE-2.0
-                                    *
-                                    * Unless required by applicable law or agreed to in writing, software
-                                    * distributed under the License is distributed on an "AS IS" BASIS,
-                                    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                    * See the License for the specific language governing permissions and
-                                    * limitations under the License.
-                                    */
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.flink.table.store.codegen
 
 import org.apache.flink.table.data.{DecimalData, TimestampData}

--- a/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/SortCodeGenerator.scala
+++ b/flink-table-store-codegen/src/main/scala/org.apache.flink.table.store.codegen/SortCodeGenerator.scala
@@ -1,0 +1,448 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.store.codegen
+
+import org.apache.flink.table.data.binary.BinaryRowData
+import org.apache.flink.table.data.{DecimalData, TimestampData}
+import org.apache.flink.table.runtime.generated.{GeneratedNormalizedKeyComputer, NormalizedKeyComputer, RecordComparator}
+import org.apache.flink.table.runtime.operators.sort.SortUtil
+import org.apache.flink.table.runtime.types.PlannerTypeUtils
+import org.apache.flink.table.store.codegen.GenerateUtils.{ROW_DATA, SEGMENT, newName}
+import org.apache.flink.table.types.logical.LogicalTypeRoot._
+import org.apache.flink.table.types.logical.{DecimalType, LogicalType, RowType, TimestampType}
+
+import scala.collection.mutable
+
+/**
+ * A code generator for generating [[NormalizedKeyComputer]] and [[RecordComparator]].
+ *
+ * @param input
+ *   input type.
+ * @param sortSpec
+ *   sort specification.
+ */
+class SortCodeGenerator(
+    val input: RowType,
+    val sortSpec: SortSpec) {
+
+  private val MAX_NORMALIZED_KEY_LEN = 16
+
+  private val SORT_UTIL = classOf[SortUtil].getCanonicalName
+
+  /** Chunks for long, int, short, byte */
+  private val POSSIBLE_CHUNK_SIZES = Array(8, 4, 2, 1)
+
+  /** For get${operator} set${operator} of [[org.apache.flink.core.memory.MemorySegment]] */
+  private val BYTE_OPERATOR_MAPPING = Map(8 -> "Long", 4 -> "Int", 2 -> "Short", 1 -> "")
+
+  /** For primitive define */
+  private val BYTE_DEFINE_MAPPING = Map(8 -> "long", 4 -> "int", 2 -> "short", 1 -> "byte")
+
+  /** For Class of primitive type */
+  private val BYTE_CLASS_MAPPING = Map(8 -> "Long", 4 -> "Integer", 2 -> "Short", 1 -> "Byte")
+
+  /** Normalized meta */
+  val (nullAwareNormalizedKeyLen, normalizedKeyNum, invertNormalizedKey, normalizedKeyLengths) = {
+    var keyLen = 0
+    var keyNum = 0
+    var inverted = false
+    val keyLengths = new mutable.ArrayBuffer[Int]
+    var break = false
+    var i = 0
+    while (i < sortSpec.getFieldSize && !break) {
+      val fieldSpec = sortSpec.getFieldSpec(i)
+      val t = input.getTypeAt(fieldSpec.getFieldIndex)
+      if (supportNormalizedKey(t)) {
+        val invert = !fieldSpec.getIsAscendingOrder
+
+        if (i == 0) {
+          // the first comparator decides whether we need to invert the key direction
+          inverted = invert
+        }
+
+        if (invert != inverted) {
+          // if a successor does not agree on the inversion direction,
+          // it cannot be part of the normalized key
+          break = true
+        } else {
+          keyNum += 1
+          // Need add null aware 1 byte
+          val len = safeAddLength(getNormalizeKeyLen(t), 1)
+          if (len < 0) {
+            throw new RuntimeException(
+              s"$t specifies an invalid length for the normalized key: " + len)
+          }
+          keyLengths += len
+          keyLen = safeAddLength(keyLen, len)
+          if (keyLen == Integer.MAX_VALUE) {
+            break = true
+          }
+        }
+      } else {
+        break = true
+      }
+      i += 1
+    }
+
+    (keyLen, keyNum, inverted, keyLengths)
+  }
+
+  def getKeyFullyDeterminesAndBytes: (Boolean, Int) = {
+    if (nullAwareNormalizedKeyLen > 18) {
+      // The maximum setting is 18 because want to put two null aware long as much as possible.
+      // Anyway, we can't fit it, so align the most efficient 8 bytes.
+      (false, Math.min(MAX_NORMALIZED_KEY_LEN, 8 * normalizedKeyNum))
+    } else {
+      (normalizedKeyNum == sortSpec.getFieldSize, nullAwareNormalizedKeyLen)
+    }
+  }
+
+  /**
+   * Generates a [[NormalizedKeyComputer]] that can be passed to a Java compiler.
+   *
+   * @param name
+   *   Class name of the function. Does not need to be unique but has to be a valid Java class
+   *   identifier.
+   * @return
+   *   A GeneratedNormalizedKeyComputer
+   */
+  def generateNormalizedKeyComputer(name: String): GeneratedNormalizedKeyComputer = {
+
+    val className = newName(name)
+
+    val (keyFullyDetermines, numKeyBytes) = getKeyFullyDeterminesAndBytes
+
+    val putKeys = generatePutNormalizedKeys(numKeyBytes)
+
+    val chunks = calculateChunks(numKeyBytes)
+
+    val reverseKeys = generateReverseNormalizedKeys(chunks)
+
+    val compareKeys = generateCompareNormalizedKeys(chunks)
+
+    val swapKeys = generateSwapNormalizedKeys(chunks)
+
+    val baseClass = classOf[NormalizedKeyComputer]
+
+    val code =
+      s"""
+      public class $className implements ${baseClass.getCanonicalName} {
+
+        public $className(Object[] references) {
+          // useless
+        }
+
+        @Override
+        public void putKey($ROW_DATA record, $SEGMENT target, int offset) {
+          ${putKeys.mkString}
+          ${reverseKeys.mkString}
+        }
+
+        @Override
+        public int compareKey($SEGMENT segI, int offsetI, $SEGMENT segJ, int offsetJ) {
+          ${compareKeys.mkString}
+        }
+
+        @Override
+        public void swapKey($SEGMENT segI, int offsetI, $SEGMENT segJ, int offsetJ) {
+          ${swapKeys.mkString}
+        }
+
+        @Override
+        public int getNumKeyBytes() {
+          return $numKeyBytes;
+        }
+
+        @Override
+        public boolean isKeyFullyDetermines() {
+          return $keyFullyDetermines;
+        }
+
+        @Override
+        public boolean invertKey() {
+          return $invertNormalizedKey;
+        }
+
+      }
+    """.stripMargin
+
+    new GeneratedNormalizedKeyComputer(className, code)
+  }
+
+  def generatePutNormalizedKeys(numKeyBytes: Int): mutable.ArrayBuffer[String] = {
+    /* Example generated code, for int:
+    if (record.isNullAt(0)) {
+      org.apache.flink.table.data.binary.BinaryRowDataUtil.minNormalizedKey(target, offset+0, 5);
+    } else {
+      target.put(offset+0, (byte) 1);
+      org.apache.flink.table.data.binary.BinaryRowDataUtil.putIntNormalizedKey(
+        record.getInt(0), target, offset+1, 4);
+    }
+     */
+    val putKeys = new mutable.ArrayBuffer[String]
+    var bytesLeft = numKeyBytes
+    var currentOffset = 0
+    var keyIndex = 0
+    while (bytesLeft > 0 && keyIndex < normalizedKeyNum) {
+      var len = normalizedKeyLengths(keyIndex)
+      val fieldSpec = sortSpec.getFieldSpec(keyIndex)
+      val index = fieldSpec.getFieldIndex
+      val nullIsMaxValue = fieldSpec.getIsAscendingOrder == fieldSpec.getNullIsLast
+      len = if (bytesLeft >= len) len else bytesLeft
+      val t = input.getTypeAt(fieldSpec.getFieldIndex)
+      val prefix = prefixGetFromBinaryRow(t)
+      val putCode = t match {
+        case _ if getNormalizeKeyLen(t) != Int.MaxValue =>
+          val get = getter(t, index)
+          s"""
+             |target.put(offset+$currentOffset, (byte) 1);
+             |$SORT_UTIL.put${prefixPutNormalizedKey(t)}NormalizedKey(
+             |  record.$get, target, offset+${currentOffset + 1}, ${len - 1});
+             |
+         """.stripMargin
+        case _ =>
+          // It is StringData/byte[].., we can omit the null aware byte(zero is the smallest),
+          // because there is no other field behind, and is not keyFullyDetermines.
+          s"""
+             |$SORT_UTIL.put${prefixPutNormalizedKey(t)}NormalizedKey(
+             |  record.get$prefix($index), target, offset+$currentOffset, $len);
+             |""".stripMargin
+      }
+      val nullCode = if (nullIsMaxValue) {
+        s"$SORT_UTIL.maxNormalizedKey(target, offset+$currentOffset, $len);"
+      } else {
+        s"$SORT_UTIL.minNormalizedKey(target, offset+$currentOffset, $len);"
+      }
+
+      val code =
+        s"""
+           |if (record.isNullAt($index)) {
+           | $nullCode
+           |} else {
+           | $putCode
+           |}
+           |""".stripMargin
+
+      putKeys += code
+      bytesLeft -= len
+      currentOffset += len
+      keyIndex += 1
+    }
+    putKeys
+  }
+
+  /**
+   * In order to better performance and not use MemorySegment's compare() and swap(), we CodeGen
+   * more efficient chunk method.
+   */
+  def calculateChunks(numKeyBytes: Int): Array[Int] = {
+    /* Example chunks, for int:
+      calculateChunks(5) = Array(4, 1)
+     */
+    val chunks = new mutable.ArrayBuffer[Int]
+    var i = 0
+    var remainBytes = numKeyBytes
+    while (remainBytes > 0) {
+      val bytes = POSSIBLE_CHUNK_SIZES(i)
+      if (bytes <= remainBytes) {
+        chunks += bytes
+        remainBytes -= bytes
+      } else {
+        i += 1
+      }
+    }
+    chunks.toArray
+  }
+
+  /**
+   * Because we put normalizedKeys in big endian way, if we are the little endian, we need to
+   * reverse these data with chunks for comparation.
+   */
+  def generateReverseNormalizedKeys(chunks: Array[Int]): mutable.ArrayBuffer[String] = {
+    /* Example generated code, for int:
+    target.putInt(offset+0, Integer.reverseBytes(target.getInt(offset+0)));
+    //byte don't need reverse.
+     */
+    val reverseKeys = new mutable.ArrayBuffer[String]
+    // If it is big endian, it would be better, no reverse.
+    if (BinaryRowData.LITTLE_ENDIAN) {
+      var reverseOffset = 0
+      for (chunk <- chunks) {
+        val operator = BYTE_OPERATOR_MAPPING(chunk)
+        val className = BYTE_CLASS_MAPPING(chunk)
+        if (chunk != 1) {
+          val reverseKey =
+            s"""
+               |target.put$operator(offset+$reverseOffset,
+               |  $className.reverseBytes(target.get$operator(offset+$reverseOffset)));
+            """.stripMargin
+          reverseKeys += reverseKey
+        }
+        reverseOffset += chunk
+      }
+    }
+    reverseKeys
+  }
+
+  /** Compare bytes with chunks and nsigned. */
+  def generateCompareNormalizedKeys(chunks: Array[Int]): mutable.ArrayBuffer[String] = {
+    /* Example generated code, for int:
+    int l_0_1 = segI.getInt(offsetI+0);
+    int l_0_2 = segJ.getInt(offsetJ+0);
+    if (l_0_1 != l_0_2) {
+      return ((l_0_1 < l_0_2) ^ (l_0_1 < 0) ^
+        (l_0_2 < 0) ? -1 : 1);
+    }
+
+    byte l_1_1 = segI.get(offsetI+4);
+    byte l_1_2 = segJ.get(offsetJ+4);
+    if (l_1_1 != l_1_2) {
+      return ((l_1_1 < l_1_2) ^ (l_1_1 < 0) ^
+        (l_1_2 < 0) ? -1 : 1);
+    }
+    return 0;
+     */
+    val compareKeys = new mutable.ArrayBuffer[String]
+    var compareOffset = 0
+    for (i <- chunks.indices) {
+      val chunk = chunks(i)
+      val operator = BYTE_OPERATOR_MAPPING(chunk)
+      val define = BYTE_DEFINE_MAPPING(chunk)
+      val compareKey =
+        s"""
+           |$define l_${i}_1 = segI.get$operator(offsetI+$compareOffset);
+           |$define l_${i}_2 = segJ.get$operator(offsetJ+$compareOffset);
+           |if (l_${i}_1 != l_${i}_2) {
+           |  return ((l_${i}_1 < l_${i}_2) ^ (l_${i}_1 < 0) ^
+           |    (l_${i}_2 < 0) ? -1 : 1);
+           |}
+            """.stripMargin
+      compareKeys += compareKey
+      compareOffset += chunk
+    }
+    compareKeys += "return 0;"
+    compareKeys
+  }
+
+  /** Swap bytes with chunks. */
+  def generateSwapNormalizedKeys(chunks: Array[Int]): mutable.ArrayBuffer[String] = {
+    /* Example generated code, for int:
+    int temp0 = segI.getInt(offsetI+0);
+    segI.putInt(offsetI+0, segJ.getInt(offsetJ+0));
+    segJ.putInt(offsetJ+0, temp0);
+
+    byte temp1 = segI.get(offsetI+4);
+    segI.put(offsetI+4, segJ.get(offsetJ+4));
+    segJ.put(offsetJ+4, temp1);
+     */
+    val swapKeys = new mutable.ArrayBuffer[String]
+    var swapOffset = 0
+    for (i <- chunks.indices) {
+      val chunk = chunks(i)
+      val operator = BYTE_OPERATOR_MAPPING(chunk)
+      val define = BYTE_DEFINE_MAPPING(chunk)
+      val swapKey =
+        s"""
+           |$define temp$i = segI.get$operator(offsetI+$swapOffset);
+           |segI.put$operator(offsetI+$swapOffset, segJ.get$operator(offsetJ+$swapOffset));
+           |segJ.put$operator(offsetJ+$swapOffset, temp$i);
+            """.stripMargin
+      swapKeys += swapKey
+      swapOffset += chunk
+    }
+    swapKeys
+  }
+
+  def getter(t: LogicalType, index: Int): String = {
+    val prefix = prefixGetFromBinaryRow(t)
+    t match {
+      case dt: DecimalType =>
+        s"get$prefix($index, ${dt.getPrecision}, ${dt.getScale})"
+      case dt: TimestampType =>
+        s"get$prefix($index, ${dt.getPrecision})"
+      case _ =>
+        s"get$prefix($index)"
+    }
+  }
+
+  /** For put${prefix}NormalizedKey() and compare$prefix() of [[SortUtil]]. */
+  def prefixPutNormalizedKey(t: LogicalType): String = prefixGetFromBinaryRow(t)
+
+  /** For get$prefix() of TypeGetterSetters. */
+  def prefixGetFromBinaryRow(t: LogicalType): String = t.getTypeRoot match {
+    case INTEGER => "Int"
+    case BIGINT => "Long"
+    case SMALLINT => "Short"
+    case TINYINT => "Byte"
+    case FLOAT => "Float"
+    case DOUBLE => "Double"
+    case BOOLEAN => "Boolean"
+    case VARCHAR | CHAR => "String"
+    case VARBINARY | BINARY => "Binary"
+    case DECIMAL => "Decimal"
+    case DATE => "Int"
+    case TIME_WITHOUT_TIME_ZONE => "Int"
+    case TIMESTAMP_WITHOUT_TIME_ZONE => "Timestamp"
+    case INTERVAL_YEAR_MONTH => "Int"
+    case INTERVAL_DAY_TIME => "Long"
+    case _ => null
+  }
+
+  /** Preventing overflow. */
+  def safeAddLength(i: Int, j: Int): Int = {
+    val sum = i + j
+    if (sum < i || sum < j) {
+      Integer.MAX_VALUE
+    } else {
+      sum
+    }
+  }
+
+  def supportNormalizedKey(t: LogicalType): Boolean = {
+    t.getTypeRoot match {
+      case _ if PlannerTypeUtils.isPrimitive(t) => true
+      case VARCHAR | CHAR | VARBINARY | BINARY | DATE | TIME_WITHOUT_TIME_ZONE => true
+      case TIMESTAMP_WITHOUT_TIME_ZONE =>
+        // TODO: support normalize key for non-compact timestamp
+        TimestampData.isCompact(t.asInstanceOf[TimestampType].getPrecision)
+      case DECIMAL => DecimalData.isCompact(t.asInstanceOf[DecimalType].getPrecision)
+      case _ => false
+    }
+  }
+
+  def getNormalizeKeyLen(t: LogicalType): Int = {
+    t.getTypeRoot match {
+      case BOOLEAN => 1
+      case TINYINT => 1
+      case SMALLINT => 2
+      case INTEGER => 4
+      case FLOAT => 4
+      case DOUBLE => 8
+      case BIGINT => 8
+      case TIMESTAMP_WITHOUT_TIME_ZONE
+          if TimestampData.isCompact(t.asInstanceOf[TimestampType].getPrecision) =>
+        8
+      case INTERVAL_YEAR_MONTH => 4
+      case INTERVAL_DAY_TIME => 8
+      case DATE => 4
+      case TIME_WITHOUT_TIME_ZONE => 4
+      case DECIMAL if DecimalData.isCompact(t.asInstanceOf[DecimalType].getPrecision) => 8
+      case VARCHAR | CHAR | VARBINARY | BINARY => Int.MaxValue
+    }
+  }
+}

--- a/flink-table-store-common/src/main/java/org/apache/flink/table/store/codegen/CodeGenerator.java
+++ b/flink-table-store-common/src/main/java/org/apache/flink/table/store/codegen/CodeGenerator.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.store.codegen;
 
-import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.runtime.generated.GeneratedClass;
 import org.apache.flink.table.runtime.generated.GeneratedNormalizedKeyComputer;
 import org.apache.flink.table.runtime.generated.GeneratedProjection;
@@ -31,8 +30,7 @@ import java.util.List;
 /** {@link GeneratedClass} generator. */
 public interface CodeGenerator {
 
-    GeneratedProjection generateProjection(
-            TableConfig tableConfig, String name, RowType inputType, int[] inputMapping);
+    GeneratedProjection generateProjection(String name, RowType inputType, int[] inputMapping);
 
     /**
      * Generate a {@link GeneratedNormalizedKeyComputer}.
@@ -42,7 +40,7 @@ public interface CodeGenerator {
      *     fields are compared in ascending order.
      */
     GeneratedNormalizedKeyComputer generateNormalizedKeyComputer(
-            TableConfig tableConfig, List<LogicalType> fieldTypes, String name);
+            List<LogicalType> fieldTypes, String name);
 
     /**
      * Generate a {@link GeneratedRecordComparator}.
@@ -51,6 +49,5 @@ public interface CodeGenerator {
      *     compared by the first field, then the second field, then the third field and so on. All *
      *     fields are compared in ascending order.
      */
-    GeneratedRecordComparator generateRecordComparator(
-            TableConfig tableConfig, List<LogicalType> fieldTypes, String name);
+    GeneratedRecordComparator generateRecordComparator(List<LogicalType> fieldTypes, String name);
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/codegen/CodeGenUtils.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/codegen/CodeGenUtils.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.store.codegen;
 
-import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.data.binary.BinaryRowDataUtil;
@@ -47,29 +46,28 @@ public class CodeGenUtils {
         Projection<RowData, BinaryRowData> projection =
                 CodeGenLoader.getInstance()
                         .discover(CodeGenerator.class)
-                        .generateProjection(new TableConfig(), "Projection", inputType, mapping)
+                        .generateProjection("Projection", inputType, mapping)
                         .newInstance(Thread.currentThread().getContextClassLoader());
         return projection;
     }
 
     public static NormalizedKeyComputer newNormalizedKeyComputer(
-            TableConfig tableConfig, List<LogicalType> fieldTypes, String name) {
+            List<LogicalType> fieldTypes, String name) {
         return CodeGenLoader.getInstance()
                 .discover(CodeGenerator.class)
-                .generateNormalizedKeyComputer(tableConfig, fieldTypes, name)
+                .generateNormalizedKeyComputer(fieldTypes, name)
                 .newInstance(Thread.currentThread().getContextClassLoader());
     }
 
     public static GeneratedRecordComparator generateRecordComparator(
-            TableConfig tableConfig, List<LogicalType> fieldTypes, String name) {
+            List<LogicalType> fieldTypes, String name) {
         return CodeGenLoader.getInstance()
                 .discover(CodeGenerator.class)
-                .generateRecordComparator(tableConfig, fieldTypes, name);
+                .generateRecordComparator(fieldTypes, name);
     }
 
-    public static RecordComparator newRecordComparator(
-            TableConfig tableConfig, List<LogicalType> fieldTypes, String name) {
-        return generateRecordComparator(tableConfig, fieldTypes, name)
+    public static RecordComparator newRecordComparator(List<LogicalType> fieldTypes, String name) {
+        return generateRecordComparator(fieldTypes, name)
                 .newInstance(Thread.currentThread().getContextClassLoader());
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/SortBufferMemTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/SortBufferMemTable.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.store.file.mergetree;
 
 import org.apache.flink.runtime.operators.sort.QuickSort;
-import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.runtime.generated.NormalizedKeyComputer;
@@ -63,11 +62,9 @@ public class SortBufferMemTable implements MemTable {
 
         // for sort binary buffer
         NormalizedKeyComputer normalizedKeyComputer =
-                CodeGenUtils.newNormalizedKeyComputer(
-                        new TableConfig(), sortKeyTypes, "MemTableKeyComputer");
+                CodeGenUtils.newNormalizedKeyComputer(sortKeyTypes, "MemTableKeyComputer");
         RecordComparator keyComparator =
-                CodeGenUtils.newRecordComparator(
-                        new TableConfig(), sortKeyTypes, "MemTableComparator");
+                CodeGenUtils.newRecordComparator(sortKeyTypes, "MemTableComparator");
 
         if (memoryPool.freePages() < 3) {
             throw new IllegalArgumentException(

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/KeyComparatorSupplier.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/KeyComparatorSupplier.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.store.file.utils;
 
-import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
 import org.apache.flink.table.runtime.generated.RecordComparator;
@@ -38,8 +37,7 @@ public class KeyComparatorSupplier implements SerializableSupplier<Comparator<Ro
 
     public KeyComparatorSupplier(RowType keyType) {
         genRecordComparator =
-                CodeGenUtils.generateRecordComparator(
-                        new TableConfig(), keyType.getChildren(), "KeyComparator");
+                CodeGenUtils.generateRecordComparator(keyType.getChildren(), "KeyComparator");
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@ under the License.
         <flink.shaded.jackson.version>2.12.4</flink.shaded.jackson.version>
         <hadoop.version>2.8.5</hadoop.version>
         <hive.version>2.3.4</hive.version>
+        <scala.version>2.12.7</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <snappy.version>1.1.8.3</snappy.version>
         <lz4.version>1.8.0</lz4.version>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,26 @@ under the License.
         <junit4.version>4.13.2</junit4.version>
         <junit5.version>5.8.1</junit5.version>
         <spotless.version>2.13.0</spotless.version>
+        <spotless.delimiter>package</spotless.delimiter>
+        <spotless.license.header>
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+        </spotless.license.header>
         <target.java.version>1.8</target.java.version>
         <assertj.version>3.21.0</assertj.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
@@ -670,25 +690,8 @@ under the License.
                                 <file>.scalafmt.conf</file>
                             </scalafmt>
                             <licenseHeader>
-                                <content>/*
-                                    * Licensed to the Apache Software Foundation (ASF) under one
-                                    * or more contributor license agreements.  See the NOTICE file
-                                    * distributed with this work for additional information
-                                    * regarding copyright ownership.  The ASF licenses this file
-                                    * to you under the Apache License, Version 2.0 (the
-                                    * "License"); you may not use this file except in compliance
-                                    * with the License.  You may obtain a copy of the License at
-                                    *
-                                    *     http://www.apache.org/licenses/LICENSE-2.0
-                                    *
-                                    * Unless required by applicable law or agreed to in writing, software
-                                    * distributed under the License is distributed on an "AS IS" BASIS,
-                                    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                    * See the License for the specific language governing permissions and
-                                    * limitations under the License.
-                                    */
-                                </content>
-                                <delimiter>package </delimiter>
+                                <content>${spotless.license.header}</content>
+                                <delimiter>${spotless.delimiter}</delimiter>
                             </licenseHeader>
                         </scala>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@ under the License.
         <log4j.version>2.17.1</log4j.version>
         <junit4.version>4.13.2</junit4.version>
         <junit5.version>5.8.1</junit5.version>
-        <spotless.version>2.4.2</spotless.version>
+        <spotless.version>2.13.0</spotless.version>
         <target.java.version>1.8</target.java.version>
         <assertj.version>3.21.0</assertj.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
@@ -663,6 +663,34 @@ under the License.
 
                             <removeUnusedImports/>
                         </java>
+                        <scala>
+                            <scalafmt>
+                                <version>3.4.3</version>
+                                <!-- This file is in the root of the project to make sure IntelliJ picks it up automatically -->
+                                <file>.scalafmt.conf</file>
+                            </scalafmt>
+                            <licenseHeader>
+                                <content>/*
+                                    * Licensed to the Apache Software Foundation (ASF) under one
+                                    * or more contributor license agreements.  See the NOTICE file
+                                    * distributed with this work for additional information
+                                    * regarding copyright ownership.  The ASF licenses this file
+                                    * to you under the Apache License, Version 2.0 (the
+                                    * "License"); you may not use this file except in compliance
+                                    * with the License.  You may obtain a copy of the License at
+                                    *
+                                    *     http://www.apache.org/licenses/LICENSE-2.0
+                                    *
+                                    * Unless required by applicable law or agreed to in writing, software
+                                    * distributed under the License is distributed on an "AS IS" BASIS,
+                                    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                    * See the License for the specific language governing permissions and
+                                    * limitations under the License.
+                                    */
+                                </content>
+                                <delimiter>package </delimiter>
+                            </licenseHeader>
+                        </scala>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
We currently have the table-planner bundled into flink-table-store-codegen, which causes:
- bundle jar is too big, 20+MB
- Dependence on planner code will make it difficult to be compatible with multiple versions of Flink