### PR TITLE
[FLINK-28335] Delete topic after tests

### DIFF
--- a/flink-table-store-kafka/src/test/java/org/apache/flink/table/store/kafka/KafkaTableTestBase.java
+++ b/flink-table-store-kafka/src/test/java/org/apache/flink/table/store/kafka/KafkaTableTestBase.java
@@ -53,6 +53,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 /** Base class for Kafka Table IT Cases. */
@@ -110,9 +111,11 @@ public abstract class KafkaTableTestBase extends AbstractTestBase {
     }
 
     @After
-    public void after() {
+    public void after() throws ExecutionException, InterruptedException {
         // Cancel timer for debug logging
         cancelTimeoutLogger();
+        // Delete topics for avoid reusing topics of Kafka cluster
+        deleteTopics();
     }
 
     public Properties getStandardProps() {
@@ -167,6 +170,11 @@ public abstract class KafkaTableTestBase extends AbstractTestBase {
                         String.format("Failed to drop Kafka topic %s", topicName), e);
             }
         }
+    }
+
+    private void deleteTopics() throws ExecutionException, InterruptedException {
+        final AdminClient adminClient = AdminClient.create(getStandardProps());
+        adminClient.deleteTopics(adminClient.listTopics().names().get()).all().get();
     }
 
     // ------------------------ For Debug Logging Purpose ----------------------------------


### PR DESCRIPTION
Currently the tests don't not delete the topics, which causes that Kafka local cluster may reuse the data inside the topic that results in a test error.

**The brief change log**
- `KafkaTableTestBase#after()` adds the deletion of the topics for Kafka cluster.