### PR TITLE
[FLINK-28064] Predicate now accepts null literals

### DIFF
--- a/flink-table-store-codegen/pom.xml
+++ b/flink-table-store-codegen/pom.xml
@@ -71,6 +71,25 @@ under the License.
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless.version}</version>
+                <configuration>
+                    <scala>
+                        <scalafmt>
+                            <version>3.4.3</version>
+                            <!-- This file is in the root of the project to make sure IntelliJ picks it up automatically -->
+                            <file>${project.basedir}/../scalafmt.conf</file>
+                        </scalafmt>
+                        <licenseHeader>
+                            <content>${spotless.license.header}</content>
+                            <delimiter>${spotless.delimiter}</delimiter>
+                        </licenseHeader>
+                    </scala>
+                </configuration>
+            </plugin>
+
             <!-- Scala Compiler -->
             <plugin>
                 <groupId>net.alchim31.maven</groupId>

--- a/flink-table-store-codegen/pom.xml
+++ b/flink-table-store-codegen/pom.xml
@@ -80,7 +80,7 @@ under the License.
                         <scalafmt>
                             <version>3.4.3</version>
                             <!-- This file is in the root of the project to make sure IntelliJ picks it up automatically -->
-                            <file>${project.basedir}/../scalafmt.conf</file>
+                            <file>${project.basedir}/../.scalafmt.conf</file>
                         </scalafmt>
                         <licenseHeader>
                             <content>${spotless.license.header}</content>

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/Equal.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/Equal.java
@@ -25,8 +25,8 @@ import java.util.Optional;
 
 import static org.apache.flink.table.store.file.predicate.CompareUtils.compareLiteral;
 
