### PR TITLE
[FLINK-28221] Store commit user name into Flink sink state and correct endInput behavior

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSink.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSink.java
@@ -83,7 +83,7 @@ public class StoreSink implements Serializable {
         return new StoreWriteOperator(table, overwritePartition, logSinkFunction);
     }
 
-    private StoreCommitter createCommitter() {
+    private StoreCommitter createCommitter(String user) {
         CatalogLock catalogLock;
         Lock lock;
         if (lockFactory == null) {
@@ -104,7 +104,7 @@ public class StoreSink implements Serializable {
         }
 
         return new StoreCommitter(
-                table.newCommit().withOverwritePartition(overwritePartition).withLock(lock),
+                table.newCommit(user).withOverwritePartition(overwritePartition).withLock(lock),
                 catalogLock);
     }
 

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileStoreITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileStoreITCase.java
@@ -66,6 +66,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -390,8 +391,11 @@ public class FileStoreITCase extends AbstractTestBase {
         if (noFail) {
             options.set(PATH, folder.toURI().toString());
         } else {
-            FailingAtomicRenameFileSystem.get().reset(3, 100);
-            options.set(PATH, FailingAtomicRenameFileSystem.getFailingPath(folder.getPath()));
+            String failingName = UUID.randomUUID().toString();
+            FailingAtomicRenameFileSystem.reset(failingName, 3, 100);
+            options.set(
+                    PATH,
+                    FailingAtomicRenameFileSystem.getFailingPath(failingName, folder.getPath()));
         }
         options.set(FILE_FORMAT, "avro");
         return options;

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/FileStoreSinkITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/FileStoreSinkITCase.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector.sink;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateBackendOptions;
+import org.apache.flink.core.execution.SavepointFormatType;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.apache.flink.runtime.scheduler.stopwithsavepoint.StopWithSavepointStoppingException;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.store.file.utils.FailingAtomicRenameFileSystem;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+import org.apache.flink.util.ExceptionUtils;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/** IT cases for {@link StoreSink} when writing file store. */
+public class FileStoreSinkITCase extends AbstractTestBase {
+
+    private String path;
+    private String failingName;
+
+    @Before
+    public void before() throws Exception {
+        path = TEMPORARY_FOLDER.newFolder().toPath().toString();
+        // for failure tests
+        failingName = UUID.randomUUID().toString();
+        FailingAtomicRenameFileSystem.reset(failingName, 100, 500);
+    }
+
+    @Test(timeout = 60000)
+    public void testRecoverFromSavepoint() throws Exception {
+        String failingPath = FailingAtomicRenameFileSystem.getFailingPath(failingName, path);
+        String savepointPath = null;
+        JobID jobId;
+        ClusterClient<?> client = MINI_CLUSTER_RESOURCE.getClusterClient();
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+
+        OUTER:
+        while (true) {
+            // start a new job or recover from savepoint
+            jobId = runRecoverFromSavepointJob(failingPath, savepointPath);
+            while (true) {
+                // wait for a random number of time before stopping with savepoint
+                Thread.sleep(random.nextInt(5000));
+                if (client.getJobStatus(jobId).get() == JobStatus.FINISHED) {
+                    // job finished, check for result
+                    break OUTER;
+                }
+                try {
+                    // try to stop with savepoint
+                    savepointPath =
+                            client.stopWithSavepoint(
+                                            jobId,
+                                            false,
+                                            path + "/savepoint",
+                                            SavepointFormatType.DEFAULT)
+                                    .get();
+                    break;
+                } catch (Exception e) {
+                    Optional<StopWithSavepointStoppingException> t =
+                            ExceptionUtils.findThrowable(
+                                    e, StopWithSavepointStoppingException.class);
+                    if (t.isPresent()) {
+                        // savepoint has been created but notifyCheckpointComplete is not called
+                        //
+                        // user should follow the exception message and recover job from the
+                        // specific savepoint
+                        savepointPath = t.get().getSavepointPath();
+                        break;
+                    }
+                    // savepoint creation may fail due to various reasons (for example the job is in
+                    // failing state, or the job has finished), just wait for a while and try again
+                }
+            }
+            // wait for job to stop
+            while (!client.getJobStatus(jobId).get().isGloballyTerminalState()) {
+                Thread.sleep(1000);
+            }
+            // recover from savepoint in the next round
+        }
+
+        checkRecoverFromSavepointResult(failingPath);
+    }
+
+    private JobID runRecoverFromSavepointJob(String failingPath, String savepointPath)
+            throws Exception {
+        Configuration conf = new Configuration();
+        if (savepointPath != null) {
+            SavepointRestoreSettings savepointRestoreSettings =
+                    SavepointRestoreSettings.forPath(savepointPath, false);
+            SavepointRestoreSettings.toConfiguration(savepointRestoreSettings, conf);
+        }
+
+        EnvironmentSettings settings = EnvironmentSettings.newInstance().inStreamingMode().build();
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(conf);
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, settings);
+        tEnv.getConfig()
+                .getConfiguration()
+                .set(ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL, Duration.ofMillis(500));
+        tEnv.getConfig().getConfiguration().set(StateBackendOptions.STATE_BACKEND, "filesystem");
+        tEnv.getConfig()
+                .getConfiguration()
+                .set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, "file://" + path + "/checkpoint");
+        tEnv.getConfig()
+                .getConfiguration()
+                .set(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 2);
+        // we're creating multiple table environments in the same process
+        // if we do not set this option, stream node id will be different even with the same SQL
+        // if stream node id is different then we can't recover from savepoint
+        tEnv.getConfig()
+                .getConfiguration()
+                .set(ExecutionConfigOptions.TABLE_EXEC_LEGACY_TRANSFORMATION_UIDS, true);
+
+        tEnv.executeSql(
+                String.join(
+                        "\n",
+                        "CREATE TABLE S (",
+                        "  a INT",
+                        ") WITH (",
+                        "  'connector' = 'datagen',",
+                        "  'rows-per-second' = '10000',",
+                        "  'fields.a.kind' = 'sequence',",
+                        "  'fields.a.start' = '0',",
+                        "  'fields.a.end' = '99999'",
+                        ")"));
+
+        String createCatalogSql =
+                String.join(
+                        "\n",
+                        "CREATE CATALOG my_catalog WITH (",
+                        "  'type' = 'table-store',",
+                        "  'warehouse' = '" + failingPath + "'",
+                        ")");
+        FailingAtomicRenameFileSystem.retryArtificialException(
+                () -> tEnv.executeSql(createCatalogSql));
+
+        tEnv.executeSql("USE CATALOG my_catalog");
+
+        String createSinkSql =
+                String.join(
+                        "\n",
+                        "CREATE TABLE IF NOT EXISTS T (",
+                        "  a INT",
+                        ") WITH (",
+                        "  'bucket' = '2',",
+                        "  'file.format' = 'avro'",
+                        ")");
+        FailingAtomicRenameFileSystem.retryArtificialException(
+                () -> tEnv.executeSql(createSinkSql));
+
+        String insertIntoSql = "INSERT INTO T SELECT * FROM default_catalog.default_database.S";
+        JobID jobId =
+                FailingAtomicRenameFileSystem.retryArtificialException(
+                                () -> tEnv.executeSql(insertIntoSql))
+                        .getJobClient()
+                        .get()
+                        .getJobID();
+
+        ClusterClient<?> client = MINI_CLUSTER_RESOURCE.getClusterClient();
+        while (client.getJobStatus(jobId).get() == JobStatus.INITIALIZING) {
+            Thread.sleep(1000);
+        }
+        return jobId;
+    }
+
+    private void checkRecoverFromSavepointResult(String failingPath) throws Exception {
+        EnvironmentSettings settings = EnvironmentSettings.newInstance().inBatchMode().build();
+        TableEnvironment tEnv = TableEnvironment.create(settings);
+        // no failure should occur when checking for answer
+        FailingAtomicRenameFileSystem.reset(failingName, 0, 1);
+
+        String createCatalogSql =
+                String.join(
+                        "\n",
+                        "CREATE CATALOG my_catalog WITH (",
+                        "  'type' = 'table-store',",
+                        "  'warehouse' = '" + failingPath + "'",
+                        ")");
+        tEnv.executeSql(createCatalogSql);
+
+        tEnv.executeSql("USE CATALOG my_catalog");
+
+        List<Integer> actual = new ArrayList<>();
+        try (CloseableIterator<Row> it = tEnv.executeSql("SELECT * FROM T").collect()) {
+            while (it.hasNext()) {
+                Row row = it.next();
+                Assert.assertEquals(1, row.getArity());
+                actual.add((Integer) row.getField(0));
+            }
+        }
+        Collections.sort(actual);
+        Assert.assertEquals(
+                IntStream.range(0, 100000).boxed().collect(Collectors.toList()), actual);
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/AbstractFileStore.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/AbstractFileStore.java
@@ -39,19 +39,16 @@ public abstract class AbstractFileStore<T> implements FileStore<T> {
     protected final SchemaManager schemaManager;
     protected final long schemaId;
     protected final CoreOptions options;
-    protected final String user;
     protected final RowType partitionType;
 
     public AbstractFileStore(
             SchemaManager schemaManager,
             long schemaId,
             CoreOptions options,
-            String user,
             RowType partitionType) {
         this.schemaManager = schemaManager;
         this.schemaId = schemaId;
         this.options = options;
-        this.user = user;
         this.partitionType = partitionType;
     }
 
@@ -94,7 +91,7 @@ public abstract class AbstractFileStore<T> implements FileStore<T> {
     }
 
     @Override
-    public FileStoreCommitImpl newCommit() {
+    public FileStoreCommitImpl newCommit(String user) {
         return new FileStoreCommitImpl(
                 schemaId,
                 user,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/AppendOnlyFileStore.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/AppendOnlyFileStore.java
@@ -35,10 +35,9 @@ public class AppendOnlyFileStore extends AbstractFileStore<RowData> {
             SchemaManager schemaManager,
             long schemaId,
             CoreOptions options,
-            String user,
             RowType partitionType,
             RowType rowType) {
-        super(schemaManager, schemaId, options, user, partitionType);
+        super(schemaManager, schemaId, options, partitionType);
         this.rowType = rowType;
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStore.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStore.java
@@ -45,7 +45,7 @@ public interface FileStore<T> extends Serializable {
 
     FileStoreWrite<T> newWrite();
 
-    FileStoreCommit newCommit();
+    FileStoreCommit newCommit(String user);
 
     FileStoreExpire newExpire();
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValueFileStore.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValueFileStore.java
@@ -45,12 +45,11 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
             SchemaManager schemaManager,
             long schemaId,
             CoreOptions options,
-            String user,
             RowType partitionType,
             RowType keyType,
             RowType valueType,
             MergeFunction mergeFunction) {
-        super(schemaManager, schemaId, options, user, partitionType);
+        super(schemaManager, schemaId, options, partitionType);
         this.keyType = keyType;
         this.valueType = valueType;
         this.mergeFunction = mergeFunction;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AbstractFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AbstractFileStoreTable.java
@@ -56,8 +56,8 @@ public abstract class AbstractFileStoreTable implements FileStoreTable {
     }
 
     @Override
-    public TableCommit newCommit() {
-        return new TableCommit(store().newCommit(), store().newExpire());
+    public TableCommit newCommit(String user) {
+        return new TableCommit(store().newCommit(user), store().newExpire());
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTable.java
@@ -52,15 +52,13 @@ public class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
 
     private final AppendOnlyFileStore store;
 
-    AppendOnlyFileStoreTable(
-            Path path, SchemaManager schemaManager, TableSchema tableSchema, String user) {
+    AppendOnlyFileStoreTable(Path path, SchemaManager schemaManager, TableSchema tableSchema) {
         super(path, tableSchema);
         this.store =
                 new AppendOnlyFileStore(
                         schemaManager,
                         tableSchema.id(),
                         new CoreOptions(tableSchema.options()),
-                        user,
                         tableSchema.logicalPartitionType(),
                         tableSchema.logicalRowType());
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTable.java
@@ -57,7 +57,7 @@ public class ChangelogValueCountFileStoreTable extends AbstractFileStoreTable {
     private final KeyValueFileStore store;
 
     ChangelogValueCountFileStoreTable(
-            Path path, SchemaManager schemaManager, TableSchema tableSchema, String user) {
+            Path path, SchemaManager schemaManager, TableSchema tableSchema) {
         super(path, tableSchema);
         RowType countType =
                 RowType.of(
@@ -68,7 +68,6 @@ public class ChangelogValueCountFileStoreTable extends AbstractFileStoreTable {
                         schemaManager,
                         tableSchema.id(),
                         new CoreOptions(tableSchema.options()),
-                        user,
                         tableSchema.logicalPartitionType(),
                         tableSchema.logicalRowType(),
                         countType,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
@@ -63,7 +63,7 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
     private final KeyValueFileStore store;
 
     ChangelogWithKeyFileStoreTable(
-            Path path, SchemaManager schemaManager, TableSchema tableSchema, String user) {
+            Path path, SchemaManager schemaManager, TableSchema tableSchema) {
         super(path, tableSchema);
         RowType rowType = tableSchema.logicalRowType();
 
@@ -104,7 +104,6 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
                         schemaManager,
                         tableSchema.id(),
                         new CoreOptions(conf),
-                        user,
                         tableSchema.logicalPartitionType(),
                         keyType,
                         rowType,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/FileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/FileStoreTable.java
@@ -47,7 +47,7 @@ public interface FileStoreTable extends Serializable {
 
     TableWrite newWrite();
 
-    TableCommit newCommit();
+    TableCommit newCommit(String user);
 
     TableCompact newCompact();
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -82,6 +82,7 @@ public class TestFileStore extends KeyValueFileStore {
     private final String root;
     private final RowDataSerializer keySerializer;
     private final RowDataSerializer valueSerializer;
+    private final String user;
 
     public static TestFileStore create(
             String format,
@@ -121,7 +122,6 @@ public class TestFileStore extends KeyValueFileStore {
                 new SchemaManager(options.path()),
                 0L,
                 options,
-                UUID.randomUUID().toString(),
                 partitionType,
                 keyType,
                 valueType,
@@ -129,6 +129,7 @@ public class TestFileStore extends KeyValueFileStore {
         this.root = root;
         this.keySerializer = new RowDataSerializer(keyType);
         this.valueSerializer = new RowDataSerializer(valueType);
+        this.user = UUID.randomUUID().toString();
     }
 
     public FileStoreExpireImpl newExpire(
@@ -220,7 +221,7 @@ public class TestFileStore extends KeyValueFileStore {
                     .write(kv);
         }
 
-        FileStoreCommit commit = newCommit();
+        FileStoreCommit commit = newCommit(user);
         ManifestCommittable committable =
                 new ManifestCommittable(String.valueOf(new Random().nextLong()));
         for (Map.Entry<BinaryRowData, Map<Integer, RecordWriter<KeyValue>>> entryWithPartition :

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileTest.java
@@ -49,6 +49,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 
@@ -100,11 +101,14 @@ public class DataFileTest {
 
     @RepeatedTest(10)
     public void testCleanUpForException() throws IOException {
-        FailingAtomicRenameFileSystem.get().reset(1, 10);
+        String failingName = UUID.randomUUID().toString();
+        FailingAtomicRenameFileSystem.reset(failingName, 1, 10);
         DataFileTestDataGenerator.Data data = gen.next();
         DataFileWriter writer =
                 createDataFileWriter(
-                        FailingAtomicRenameFileSystem.getFailingPath(tempDir.toString()), "avro");
+                        FailingAtomicRenameFileSystem.getFailingPath(
+                                failingName, tempDir.toString()),
+                        "avro");
 
         try {
             writer.write(CloseableIterator.fromList(data.content, kv -> {}), 0);

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestFileMetaTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestFileMetaTest.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.TreeSet;
+import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -107,12 +108,14 @@ public class ManifestFileMetaTest {
 
     @RepeatedTest(10)
     public void testCleanUpForException() throws IOException {
-        FailingAtomicRenameFileSystem.get().reset(1, 10);
+        String failingName = UUID.randomUUID().toString();
+        FailingAtomicRenameFileSystem.reset(failingName, 1, 10);
         List<ManifestFileMeta> input = new ArrayList<>();
         createData(ThreadLocalRandom.current().nextInt(5), input, null);
         ManifestFile failingManifestFile =
                 createManifestFile(
-                        FailingAtomicRenameFileSystem.getFailingPath(tempDir.toString()));
+                        FailingAtomicRenameFileSystem.getFailingPath(
+                                failingName, tempDir.toString()));
 
         try {
             ManifestFileMeta.merge(input, failingManifestFile, 500, 3);

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestFileTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestFileTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
@@ -65,11 +66,13 @@ public class ManifestFileTest {
 
     @RepeatedTest(10)
     public void testCleanUpForException() throws IOException {
-        FailingAtomicRenameFileSystem.get().reset(1, 10);
+        String failingName = UUID.randomUUID().toString();
+        FailingAtomicRenameFileSystem.reset(failingName, 1, 10);
         List<ManifestEntry> entries = generateData();
         ManifestFile manifestFile =
                 createManifestFile(
-                        FailingAtomicRenameFileSystem.getFailingPath(tempDir.toString()));
+                        FailingAtomicRenameFileSystem.getFailingPath(
+                                failingName, tempDir.toString()));
 
         try {
             manifestFile.write(entries);

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestListTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestListTest.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -57,11 +58,13 @@ public class ManifestListTest {
 
     @RepeatedTest(10)
     public void testCleanUpForException() throws IOException {
-        FailingAtomicRenameFileSystem.get().reset(1, 3);
+        String failingName = UUID.randomUUID().toString();
+        FailingAtomicRenameFileSystem.reset(failingName, 1, 3);
         List<ManifestFileMeta> metas = generateData();
         ManifestList manifestList =
                 createManifestList(
-                        FailingAtomicRenameFileSystem.getFailingPath(tempDir.toString()));
+                        FailingAtomicRenameFileSystem.getFailingPath(
+                                failingName, tempDir.toString()));
 
         try {
             manifestList.write(metas);

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
@@ -64,7 +65,7 @@ public class TestCommitThread extends Thread {
         this.writers = new HashMap<>();
 
         this.write = safeStore.newWrite();
-        this.commit = testStore.newCommit();
+        this.commit = testStore.newCommit(UUID.randomUUID().toString());
     }
 
     public Map<BinaryRowData, List<KeyValue>> getResult() {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/schema/SchemaManagerTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/schema/SchemaManagerTest.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -65,8 +66,9 @@ public class SchemaManagerTest {
     @BeforeEach
     public void beforeEach() throws IOException {
         // for failure tests
-        FailingAtomicRenameFileSystem.get().reset(100, 5000);
-        String root = FailingAtomicRenameFileSystem.getFailingPath(tempDir.toString());
+        String failingName = UUID.randomUUID().toString();
+        FailingAtomicRenameFileSystem.reset(failingName, 100, 100);
+        String root = FailingAtomicRenameFileSystem.getFailingPath(failingName, tempDir.toString());
         manager = new SchemaManager(new Path(root));
     }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTableTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.store.file.predicate.PredicateBuilder;
 import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.schema.UpdateSchema;
+import org.apache.flink.table.store.table.sink.TableCommit;
 import org.apache.flink.table.store.table.sink.TableWrite;
 import org.apache.flink.table.store.table.source.Split;
 import org.apache.flink.table.store.table.source.TableRead;
@@ -140,21 +141,22 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
     private void writeData() throws Exception {
         FileStoreTable table = createFileStoreTable();
         TableWrite write = table.newWrite();
+        TableCommit commit = table.newCommit("user");
 
         write.write(GenericRowData.of(1, 10, 100L));
         write.write(GenericRowData.of(2, 20, 200L));
         write.write(GenericRowData.of(1, 11, 101L));
-        table.newCommit().commit("0", write.prepareCommit());
+        commit.commit("0", write.prepareCommit());
 
         write.write(GenericRowData.of(1, 12, 102L));
         write.write(GenericRowData.of(2, 21, 201L));
         write.write(GenericRowData.of(2, 22, 202L));
-        table.newCommit().commit("1", write.prepareCommit());
+        commit.commit("1", write.prepareCommit());
 
         write.write(GenericRowData.of(1, 11, 101L));
         write.write(GenericRowData.of(2, 21, 201L));
         write.write(GenericRowData.of(1, 12, 102L));
-        table.newCommit().commit("2", write.prepareCommit());
+        commit.commit("2", write.prepareCommit());
 
         write.close();
     }
@@ -175,6 +177,6 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                                 Collections.emptyList(),
                                 conf.toMap(),
                                 ""));
-        return new AppendOnlyFileStoreTable(tablePath, schemaManager, tableSchema, "user");
+        return new AppendOnlyFileStoreTable(tablePath, schemaManager, tableSchema);
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTableTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.store.file.predicate.PredicateBuilder;
 import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.schema.UpdateSchema;
+import org.apache.flink.table.store.table.sink.TableCommit;
 import org.apache.flink.table.store.table.sink.TableWrite;
 import org.apache.flink.table.store.table.source.Split;
 import org.apache.flink.table.store.table.source.TableRead;
@@ -140,24 +141,25 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
     private void writeData() throws Exception {
         FileStoreTable table = createFileStoreTable();
         TableWrite write = table.newWrite();
+        TableCommit commit = table.newCommit("user");
 
         write.write(GenericRowData.of(1, 10, 100L));
         write.write(GenericRowData.of(2, 20, 200L));
         write.write(GenericRowData.of(1, 11, 101L));
-        table.newCommit().commit("0", write.prepareCommit());
+        commit.commit("0", write.prepareCommit());
 
         write.write(GenericRowData.of(2, 21, 201L));
         write.write(GenericRowData.of(1, 12, 102L));
         write.write(GenericRowData.of(2, 21, 201L));
         write.write(GenericRowData.of(2, 21, 201L));
-        table.newCommit().commit("1", write.prepareCommit());
+        commit.commit("1", write.prepareCommit());
 
         write.write(GenericRowData.of(1, 11, 101L));
         write.write(GenericRowData.of(2, 22, 202L));
         write.write(GenericRowData.ofKind(RowKind.DELETE, 2, 21, 201L));
         write.write(GenericRowData.ofKind(RowKind.DELETE, 1, 10, 100L));
         write.write(GenericRowData.ofKind(RowKind.DELETE, 2, 21, 201L));
-        table.newCommit().commit("2", write.prepareCommit());
+        commit.commit("2", write.prepareCommit());
 
         write.close();
     }
@@ -178,6 +180,6 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
                                 Collections.emptyList(),
                                 conf.toMap(),
                                 ""));
-        return new ChangelogValueCountFileStoreTable(tablePath, schemaManager, tableSchema, "user");
+        return new ChangelogValueCountFileStoreTable(tablePath, schemaManager, tableSchema);
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/FileStoreTableTestBase.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/FileStoreTableTestBase.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.store.file.mergetree.compact.ConcatRecordReader;
 import org.apache.flink.table.store.file.mergetree.compact.ConcatRecordReader.ReaderSupplier;
 import org.apache.flink.table.store.file.utils.RecordReader;
 import org.apache.flink.table.store.file.utils.RecordReaderIterator;
+import org.apache.flink.table.store.table.sink.TableCommit;
 import org.apache.flink.table.store.table.sink.TableWrite;
 import org.apache.flink.table.store.table.source.Split;
 import org.apache.flink.table.store.table.source.TableRead;
@@ -78,18 +79,18 @@ public abstract class FileStoreTableTestBase {
         FileStoreTable table = createFileStoreTable();
 
         TableWrite write = table.newWrite();
+        TableCommit commit = table.newCommit("user");
         write.write(GenericRowData.of(1, 10, 100L));
         write.write(GenericRowData.of(2, 20, 200L));
-        table.newCommit().commit("0", write.prepareCommit());
+        commit.commit("0", write.prepareCommit());
         write.close();
 
         write = table.newWrite().withOverwrite(true);
+        commit = table.newCommit("user");
         write.write(GenericRowData.of(2, 21, 201L));
         Map<String, String> overwritePartition = new HashMap<>();
         overwritePartition.put("pt", "2");
-        table.newCommit()
-                .withOverwritePartition(overwritePartition)
-                .commit("1", write.prepareCommit());
+        commit.withOverwritePartition(overwritePartition).commit("1", write.prepareCommit());
         write.close();
 
         List<Split> splits = table.newScan().plan().splits;

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/WritePreemptMemoryTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/WritePreemptMemoryTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.schema.UpdateSchema;
 import org.apache.flink.table.store.table.sink.FileCommittable;
+import org.apache.flink.table.store.table.sink.TableCommit;
 import org.apache.flink.table.store.table.sink.TableWrite;
 import org.apache.flink.table.store.table.source.Split;
 import org.apache.flink.table.store.table.source.TableRead;
@@ -62,6 +63,7 @@ public class WritePreemptMemoryTest extends FileStoreTableTestBase {
         // write
         FileStoreTable table = createFileStoreTable();
         TableWrite write = table.newWrite();
+        TableCommit commit = table.newCommit("user");
         Random random = new Random();
         List<String> expected = new ArrayList<>();
         for (int i = 0; i < 10_000; i++) {
@@ -71,7 +73,7 @@ public class WritePreemptMemoryTest extends FileStoreTableTestBase {
             expected.add(BATCH_ROW_TO_STRING.apply(row));
         }
         List<FileCommittable> committables = write.prepareCommit();
-        table.newCommit().commit("0", committables);
+        commit.commit("0", committables);
         write.close();
 
         // read
@@ -102,6 +104,6 @@ public class WritePreemptMemoryTest extends FileStoreTableTestBase {
                                 Arrays.asList("pt", "a"),
                                 conf.toMap(),
                                 ""));
-        return new ChangelogWithKeyFileStoreTable(tablePath, schemaManager, schema, "user");
+        return new ChangelogWithKeyFileStoreTable(tablePath, schemaManager, schema);
     }
 }

--- a/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/avro/AbstractAvroBulkFormat.java
+++ b/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/avro/AbstractAvroBulkFormat.java
@@ -173,7 +173,18 @@ public abstract class AbstractAvroBulkFormat<A, T, SplitT extends FileSourceSpli
                     iterator,
                     currentBlockStart,
                     recordsToSkip,
-                    () -> pool.recycler().recycle(reuse));
+                    new Runnable() {
+                        private boolean shouldRecycle = true;
+
+                        @Override
+                        public void run() {
+                            // make sure this method is reentrant
+                            if (shouldRecycle) {
+                                pool.recycler().recycle(reuse);
+                                shouldRecycle = false;
+                            }
+                        }
+                    });
         }
 
         private boolean readNextBlock() throws IOException {

--- a/flink-table-store-hive/flink-table-store-hive-connector/src/main/java/org/apache/flink/table/store/TableStoreJobConf.java
+++ b/flink-table-store-hive/flink-table-store-hive-connector/src/main/java/org/apache/flink/table/store/TableStoreJobConf.java
@@ -31,7 +31,6 @@ import java.util.Properties;
 public class TableStoreJobConf {
 
     private static final String INTERNAL_LOCATION = "table-store.internal.location";
-    private static final String INTERNAL_FILE_STORE_USER = "table-store.internal.file-store.user";
 
     private final JobConf jobConf;
 
@@ -47,13 +46,5 @@ public class TableStoreJobConf {
 
     public String getLocation() {
         return jobConf.get(INTERNAL_LOCATION);
-    }
-
-    public String getFileStoreUser() {
-        return jobConf.get(INTERNAL_FILE_STORE_USER);
-    }
-
-    public void setFileStoreUser(String user) {
-        jobConf.set(INTERNAL_FILE_STORE_USER, user);
     }
 }

--- a/flink-table-store-hive/flink-table-store-hive-connector/src/main/java/org/apache/flink/table/store/hive/TableStoreHiveStorageHandler.java
+++ b/flink-table-store-hive/flink-table-store-hive-connector/src/main/java/org/apache/flink/table/store/hive/TableStoreHiveStorageHandler.java
@@ -39,7 +39,6 @@ import org.apache.hadoop.mapred.OutputFormat;
 
 import java.util.Map;
 import java.util.Properties;
-import java.util.UUID;
 
 /** {@link HiveStorageHandler} for table store. This is the entrance class of Hive API. */
 public class TableStoreHiveStorageHandler
@@ -85,10 +84,7 @@ public class TableStoreHiveStorageHandler
     public void configureTableJobProperties(TableDesc tableDesc, Map<String, String> map) {}
 
     @Override
-    public void configureJobConf(TableDesc tableDesc, JobConf jobConf) {
-        TableStoreJobConf wrapper = new TableStoreJobConf(jobConf);
-        wrapper.setFileStoreUser(UUID.randomUUID().toString());
-    }
+    public void configureJobConf(TableDesc tableDesc, JobConf jobConf) {}
 
     @Override
     public void setConf(Configuration configuration) {

--- a/flink-table-store-hive/flink-table-store-hive-connector/src/main/java/org/apache/flink/table/store/mapred/TableStoreInputFormat.java
+++ b/flink-table-store-hive/flink-table-store-hive-connector/src/main/java/org/apache/flink/table/store/mapred/TableStoreInputFormat.java
@@ -72,7 +72,7 @@ public class TableStoreInputFormat implements InputFormat<Void, RowDataContainer
         TableStoreJobConf wrapper = new TableStoreJobConf(jobConf);
         Configuration conf = new Configuration();
         conf.set(CoreOptions.PATH, wrapper.getLocation());
-        return FileStoreTableFactory.create(conf, wrapper.getFileStoreUser());
+        return FileStoreTableFactory.create(conf);
     }
 
     private Optional<Predicate> createPredicate(TableSchema tableSchema, JobConf jobConf) {

--- a/flink-table-store-hive/flink-table-store-hive-connector/src/test/java/org/apache/flink/table/store/FileStoreTestUtils.java
+++ b/flink-table-store-hive/flink-table-store-hive-connector/src/test/java/org/apache/flink/table/store/FileStoreTestUtils.java
@@ -47,6 +47,6 @@ public class FileStoreTestUtils {
         // only path, other config should be read from file store.
         conf = new Configuration();
         conf.set(PATH, tablePath.toString());
-        return FileStoreTableFactory.create(conf, "user");
+        return FileStoreTableFactory.create(conf);
     }
 }

--- a/flink-table-store-hive/flink-table-store-hive-connector/src/test/java/org/apache/flink/table/store/hive/TableStoreHiveStorageHandlerITCase.java
+++ b/flink-table-store-hive/flink-table-store-hive-connector/src/test/java/org/apache/flink/table/store/hive/TableStoreHiveStorageHandlerITCase.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.store.CoreOptions;
 import org.apache.flink.table.store.FileStoreTestUtils;
 import org.apache.flink.table.store.hive.objectinspector.TableStoreObjectInspectorFactory;
 import org.apache.flink.table.store.table.FileStoreTable;
+import org.apache.flink.table.store.table.sink.TableCommit;
 import org.apache.flink.table.store.table.sink.TableWrite;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
@@ -101,13 +102,14 @@ public class TableStoreHiveStorageHandlerITCase {
                         Arrays.asList("a", "b"));
 
         TableWrite write = table.newWrite();
+        TableCommit commit = table.newCommit("user");
         write.write(GenericRowData.of(1, 10L, StringData.fromString("Hi")));
         write.write(GenericRowData.of(1, 20L, StringData.fromString("Hello")));
         write.write(GenericRowData.of(2, 30L, StringData.fromString("World")));
         write.write(GenericRowData.of(1, 10L, StringData.fromString("Hi Again")));
         write.write(GenericRowData.ofKind(RowKind.DELETE, 2, 30L, StringData.fromString("World")));
         write.write(GenericRowData.of(2, 40L, StringData.fromString("Test")));
-        table.newCommit().commit("0", write.prepareCommit());
+        commit.commit("0", write.prepareCommit());
         write.close();
 
         hiveShell.execute(
@@ -143,13 +145,14 @@ public class TableStoreHiveStorageHandlerITCase {
                         Collections.emptyList());
 
         TableWrite write = table.newWrite();
+        TableCommit commit = table.newCommit("user");
         write.write(GenericRowData.of(1, 10L, StringData.fromString("Hi")));
         write.write(GenericRowData.of(1, 20L, StringData.fromString("Hello")));
         write.write(GenericRowData.of(2, 30L, StringData.fromString("World")));
         write.write(GenericRowData.of(1, 10L, StringData.fromString("Hi")));
         write.write(GenericRowData.ofKind(RowKind.DELETE, 2, 30L, StringData.fromString("World")));
         write.write(GenericRowData.of(2, 40L, StringData.fromString("Test")));
-        table.newCommit().commit("0", write.prepareCommit());
+        commit.commit("0", write.prepareCommit());
         write.close();
 
         hiveShell.execute(
@@ -192,10 +195,11 @@ public class TableStoreHiveStorageHandlerITCase {
         }
 
         TableWrite write = table.newWrite();
+        TableCommit commit = table.newCommit("user");
         for (GenericRowData rowData : input) {
             write.write(rowData);
         }
-        table.newCommit().commit("0", write.prepareCommit());
+        commit.commit("0", write.prepareCommit());
         write.close();
 
         hiveShell.execute(
@@ -298,18 +302,19 @@ public class TableStoreHiveStorageHandlerITCase {
         // TODO add NaN related tests after FLINK-27627 and FLINK-27628 are fixed
 
         TableWrite write = table.newWrite();
+        TableCommit commit = table.newCommit("user");
         write.write(GenericRowData.of(1));
-        table.newCommit().commit("0", write.prepareCommit());
+        commit.commit("0", write.prepareCommit());
         write.write(GenericRowData.of((Object) null));
-        table.newCommit().commit("1", write.prepareCommit());
+        commit.commit("1", write.prepareCommit());
         write.write(GenericRowData.of(2));
         write.write(GenericRowData.of(3));
         write.write(GenericRowData.of((Object) null));
-        table.newCommit().commit("2", write.prepareCommit());
+        commit.commit("2", write.prepareCommit());
         write.write(GenericRowData.of(4));
         write.write(GenericRowData.of(5));
         write.write(GenericRowData.of(6));
-        table.newCommit().commit("3", write.prepareCommit());
+        commit.commit("3", write.prepareCommit());
         write.close();
 
         hiveShell.execute(
@@ -389,20 +394,21 @@ public class TableStoreHiveStorageHandlerITCase {
                         Collections.emptyList());
 
         TableWrite write = table.newWrite();
+        TableCommit commit = table.newCommit("user");
         write.write(
                 GenericRowData.of(
                         375, /* 1971-01-11 */
                         TimestampData.fromLocalDateTime(
                                 LocalDateTime.of(2022, 5, 17, 17, 29, 20))));
-        table.newCommit().commit("0", write.prepareCommit());
+        commit.commit("0", write.prepareCommit());
         write.write(GenericRowData.of(null, null));
-        table.newCommit().commit("1", write.prepareCommit());
+        commit.commit("1", write.prepareCommit());
         write.write(GenericRowData.of(376 /* 1971-01-12 */, null));
         write.write(
                 GenericRowData.of(
                         null,
                         TimestampData.fromLocalDateTime(LocalDateTime.of(2022, 6, 18, 8, 30, 0))));
-        table.newCommit().commit("2", write.prepareCommit());
+        commit.commit("2", write.prepareCommit());
         write.close();
 
         hiveShell.execute(

--- a/flink-table-store-hive/flink-table-store-hive-connector/src/test/java/org/apache/flink/table/store/mapred/TableStoreRecordReaderTest.java
+++ b/flink-table-store-hive/flink-table-store-hive-connector/src/test/java/org/apache/flink/table/store/mapred/TableStoreRecordReaderTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.store.RowDataContainer;
 import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.utils.RecordReader;
 import org.apache.flink.table.store.table.FileStoreTable;
+import org.apache.flink.table.store.table.sink.TableCommit;
 import org.apache.flink.table.store.table.sink.TableWrite;
 import org.apache.flink.table.store.table.source.Split;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -72,12 +73,13 @@ public class TableStoreRecordReaderTest {
                         Collections.singletonList("a"));
 
         TableWrite write = table.newWrite();
+        TableCommit commit = table.newCommit("user");
         write.write(GenericRowData.of(1L, StringData.fromString("Hi")));
         write.write(GenericRowData.of(2L, StringData.fromString("Hello")));
         write.write(GenericRowData.of(3L, StringData.fromString("World")));
         write.write(GenericRowData.of(1L, StringData.fromString("Hi again")));
         write.write(GenericRowData.ofKind(RowKind.DELETE, 2L, StringData.fromString("Hello")));
-        table.newCommit().commit("0", write.prepareCommit());
+        commit.commit("0", write.prepareCommit());
 
         Tuple2<RecordReader<RowData>, Long> tuple = read(table, BinaryRowDataUtil.EMPTY_ROW, 0);
         TableStoreRecordReader reader = new TableStoreRecordReader(tuple.f0, tuple.f1);
@@ -113,13 +115,14 @@ public class TableStoreRecordReaderTest {
                         Collections.emptyList());
 
         TableWrite write = table.newWrite();
+        TableCommit commit = table.newCommit("user");
         write.write(GenericRowData.of(1, StringData.fromString("Hi")));
         write.write(GenericRowData.of(2, StringData.fromString("Hello")));
         write.write(GenericRowData.of(3, StringData.fromString("World")));
         write.write(GenericRowData.of(1, StringData.fromString("Hi")));
         write.write(GenericRowData.ofKind(RowKind.DELETE, 2, StringData.fromString("Hello")));
         write.write(GenericRowData.of(1, StringData.fromString("Hi")));
-        table.newCommit().commit("0", write.prepareCommit());
+        commit.commit("0", write.prepareCommit());
 
         Tuple2<RecordReader<RowData>, Long> tuple = read(table, BinaryRowDataUtil.EMPTY_ROW, 0);
         TableStoreRecordReader reader = new TableStoreRecordReader(tuple.f0, tuple.f1);

--- a/flink-table-store-spark/src/test/java/org/apache/flink/table/store/spark/SimpleTableTestHelper.java
+++ b/flink-table-store-spark/src/test/java/org/apache/flink/table/store/spark/SimpleTableTestHelper.java
@@ -55,9 +55,9 @@ public class SimpleTableTestHelper {
                                 ""));
         Configuration conf = Configuration.fromMap(options);
         conf.setString("path", path.toString());
-        FileStoreTable table = FileStoreTableFactory.create(conf, "user");
+        FileStoreTable table = FileStoreTableFactory.create(conf);
         this.writer = table.newWrite();
-        this.commit = table.newCommit();
+        this.commit = table.newCommit("user");
     }
 
     public void write(RowData row) throws Exception {

--- a/pom.xml
+++ b/pom.xml
@@ -422,7 +422,6 @@ under the License.
                     <trimStackTrace>false</trimStackTrace>
                     <systemPropertyVariables>
                         <forkNumber>0${surefire.forkNumber}</forkNumber>
-                        <checkpointing.randomization>true</checkpointing.randomization>
                         <project.basedir>${project.basedir}</project.basedir>
                         <!--suppress MavenModelInspection -->
                         <test.randomization.seed>${test.randomization.seed}</test.randomization.seed>


### PR DESCRIPTION
Currently commit user name is not stored in state. If user stop with savepoint and later recover the job, commit user name will change and may commit duplicated snapshots to file store. This PR fixes this issue.

This PR also corrects the behavior of `endInput` method in `CommitOperator`. According to the docs in `BoundedOneInput` this method should only flush data and should never commit.