### PR TITLE
[hotfix][docs] Architecture image resource not found.

### DIFF
--- a/docs/content/docs/development/overview.md
+++ b/docs/content/docs/development/overview.md
@@ -31,9 +31,7 @@ batch processing in Flink, supporting high-speed data ingestion and timely data 
 
 ## Architecture
 
-<center>
-<img src="/img/architecture.png" width="100%"/>
-</center>
+{{< img src="/img/architecture.png">}}
 
 As shown in the architecture above:
 


### PR DESCRIPTION
<img width="1009" alt="image" src="https://user-images.githubusercontent.com/1757754/176854475-43b124d1-4b51-4dfb-90e2-d7e18f06416a.png">