-/** A {@link LeafBinaryFunction} to eval equal. */
-public class Equal extends LeafBinaryFunction {
+/** A {@link NullFalseLeafBinaryFunction} to eval equal. */
+public class Equal extends NullFalseLeafBinaryFunction {
 
     public static final Equal INSTANCE = new Equal();
 
@@ -34,14 +34,11 @@ public class Equal extends LeafBinaryFunction {
 
     @Override
     public boolean test(LogicalType type, Object field, Object literal) {
-        return field != null && compareLiteral(type, literal, field) == 0;
+        return compareLiteral(type, literal, field) == 0;
     }
 
     @Override
     public boolean test(LogicalType type, long rowCount, FieldStats fieldStats, Object literal) {
-        if (rowCount == fieldStats.nullCount()) {
-            return false;
-        }
         return compareLiteral(type, literal, fieldStats.minValue()) >= 0
                 && compareLiteral(type, literal, fieldStats.maxValue()) <= 0;
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/GreaterOrEqual.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/GreaterOrEqual.java
@@ -25,8 +25,8 @@ import java.util.Optional;
 
 import static org.apache.flink.table.store.file.predicate.CompareUtils.compareLiteral;
 
-/** A {@link LeafBinaryFunction} to eval greater or equal. */
-public class GreaterOrEqual extends LeafBinaryFunction {
+/** A {@link NullFalseLeafBinaryFunction} to eval greater or equal. */
+public class GreaterOrEqual extends NullFalseLeafBinaryFunction {
 
     public static final GreaterOrEqual INSTANCE = new GreaterOrEqual();
 
@@ -34,14 +34,11 @@ public class GreaterOrEqual extends LeafBinaryFunction {
 
     @Override
     public boolean test(LogicalType type, Object field, Object literal) {
-        return field != null && compareLiteral(type, literal, field) <= 0;
+        return compareLiteral(type, literal, field) <= 0;
     }
 
     @Override
     public boolean test(LogicalType type, long rowCount, FieldStats fieldStats, Object literal) {
-        if (rowCount == fieldStats.nullCount()) {
-            return false;
-        }
         return compareLiteral(type, literal, fieldStats.maxValue()) <= 0;
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/GreaterThan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/GreaterThan.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 import static org.apache.flink.table.store.file.predicate.CompareUtils.compareLiteral;
 
 /** A {@link LeafFunction} to eval greater. */
-public class GreaterThan extends LeafBinaryFunction {
+public class GreaterThan extends NullFalseLeafBinaryFunction {
 
     public static final GreaterThan INSTANCE = new GreaterThan();
 
@@ -34,14 +34,11 @@ public class GreaterThan extends LeafBinaryFunction {
 
     @Override
     public boolean test(LogicalType type, Object field, Object literal) {
-        return field != null && compareLiteral(type, literal, field) < 0;
+        return compareLiteral(type, literal, field) < 0;
     }
 
     @Override
     public boolean test(LogicalType type, long rowCount, FieldStats fieldStats, Object literal) {
-        if (rowCount == fieldStats.nullCount()) {
-            return false;
-        }
         return compareLiteral(type, literal, fieldStats.maxValue()) < 0;
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/IsNotNull.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/IsNotNull.java
@@ -23,7 +23,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 
 import java.util.Optional;
 
-/** A {@link LeafBinaryFunction} to eval is not null. */
+/** A {@link NullFalseLeafBinaryFunction} to eval is not null. */
 public class IsNotNull extends LeafUnaryFunction {
 
     public static final IsNotNull INSTANCE = new IsNotNull();

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/IsNull.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/IsNull.java
@@ -23,7 +23,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 
 import java.util.Optional;
 
-/** A {@link LeafBinaryFunction} to eval is null. */
+/** A {@link NullFalseLeafBinaryFunction} to eval is null. */
 public class IsNull extends LeafUnaryFunction {
 
     public static final IsNull INSTANCE = new IsNull();

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/LessOrEqual.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/LessOrEqual.java
@@ -25,8 +25,8 @@ import java.util.Optional;
 
 import static org.apache.flink.table.store.file.predicate.CompareUtils.compareLiteral;
 
-/** A {@link LeafBinaryFunction} to eval less or equal. */
-public class LessOrEqual extends LeafBinaryFunction {
+/** A {@link NullFalseLeafBinaryFunction} to eval less or equal. */
+public class LessOrEqual extends NullFalseLeafBinaryFunction {
 
     public static final LessOrEqual INSTANCE = new LessOrEqual();
 
@@ -34,14 +34,11 @@ public class LessOrEqual extends LeafBinaryFunction {
 
     @Override
     public boolean test(LogicalType type, Object field, Object literal) {
-        return field != null && compareLiteral(type, literal, field) >= 0;
+        return compareLiteral(type, literal, field) >= 0;
     }
 
     @Override
     public boolean test(LogicalType type, long rowCount, FieldStats fieldStats, Object literal) {
-        if (rowCount == fieldStats.nullCount()) {
-            return false;
-        }
         return compareLiteral(type, literal, fieldStats.minValue()) >= 0;
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/LessThan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/LessThan.java
@@ -25,8 +25,8 @@ import java.util.Optional;
 
 import static org.apache.flink.table.store.file.predicate.CompareUtils.compareLiteral;
 
-/** A {@link LeafBinaryFunction} to eval less or equal. */
-public class LessThan extends LeafBinaryFunction {
+/** A {@link NullFalseLeafBinaryFunction} to eval less or equal. */
+public class LessThan extends NullFalseLeafBinaryFunction {
 
     public static final LessThan INSTANCE = new LessThan();
 
@@ -34,14 +34,11 @@ public class LessThan extends LeafBinaryFunction {
 
     @Override
     public boolean test(LogicalType type, Object field, Object literal) {
-        return field != null && compareLiteral(type, literal, field) > 0;
+        return compareLiteral(type, literal, field) > 0;
     }
 
     @Override
     public boolean test(LogicalType type, long rowCount, FieldStats fieldStats, Object literal) {
-        if (rowCount == fieldStats.nullCount()) {
-            return false;
-        }
         return compareLiteral(type, literal, fieldStats.minValue()) > 0;
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/NotEqual.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/NotEqual.java
@@ -25,8 +25,8 @@ import java.util.Optional;
 
 import static org.apache.flink.table.store.file.predicate.CompareUtils.compareLiteral;
 
-/** A {@link LeafBinaryFunction} to eval not equal. */
-public class NotEqual extends LeafBinaryFunction {
+/** A {@link NullFalseLeafBinaryFunction} to eval not equal. */
+public class NotEqual extends NullFalseLeafBinaryFunction {
 
     public static final NotEqual INSTANCE = new NotEqual();
 
@@ -34,14 +34,11 @@ public class NotEqual extends LeafBinaryFunction {
 
     @Override
     public boolean test(LogicalType type, Object field, Object literal) {
-        return field != null && compareLiteral(type, literal, field) != 0;
+        return compareLiteral(type, literal, field) != 0;
     }
 
     @Override
     public boolean test(LogicalType type, long rowCount, FieldStats fieldStats, Object literal) {
-        if (rowCount == fieldStats.nullCount()) {
-            return false;
-        }
         return compareLiteral(type, literal, fieldStats.minValue()) != 0
                 || compareLiteral(type, literal, fieldStats.maxValue()) != 0;
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/NullFalseLeafBinaryFunction.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/NullFalseLeafBinaryFunction.java
@@ -24,7 +24,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import java.util.List;
 
 /** Function to test a field with a literal. */
-public abstract class LeafBinaryFunction implements LeafFunction {
+public abstract class NullFalseLeafBinaryFunction implements LeafFunction {
 
     private static final long serialVersionUID = 1L;
 
@@ -35,12 +35,18 @@ public abstract class LeafBinaryFunction implements LeafFunction {
 
     @Override
     public boolean test(LogicalType type, Object field, List<Object> literals) {
+        if (field == null || literals.get(0) == null) {
+            return false;
+        }
         return test(type, field, literals.get(0));
     }
 
     @Override
     public boolean test(
             LogicalType type, long rowCount, FieldStats fieldStats, List<Object> literals) {
+        if (rowCount == fieldStats.nullCount() || literals.get(0) == null) {
+            return false;
+        }
         return test(type, rowCount, fieldStats, literals.get(0));
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/PredicateBuilder.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/PredicateBuilder.java
@@ -86,7 +86,7 @@ public class PredicateBuilder {
         return leaf(StartsWith.INSTANCE, idx, patternLiteral);
     }
 
-    public Predicate leaf(LeafBinaryFunction function, int idx, Object literal) {
+    public Predicate leaf(NullFalseLeafBinaryFunction function, int idx, Object literal) {
         return new LeafPredicate(function, rowType.getTypeAt(idx), idx, singletonList(literal));
     }
 
@@ -160,7 +160,7 @@ public class PredicateBuilder {
 
     public static Object convertJavaObject(LogicalType literalType, Object o) {
         if (o == null) {
-            throw new UnsupportedOperationException("Null literals are currently unsupported");
+            return null;
         }
         switch (literalType.getTypeRoot()) {
             case BOOLEAN:

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/PredicateConverter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/PredicateConverter.java
@@ -195,7 +195,7 @@ public class PredicateConverter implements ExpressionVisitor<Predicate> {
     private Object extractLiteral(DataType expectedType, Expression expression) {
         LogicalType expectedLogicalType = expectedType.getLogicalType();
         if (!supportsPredicate(expectedLogicalType)) {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedExpression();
         }
 
         if (expression instanceof ValueLiteralExpression) {
@@ -220,7 +220,7 @@ public class PredicateConverter implements ExpressionVisitor<Predicate> {
             }
         }
 
-        throw new UnsupportedOperationException();
+        throw new UnsupportedExpression();
     }
 
     private boolean supportsPredicate(LogicalType type) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/PredicateConverter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/PredicateConverter.java
@@ -103,13 +103,11 @@ public class PredicateConverter implements ExpressionVisitor<Predicate> {
                     .is(LogicalTypeFamily.CHARACTER_STRING)) {
                 String sqlPattern =
                         extractLiteral(fieldRefExpr.getOutputDataType(), children.get(1))
-                                .orElseThrow(UnsupportedExpression::new)
                                 .toString();
                 String escape =
                         children.size() <= 2
                                 ? null
                                 : extractLiteral(fieldRefExpr.getOutputDataType(), children.get(2))
-                                        .orElseThrow(UnsupportedExpression::new)
                                         .toString();
                 String escapedSqlPattern = sqlPattern;
                 boolean allowQuick = false;
@@ -171,19 +169,16 @@ public class PredicateConverter implements ExpressionVisitor<Predicate> {
             BiFunction<Integer, Object, Predicate> visit1,
             BiFunction<Integer, Object, Predicate> visit2) {
         Optional<FieldReferenceExpression> fieldRefExpr = extractFieldReference(children.get(0));
-        Optional<Object> literal;
         if (fieldRefExpr.isPresent()) {
-            literal = extractLiteral(fieldRefExpr.get().getOutputDataType(), children.get(1));
-            if (literal.isPresent()) {
-                return visit1.apply(fieldRefExpr.get().getFieldIndex(), literal.get());
-            }
+            Object literal =
+                    extractLiteral(fieldRefExpr.get().getOutputDataType(), children.get(1));
+            return visit1.apply(fieldRefExpr.get().getFieldIndex(), literal);
         } else {
             fieldRefExpr = extractFieldReference(children.get(1));
             if (fieldRefExpr.isPresent()) {
-                literal = extractLiteral(fieldRefExpr.get().getOutputDataType(), children.get(0));
-                if (literal.isPresent()) {
-                    return visit2.apply(fieldRefExpr.get().getFieldIndex(), literal.get());
-                }
+                Object literal =
+                        extractLiteral(fieldRefExpr.get().getOutputDataType(), children.get(0));
+                return visit2.apply(fieldRefExpr.get().getFieldIndex(), literal);
             }
         }
 
@@ -197,33 +192,35 @@ public class PredicateConverter implements ExpressionVisitor<Predicate> {
         return Optional.empty();
     }
 
-    private Optional<Object> extractLiteral(DataType expectedType, Expression expression) {
+    private Object extractLiteral(DataType expectedType, Expression expression) {
         LogicalType expectedLogicalType = expectedType.getLogicalType();
         if (!supportsPredicate(expectedLogicalType)) {
-            return Optional.empty();
+            throw new UnsupportedOperationException();
         }
-        Object literal = null;
+
         if (expression instanceof ValueLiteralExpression) {
             ValueLiteralExpression valueExpression = (ValueLiteralExpression) expression;
+            if (valueExpression.isNull()) {
+                return null;
+            }
+
             DataType actualType = valueExpression.getOutputDataType();
             LogicalType actualLogicalType = actualType.getLogicalType();
             Optional<?> valueOpt = valueExpression.getValueAs(actualType.getConversionClass());
-            if (!valueOpt.isPresent()) {
-                return Optional.empty();
-            }
-            Object value = valueOpt.get();
-            if (actualLogicalType.getTypeRoot().equals(expectedLogicalType.getTypeRoot())) {
-                literal = getConverter(expectedType).toInternalOrNull(value);
-            } else if (supportsImplicitCast(actualLogicalType, expectedLogicalType)) {
-                try {
-                    value = TypeUtils.castFromString(value.toString(), expectedLogicalType);
-                    literal = value;
-                } catch (Exception ignored) {
-                    // ignore here, let #visit throw UnsupportedExpression
+            if (valueOpt.isPresent()) {
+                Object value = valueOpt.get();
+                if (actualLogicalType.getTypeRoot().equals(expectedLogicalType.getTypeRoot())) {
+                    return getConverter(expectedType).toInternalOrNull(value);
+                } else if (supportsImplicitCast(actualLogicalType, expectedLogicalType)) {
+                    try {
+                        return TypeUtils.castFromString(value.toString(), expectedLogicalType);
+                    } catch (Exception ignored) {
+                    }
                 }
             }
         }
-        return literal == null ? Optional.empty() : Optional.of(literal);
+
+        throw new UnsupportedOperationException();
     }
 
     private boolean supportsPredicate(LogicalType type) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/StartsWith.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/StartsWith.java
@@ -24,8 +24,11 @@ import org.apache.flink.table.types.logical.LogicalType;
 
 import java.util.Optional;
 
-/** A {@link LeafBinaryFunction} to evaluate {@code filter like 'abc%' or filter like 'abc_'}. */
-public class StartsWith extends LeafBinaryFunction {
+/**
+ * A {@link NullFalseLeafBinaryFunction} to evaluate {@code filter like 'abc%' or filter like
+ * 'abc_'}.
+ */
+public class StartsWith extends NullFalseLeafBinaryFunction {
 
     public static final StartsWith INSTANCE = new StartsWith();
 
@@ -34,15 +37,12 @@ public class StartsWith extends LeafBinaryFunction {
     @Override
     public boolean test(LogicalType type, Object field, Object patternLiteral) {
         BinaryStringData fieldString = (BinaryStringData) field;
-        return fieldString != null && fieldString.startsWith((BinaryStringData) patternLiteral);
+        return fieldString.startsWith((BinaryStringData) patternLiteral);
     }
 
     @Override
     public boolean test(
             LogicalType type, long rowCount, FieldStats fieldStats, Object patternLiteral) {
-        if (rowCount == fieldStats.nullCount()) {
-            return false;
-        }
         BinaryStringData min = (BinaryStringData) fieldStats.minValue();
         BinaryStringData max = (BinaryStringData) fieldStats.maxValue();
         BinaryStringData pattern = (BinaryStringData) patternLiteral;

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/predicate/PredicateBuilderTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/predicate/PredicateBuilderTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.store.file.predicate;
 
+import org.apache.flink.table.store.format.FieldStats;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
 
@@ -29,6 +30,114 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link PredicateBuilder}. */
 public class PredicateBuilderTest {
+
+    @Test
+    public void testIn() {
+        PredicateBuilder builder = new PredicateBuilder(RowType.of(new IntType()));
+        Predicate predicate = builder.in(0, Arrays.asList(1, 3));
+
+        assertThat(predicate.test(new Object[] {1})).isEqualTo(true);
+        assertThat(predicate.test(new Object[] {2})).isEqualTo(false);
+        assertThat(predicate.test(new Object[] {3})).isEqualTo(true);
+        assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
+
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+                .isEqualTo(false);
+    }
+
+    @Test
+    public void testInNull() {
+        PredicateBuilder builder = new PredicateBuilder(RowType.of(new IntType()));
+        Predicate predicate = builder.in(0, Arrays.asList(1, null, 3));
+
+        assertThat(predicate.test(new Object[] {1})).isEqualTo(true);
+        assertThat(predicate.test(new Object[] {2})).isEqualTo(false);
+        assertThat(predicate.test(new Object[] {3})).isEqualTo(true);
+        assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
+
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+                .isEqualTo(false);
+    }
+
+    @Test
+    public void testNotIn() {
+        PredicateBuilder builder = new PredicateBuilder(RowType.of(new IntType()));
+        Predicate predicate = builder.in(0, Arrays.asList(1, 3)).negate().get();
+
+        assertThat(predicate.test(new Object[] {1})).isEqualTo(false);
+        assertThat(predicate.test(new Object[] {2})).isEqualTo(true);
+        assertThat(predicate.test(new Object[] {3})).isEqualTo(false);
+        assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
+
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(1, 1, 0)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(3, 3, 0)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(1, 3, 0)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(true);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+                .isEqualTo(false);
+    }
+
+    @Test
+    public void testNotInNull() {
+        PredicateBuilder builder = new PredicateBuilder(RowType.of(new IntType()));
+        Predicate predicate = builder.in(0, Arrays.asList(1, null, 3)).negate().get();
+
+        assertThat(predicate.test(new Object[] {1})).isEqualTo(false);
+        assertThat(predicate.test(new Object[] {2})).isEqualTo(false);
+        assertThat(predicate.test(new Object[] {3})).isEqualTo(false);
+        assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
+
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(1, 1, 0)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(3, 3, 0)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(1, 3, 0)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+                .isEqualTo(false);
+    }
+
+    @Test
+    public void testBetween() {
+        PredicateBuilder builder = new PredicateBuilder(RowType.of(new IntType()));
+        Predicate predicate = builder.between(0, 1, 3);
+
+        assertThat(predicate.test(new Object[] {1})).isEqualTo(true);
+        assertThat(predicate.test(new Object[] {2})).isEqualTo(true);
+        assertThat(predicate.test(new Object[] {3})).isEqualTo(true);
+        assertThat(predicate.test(new Object[] {4})).isEqualTo(false);
+        assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
+
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(2, 5, 0)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 2, 0)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+                .isEqualTo(false);
+    }
+
+    @Test
+    public void testBetweenNull() {
+        PredicateBuilder builder = new PredicateBuilder(RowType.of(new IntType()));
+        Predicate predicate = builder.between(0, 1, null);
+
+        assertThat(predicate.test(new Object[] {1})).isEqualTo(false);
+        assertThat(predicate.test(new Object[] {2})).isEqualTo(false);
+        assertThat(predicate.test(new Object[] {3})).isEqualTo(false);
+        assertThat(predicate.test(new Object[] {4})).isEqualTo(false);
+        assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
+
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(2, 5, 0)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 2, 0)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+                .isEqualTo(false);
+    }
 
     @Test
     public void testSplitAnd() {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/predicate/PredicateConverterTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/predicate/PredicateConverterTest.java
@@ -64,6 +64,8 @@ public class PredicateConverterTest {
                 new FieldReferenceExpression("long1", DataTypes.BIGINT(), 0, 0);
         ValueLiteralExpression intLitExpr = new ValueLiteralExpression(10);
         long longLit = 10L;
+        ValueLiteralExpression nullLongLitExpr =
+                new ValueLiteralExpression(null, DataTypes.BIGINT());
 
         FieldReferenceExpression doubleRefExpr =
                 new FieldReferenceExpression("double1", DataTypes.DOUBLE(), 0, 1);
@@ -94,10 +96,22 @@ public class PredicateConverterTest {
                         BUILDER.equal(0, longLit)),
                 Arguments.of(
                         CallExpression.permanent(
+                                BuiltInFunctionDefinitions.EQUALS,
+                                Arrays.asList(nullLongLitExpr, longRefExpr),
+                                DataTypes.BOOLEAN()),
+                        BUILDER.equal(0, null)),
+                Arguments.of(
+                        CallExpression.permanent(
                                 BuiltInFunctionDefinitions.NOT_EQUALS,
                                 Arrays.asList(longRefExpr, intLitExpr),
                                 DataTypes.BOOLEAN()),
                         BUILDER.notEqual(0, longLit)),
+                Arguments.of(
+                        CallExpression.permanent(
+                                BuiltInFunctionDefinitions.NOT_EQUALS,
+                                Arrays.asList(longRefExpr, nullLongLitExpr),
+                                DataTypes.BOOLEAN()),
+                        BUILDER.notEqual(0, null)),
                 Arguments.of(
                         CallExpression.permanent(
                                 BuiltInFunctionDefinitions.GREATER_THAN,
@@ -106,10 +120,22 @@ public class PredicateConverterTest {
                         BUILDER.greaterThan(0, longLit)),
                 Arguments.of(
                         CallExpression.permanent(
+                                BuiltInFunctionDefinitions.GREATER_THAN,
+                                Arrays.asList(longRefExpr, nullLongLitExpr),
+                                DataTypes.BOOLEAN()),
+                        BUILDER.greaterThan(0, null)),
+                Arguments.of(
+                        CallExpression.permanent(
                                 BuiltInFunctionDefinitions.GREATER_THAN_OR_EQUAL,
                                 Arrays.asList(longRefExpr, intLitExpr),
                                 DataTypes.BOOLEAN()),
                         BUILDER.greaterOrEqual(0, longLit)),
+                Arguments.of(
+                        CallExpression.permanent(
+                                BuiltInFunctionDefinitions.GREATER_THAN_OR_EQUAL,
+                                Arrays.asList(longRefExpr, nullLongLitExpr),
+                                DataTypes.BOOLEAN()),
+                        BUILDER.greaterOrEqual(0, null)),
                 Arguments.of(
                         CallExpression.permanent(
                                 BuiltInFunctionDefinitions.LESS_THAN,
@@ -118,10 +144,22 @@ public class PredicateConverterTest {
                         BUILDER.lessThan(0, longLit)),
                 Arguments.of(
                         CallExpression.permanent(
+                                BuiltInFunctionDefinitions.LESS_THAN,
+                                Arrays.asList(longRefExpr, nullLongLitExpr),
+                                DataTypes.BOOLEAN()),
+                        BUILDER.lessThan(0, null)),
+                Arguments.of(
+                        CallExpression.permanent(
                                 BuiltInFunctionDefinitions.LESS_THAN_OR_EQUAL,
                                 Arrays.asList(longRefExpr, intLitExpr),
                                 DataTypes.BOOLEAN()),
                         BUILDER.lessOrEqual(0, longLit)),
+                Arguments.of(
+                        CallExpression.permanent(
+                                BuiltInFunctionDefinitions.LESS_THAN_OR_EQUAL,
+                                Arrays.asList(longRefExpr, nullLongLitExpr),
+                                DataTypes.BOOLEAN()),
+                        BUILDER.lessOrEqual(0, null)),
                 Arguments.of(
                         CallExpression.permanent(
                                 BuiltInFunctionDefinitions.AND,

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/predicate/PredicateTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/predicate/PredicateTest.java
@@ -72,6 +72,24 @@ public class PredicateTest {
     }
 
     @Test
+    public void testEqualNull() {
+        PredicateBuilder builder = new PredicateBuilder(RowType.of(new IntType()));
+        CallExpression expression =
+                call(
+                        BuiltInFunctionDefinitions.EQUALS,
+                        field(0, DataTypes.INT()),
+                        literal(null, DataTypes.INT()));
+        Predicate predicate = expression.accept(new PredicateConverter(builder));
+
+        assertThat(predicate.test(new Object[] {4})).isEqualTo(false);
+        assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
+
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+                .isEqualTo(false);
+    }
+
+    @Test
     public void testNotEqual() {
         PredicateBuilder builder = new PredicateBuilder(RowType.of(new IntType()));
         CallExpression expression =
@@ -90,6 +108,24 @@ public class PredicateTest {
                 .isEqualTo(false);
 
         assertThat(predicate.negate().orElse(null)).isEqualTo(builder.equal(0, 5));
+    }
+
+    @Test
+    public void testNotEqualNull() {
+        PredicateBuilder builder = new PredicateBuilder(RowType.of(new IntType()));
+        CallExpression expression =
+                call(
+                        BuiltInFunctionDefinitions.NOT_EQUALS,
+                        field(0, DataTypes.INT()),
+                        literal(null, DataTypes.INT()));
+        Predicate predicate = expression.accept(new PredicateConverter(builder));
+
+        assertThat(predicate.test(new Object[] {4})).isEqualTo(false);
+        assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
+
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+                .isEqualTo(false);
     }
 
     @Test
@@ -118,6 +154,24 @@ public class PredicateTest {
     }
 
     @Test
+    public void testGreaterNull() {
+        PredicateBuilder builder = new PredicateBuilder(RowType.of(new IntType()));
+        CallExpression expression =
+                call(
+                        BuiltInFunctionDefinitions.GREATER_THAN,
+                        field(0, DataTypes.INT()),
+                        literal(null, DataTypes.INT()));
+        Predicate predicate = expression.accept(new PredicateConverter(builder));
+
+        assertThat(predicate.test(new Object[] {4})).isEqualTo(false);
+        assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
+
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 4, 0)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+                .isEqualTo(false);
+    }
+
+    @Test
     public void testGreaterOrEqual() {
         PredicateBuilder builder = new PredicateBuilder(RowType.of(new IntType()));
         CallExpression expression =
@@ -143,6 +197,24 @@ public class PredicateTest {
     }
 
     @Test
+    public void testGreaterOrEqualNull() {
+        PredicateBuilder builder = new PredicateBuilder(RowType.of(new IntType()));
+        CallExpression expression =
+                call(
+                        BuiltInFunctionDefinitions.GREATER_THAN_OR_EQUAL,
+                        field(0, DataTypes.INT()),
+                        literal(null, DataTypes.INT()));
+        Predicate predicate = expression.accept(new PredicateConverter(builder));
+
+        assertThat(predicate.test(new Object[] {4})).isEqualTo(false);
+        assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
+
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 4, 0)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+                .isEqualTo(false);
+    }
+
+    @Test
     public void testLess() {
         PredicateBuilder builder = new PredicateBuilder(RowType.of(new IntType()));
         CallExpression expression =
@@ -161,6 +233,24 @@ public class PredicateTest {
                 .isEqualTo(false);
 
         assertThat(predicate.negate().orElse(null)).isEqualTo(builder.greaterOrEqual(0, 5));
+    }
+
+    @Test
+    public void testLessNull() {
+        PredicateBuilder builder = new PredicateBuilder(RowType.of(new IntType()));
+        CallExpression expression =
+                call(
+                        BuiltInFunctionDefinitions.LESS_THAN,
+                        field(0, DataTypes.INT()),
+                        literal(null, DataTypes.INT()));
+        Predicate predicate = expression.accept(new PredicateConverter(builder));
+
+        assertThat(predicate.test(new Object[] {4})).isEqualTo(false);
+        assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
+
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+                .isEqualTo(false);
     }
 
     @Test
@@ -185,6 +275,24 @@ public class PredicateTest {
                 .isEqualTo(false);
 
         assertThat(predicate.negate().orElse(null)).isEqualTo(builder.greaterThan(0, 5));
+    }
+
+    @Test
+    public void testLessOrEqualNull() {
+        PredicateBuilder builder = new PredicateBuilder(RowType.of(new IntType()));
+        CallExpression expression =
+                call(
+                        BuiltInFunctionDefinitions.LESS_THAN_OR_EQUAL,
+                        field(0, DataTypes.INT()),
+                        literal(null, DataTypes.INT()));
+        Predicate predicate = expression.accept(new PredicateConverter(builder));
+
+        assertThat(predicate.test(new Object[] {4})).isEqualTo(false);
+        assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
+
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+                .isEqualTo(false);
     }
 
     @Test

--- a/flink-table-store-hive/flink-table-store-hive-connector/pom.xml
+++ b/flink-table-store-hive/flink-table-store-hive-connector/pom.xml
@@ -81,6 +81,23 @@ under the License.
             </exclusions>
         </dependency>
 
+        <!--
+        Why we need this test dependency:
+        IDEA reads classes from the same project from target/classes of that module,
+        so even though we've packaged and shaded avro classes into flink-table-store-format.jar
+        we still have to include this test dependency here.
+
+        Why do we put this test dependency before the provided hive-exec:
+        hive-exec produces a shaded jar which contains old versioned avro classes,
+        so we need to make sure that our newer avro is loaded first.
+        -->
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>1.10.0</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-exec</artifactId>
@@ -127,19 +144,6 @@ under the License.
             <version>${project.version}</version>
             <scope>test</scope>
             <type>test-jar</type>
-        </dependency>
-
-        <!--
-        IDEA reads classes from the same project from target/classes of that module,
-        so even though we've packaged and shaded avro classes into flink-table-store-format.jar
-        we still have to include this test dependency here.
-        -->
-
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-sql-avro</artifactId>
-            <version>${flink.version}</version>
-            <scope>test</scope>
         </dependency>
 
         <!-- dependencies for IT cases -->

--- a/flink-table-store-hive/flink-table-store-hive-connector/src/test/java/org/apache/flink/table/store/SearchArgumentToPredicateConverterTest.java
+++ b/flink-table-store-hive/flink-table-store-hive-connector/src/test/java/org/apache/flink/table/store/SearchArgumentToPredicateConverterTest.java
@@ -181,6 +181,17 @@ public class SearchArgumentToPredicateConverterTest {
     }
 
     @Test
+    public void testInNull() {
+        SearchArgument.Builder builder = SearchArgumentFactory.newBuilder();
+        SearchArgument sarg =
+                builder.in("f_bigint", PredicateLeaf.Type.LONG, 100L, null, 300L).build();
+        Predicate expected =
+                PredicateBuilder.or(
+                        BUILDER.equal(1, 100L), BUILDER.equal(1, null), BUILDER.equal(1, 300L));
+        assertExpected(sarg, expected);
+    }
+
+    @Test
     public void testNotIn() {
         SearchArgument.Builder builder = SearchArgumentFactory.newBuilder();
         SearchArgument sarg =
@@ -192,6 +203,22 @@ public class SearchArgumentToPredicateConverterTest {
                 PredicateBuilder.and(
                         BUILDER.notEqual(1, 100L),
                         BUILDER.notEqual(1, 200L),
+                        BUILDER.notEqual(1, 300L));
+        assertExpected(sarg, expected);
+    }
+
+    @Test
+    public void testNotInNull() {
+        SearchArgument.Builder builder = SearchArgumentFactory.newBuilder();
+        SearchArgument sarg =
+                builder.startNot()
+                        .in("f_bigint", PredicateLeaf.Type.LONG, 100L, null, 300L)
+                        .end()
+                        .build();
+        Predicate expected =
+                PredicateBuilder.and(
+                        BUILDER.notEqual(1, 100L),
+                        BUILDER.notEqual(1, null),
                         BUILDER.notEqual(1, 300L));
         assertExpected(sarg, expected);
     }

--- a/flink-table-store-hive/flink-table-store-hive-connector/src/test/java/org/apache/flink/table/store/hive/TableStoreHiveStorageHandlerITCase.java
+++ b/flink-table-store-hive/flink-table-store-hive-connector/src/test/java/org/apache/flink/table/store/hive/TableStoreHiveStorageHandlerITCase.java
@@ -346,9 +346,16 @@ public class TableStoreHiveStorageHandlerITCase {
                 Arrays.asList("1", "3"),
                 hiveShell.executeQuery("SELECT * FROM test_table WHERE a IN (0, 1, 3, 7)"));
         Assert.assertEquals(
+                Collections.singletonList("3"),
+                hiveShell.executeQuery("SELECT * FROM test_table WHERE a IN (0, NULL, 3, 7)"));
+        Assert.assertEquals(
                 Arrays.asList("4", "6"),
                 hiveShell.executeQuery(
                         "SELECT * FROM test_table WHERE a NOT IN (0, 1, 3, 2, 5, 7)"));
+        Assert.assertEquals(
+                Collections.emptyList(),
+                hiveShell.executeQuery(
+                        "SELECT * FROM test_table WHERE a NOT IN (0, 1, NULL, 2, 5, 7)"));
         Assert.assertEquals(
                 Arrays.asList("2", "3"),
                 hiveShell.executeQuery("SELECT * FROM test_table WHERE a BETWEEN 2 AND 3"));

--- a/flink-table-store-spark/src/test/java/org/apache/flink/table/store/spark/SparkFilterConverterTest.java
+++ b/flink-table-store-spark/src/test/java/org/apache/flink/table/store/spark/SparkFilterConverterTest.java
@@ -71,25 +71,50 @@ public class SparkFilterConverterTest {
         Predicate actualLt = converter.convert(lt);
         assertThat(actualLt).isEqualTo(expectedLt);
 
+        LessThan ltNull = LessThan.apply(field, null);
+        Predicate expectedLtNull = builder.lessThan(0, null);
+        Predicate actualLtNull = converter.convert(ltNull);
+        assertThat(actualLtNull).isEqualTo(expectedLtNull);
+
         LessThanOrEqual ltEq = LessThanOrEqual.apply(field, 1);
         Predicate expectedLtEq = builder.lessOrEqual(0, 1);
         Predicate actualLtEq = converter.convert(ltEq);
         assertThat(actualLtEq).isEqualTo(expectedLtEq);
+
+        LessThanOrEqual ltEqNull = LessThanOrEqual.apply(field, null);
+        Predicate expectedLtEqNull = builder.lessOrEqual(0, null);
+        Predicate actualLtEqNull = converter.convert(ltEqNull);
+        assertThat(actualLtEqNull).isEqualTo(expectedLtEqNull);
 
         GreaterThan gt = GreaterThan.apply(field, 1);
         Predicate expectedGt = builder.greaterThan(0, 1);
         Predicate actualGt = converter.convert(gt);
         assertThat(actualGt).isEqualTo(expectedGt);
 
+        GreaterThan gtNull = GreaterThan.apply(field, null);
+        Predicate expectedGtNull = builder.greaterThan(0, null);
+        Predicate actualGtNull = converter.convert(gtNull);
+        assertThat(actualGtNull).isEqualTo(expectedGtNull);
+
         GreaterThanOrEqual gtEq = GreaterThanOrEqual.apply(field, 1);
         Predicate expectedGtEq = builder.greaterOrEqual(0, 1);
         Predicate actualGtEq = converter.convert(gtEq);
         assertThat(actualGtEq).isEqualTo(expectedGtEq);
 
+        GreaterThanOrEqual gtEqNull = GreaterThanOrEqual.apply(field, null);
+        Predicate expectedGtEqNull = builder.greaterOrEqual(0, null);
+        Predicate actualGtEqNull = converter.convert(gtEqNull);
+        assertThat(actualGtEqNull).isEqualTo(expectedGtEqNull);
+
         EqualTo eq = EqualTo.apply(field, 1);
         Predicate expectedEq = builder.equal(0, 1);
         Predicate actualEq = converter.convert(eq);
         assertThat(actualEq).isEqualTo(expectedEq);
+
+        EqualTo eqNull = EqualTo.apply(field, null);
+        Predicate expectedEqNull = builder.equal(0, null);
+        Predicate actualEqNull = converter.convert(eqNull);
+        assertThat(actualEqNull).isEqualTo(expectedEqNull);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -682,17 +682,6 @@ under the License.
 
                             <removeUnusedImports/>
                         </java>
-                        <scala>
-                            <scalafmt>
-                                <version>3.4.3</version>
-                                <!-- This file is in the root of the project to make sure IntelliJ picks it up automatically -->
-                                <file>.scalafmt.conf</file>
-                            </scalafmt>
-                            <licenseHeader>
-                                <content>${spotless.license.header}</content>
-                                <delimiter>${spotless.delimiter}</delimiter>
-                            </licenseHeader>
-                        </scala>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
Previously predicate functions does not accept null literals. This limits the range of supported predicates.

This PR adds support for null literals in predicates. We can now support predicates containing null literals, including `in` predicate with nulls.