### PR TITLE
[hotfix] Check bucket on write instead of scan

### DIFF
--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/TestChangelogDataReadWrite.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/TestChangelogDataReadWrite.java
@@ -145,8 +145,10 @@ public class TestChangelogDataReadWrite {
                 new KeyValueFileStoreWrite(
                                 new SchemaManager(tablePath),
                                 0,
+                                RowType.of(),
                                 KEY_TYPE,
                                 VALUE_TYPE,
+                                2,
                                 () -> COMPARATOR,
                                 new DeduplicateMergeFunction(),
                                 avro,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/AppendOnlyFileStore.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/AppendOnlyFileStore.java
@@ -43,7 +43,12 @@ public class AppendOnlyFileStore extends AbstractFileStore<RowData> {
 
     @Override
     public AppendOnlyFileStoreScan newScan() {
-        return newScan(false);
+        return new AppendOnlyFileStoreScan(
+                partitionType,
+                rowType,
+                snapshotManager(),
+                manifestFileFactory(),
+                manifestListFactory());
     }
 
     @Override
@@ -56,22 +61,13 @@ public class AppendOnlyFileStore extends AbstractFileStore<RowData> {
     public AppendOnlyFileStoreWrite newWrite() {
         return new AppendOnlyFileStoreWrite(
                 schemaId,
+                partitionType,
                 rowType,
+                options.bucket(),
                 options.fileFormat(),
                 pathFactory(),
                 snapshotManager(),
-                newScan(true),
+                newScan(),
                 options.mergeTreeOptions().targetFileSize);
-    }
-
-    private AppendOnlyFileStoreScan newScan(boolean checkNumOfBuckets) {
-        return new AppendOnlyFileStoreScan(
-                partitionType,
-                rowType,
-                snapshotManager(),
-                manifestFileFactory(),
-                manifestListFactory(),
-                options.bucket(),
-                checkNumOfBuckets);
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValueFileStore.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValueFileStore.java
@@ -56,7 +56,12 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
 
     @Override
     public KeyValueFileStoreScan newScan() {
-        return newScan(false);
+        return new KeyValueFileStoreScan(
+                partitionType,
+                keyType,
+                snapshotManager(),
+                manifestFileFactory(),
+                manifestListFactory());
     }
 
     @Override
@@ -77,26 +82,17 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
         return new KeyValueFileStoreWrite(
                 schemaManager,
                 schemaId,
+                partitionType,
                 keyType,
                 valueType,
+                options.bucket(),
                 keyComparatorSupplier,
                 mergeFunction,
                 options.fileFormat(),
                 pathFactory(),
                 snapshotManager(),
-                newScan(true),
+                newScan(),
                 options.mergeTreeOptions());
-    }
-
-    private KeyValueFileStoreScan newScan(boolean checkNumOfBuckets) {
-        return new KeyValueFileStoreScan(
-                partitionType,
-                keyType,
-                snapshotManager(),
-                manifestFileFactory(),
-                manifestListFactory(),
-                options.bucket(),
-                checkNumOfBuckets);
     }
 
     public Comparator<RowData> newKeyComparator() {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AppendOnlyFileStoreScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AppendOnlyFileStoreScan.java
@@ -38,16 +38,8 @@ public class AppendOnlyFileStoreScan extends AbstractFileStoreScan {
             RowType rowType,
             SnapshotManager snapshotManager,
             ManifestFile.Factory manifestFileFactory,
-            ManifestList.Factory manifestListFactory,
-            int numOfBuckets,
-            boolean checkNumOfBuckets) {
-        super(
-                partitionType,
-                snapshotManager,
-                manifestFileFactory,
-                manifestListFactory,
-                numOfBuckets,
-                checkNumOfBuckets);
+            ManifestList.Factory manifestListFactory) {
+        super(partitionType, snapshotManager, manifestFileFactory, manifestListFactory);
         this.rowStatsConverter = new FieldStatsArraySerializer(rowType);
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AppendOnlyFileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AppendOnlyFileStoreWrite.java
@@ -47,13 +47,15 @@ public class AppendOnlyFileStoreWrite extends AbstractFileStoreWrite<RowData> {
 
     public AppendOnlyFileStoreWrite(
             long schemaId,
+            RowType partitionType,
             RowType rowType,
+            int expectedNumBucket,
             FileFormat fileFormat,
             FileStorePathFactory pathFactory,
             SnapshotManager snapshotManager,
             FileStoreScan scan,
             long targetFileSize) {
-        super(snapshotManager, scan);
+        super(partitionType, snapshotManager, scan, expectedNumBucket);
         this.schemaId = schemaId;
         this.rowType = rowType;
         this.fileFormat = fileFormat;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreScan.java
@@ -38,16 +38,8 @@ public class KeyValueFileStoreScan extends AbstractFileStoreScan {
             RowType keyType,
             SnapshotManager snapshotManager,
             ManifestFile.Factory manifestFileFactory,
-            ManifestList.Factory manifestListFactory,
-            int numOfBuckets,
-            boolean checkNumOfBuckets) {
-        super(
-                partitionType,
-                snapshotManager,
-                manifestFileFactory,
-                manifestListFactory,
-                numOfBuckets,
-                checkNumOfBuckets);
+            ManifestList.Factory manifestListFactory) {
+        super(partitionType, snapshotManager, manifestFileFactory, manifestListFactory);
         this.keyStatsConverter = new FieldStatsArraySerializer(keyType);
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreWrite.java
@@ -65,8 +65,10 @@ public class KeyValueFileStoreWrite extends AbstractFileStoreWrite<KeyValue> {
     public KeyValueFileStoreWrite(
             SchemaManager schemaManager,
             long schemaId,
+            RowType partitionType,
             RowType keyType,
             RowType valueType,
+            int expectedNumBucket,
             Supplier<Comparator<RowData>> keyComparatorSupplier,
             MergeFunction mergeFunction,
             FileFormat fileFormat,
@@ -74,7 +76,7 @@ public class KeyValueFileStoreWrite extends AbstractFileStoreWrite<KeyValue> {
             SnapshotManager snapshotManager,
             FileStoreScan scan,
             MergeTreeOptions options) {
-        super(snapshotManager, scan);
+        super(partitionType, snapshotManager, scan, expectedNumBucket);
         this.dataFileReaderFactory =
                 new DataFileReader.Factory(
                         schemaManager, schemaId, keyType, valueType, fileFormat, pathFactory);


### PR DESCRIPTION
Total bucket checking should be in write instead of scan.
This would have been what write needed to do and should not have been perceived by scan.