### PR TITLE
[FLINK-28017] Introduce bucket-key to table store

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/BucketStreamPartitioner.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/BucketStreamPartitioner.java
@@ -48,8 +48,7 @@ public class BucketStreamPartitioner extends StreamPartitioner<RowData> {
     @Override
     public int selectChannel(SerializationDelegate<StreamRecord<RowData>> record) {
         RowData row = record.getInstance().getValue();
-        int bucket = recordConverter.bucket(row, recordConverter.primaryKey(row));
-        return bucket % numberOfChannels;
+        return recordConverter.bucket(row) % numberOfChannels;
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
@@ -56,8 +56,17 @@ public class CoreOptions implements Serializable {
                     .stringType()
                     .noDefaultValue()
                     .withDescription(
-                            "Specifies the table store distribution policy. Data is assigned"
-                                    + " to each bucket according to the hash value of bucket-key.");
+                            Description.builder()
+                                    .text(
+                                            "Specify the table store distribution policy. Data is assigned"
+                                                    + " to each bucket according to the hash value of bucket-key.")
+                                    .linebreak()
+                                    .text("If you specify multiple fields, delimiter is ','.")
+                                    .linebreak()
+                                    .text(
+                                            "If not specified, the primary key will be used; "
+                                                    + "if there is no primary key, the full row will be used.")
+                                    .build());
 
     @Internal
     public static final ConfigOption<String> PATH =

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
@@ -51,6 +51,14 @@ public class CoreOptions implements Serializable {
                     .defaultValue(1)
                     .withDescription("Bucket number for file store.");
 
+    public static final ConfigOption<String> BUCKET_KEY =
+            ConfigOptions.key("bucket-key")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Specifies the table store distribution policy. Data is assigned"
+                                    + " to each bucket according to the hash value of bucket-key.");
+
     @Internal
     public static final ConfigOption<String> PATH =
             ConfigOptions.key("path")

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/TableSchema.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/TableSchema.java
@@ -39,7 +39,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.table.store.file.FileStoreOptions.BUCKET_KEY;
+import static org.apache.flink.table.store.CoreOptions.BUCKET_KEY;
 
 /** Schema of a table. */
 public class TableSchema implements Serializable {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/sink/SinkRecordConverterTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/sink/SinkRecordConverterTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.table.sink;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.file.schema.DataField;
+import org.apache.flink.table.store.file.schema.TableSchema;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.table.store.file.FileStoreOptions.BUCKET_KEY;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/** Test for {@link SinkRecordConverter}. */
+public class SinkRecordConverterTest {
+
+    @Test
+    public void testInvalidBucket() {
+        assertThatThrownBy(() -> converter("n", "b"))
+                .hasMessageContaining("Field names [a, b, c] should contains all bucket keys [n].");
+
+        assertThatThrownBy(() -> converter("a", "b"))
+                .hasMessageContaining("Primary keys [b] should contains all bucket keys [a].");
+    }
+
+    @Test
+    public void testBucket() {
+        GenericRowData row = GenericRowData.of(5, 6, 7);
+        assertThat(bucket(converter("a", "a,b"), row)).isEqualTo(96);
+        assertThat(bucket(converter("", "a"), row)).isEqualTo(96);
+        assertThat(bucket(converter("", "a,b"), row)).isEqualTo(27);
+        assertThat(bucket(converter("a,b", "a,b"), row)).isEqualTo(27);
+        assertThat(bucket(converter("", ""), row)).isEqualTo(40);
+        assertThat(bucket(converter("a,b,c", ""), row)).isEqualTo(40);
+        assertThat(bucket(converter("", "a,b,c"), row)).isEqualTo(40);
+    }
+
+    private int bucket(SinkRecordConverter converter, RowData row) {
+        int bucket1 = converter.bucket(row);
+        int bucket2 = converter.convert(row).bucket();
+        assertThat(bucket1).isEqualTo(bucket2);
+        return bucket1;
+    }
+
+    private SinkRecordConverter converter(String bk, String pk) {
+        RowType rowType =
+                new RowType(
+                        Arrays.asList(
+                                new RowType.RowField("a", new IntType()),
+                                new RowType.RowField("b", new IntType()),
+                                new RowType.RowField("c", new IntType())));
+        List<DataField> fields = TableSchema.newFields(rowType);
+        Map<String, String> options = new HashMap<>();
+        options.put(BUCKET_KEY.key(), bk);
+        TableSchema schema =
+                new TableSchema(
+                        0,
+                        fields,
+                        TableSchema.currentHighestFieldId(fields),
+                        Collections.emptyList(),
+                        "".equals(pk) ? Collections.emptyList() : Arrays.asList(pk.split(",")),
+                        options,
+                        "");
+        return new SinkRecordConverter(100, schema);
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/sink/SinkRecordConverterTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/sink/SinkRecordConverterTest.java
@@ -33,7 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.flink.table.store.file.FileStoreOptions.BUCKET_KEY;
+import static org.apache.flink.table.store.CoreOptions.BUCKET_KEY;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 


### PR DESCRIPTION
Specifies the table store distribution policy. Data is assigned to each bucket according to the hash value of bucket-key.
- It is primary key when table has primary key. The user can specify a bucket key, it should be part of primary keys.
- It is all fields when table has no primary key.
If there are filter conditions for specific fields, reasonable settings can give a big performance boost to the table, but care needs to be taken to avoid data skewing.