### PR TITLE
[FLINK-28110] Support projection pushdown for Hive readers

### DIFF
--- a/flink-table-store-common/src/main/java/org/apache/flink/table/store/utils/ProjectedRowData.java
+++ b/flink-table-store-common/src/main/java/org/apache/flink/table/store/utils/ProjectedRowData.java
@@ -80,6 +80,9 @@ public class ProjectedRowData implements RowData {
 
     @Override
     public boolean isNullAt(int pos) {
+        if (indexMapping[pos] < 0) {
+            return true;
+        }
         return row.isNullAt(indexMapping[pos]);
     }
 

--- a/flink-table-store-hive/flink-table-store-hive-connector/src/main/java/org/apache/flink/table/store/mapred/TableStoreInputSplit.java
+++ b/flink-table-store-hive/flink-table-store-hive-connector/src/main/java/org/apache/flink/table/store/mapred/TableStoreInputSplit.java
@@ -50,10 +50,6 @@ public class TableStoreInputSplit extends FileSplit {
         this.split = split;
     }
 
-    public static TableStoreInputSplit create(String path, Split split) {
-        return new TableStoreInputSplit(path, split);
-    }
-
     public Split split() {
         return split;
     }

--- a/flink-table-store-hive/flink-table-store-hive-connector/src/main/java/org/apache/flink/table/store/mapred/TableStoreRecordReader.java
+++ b/flink-table-store-hive/flink-table-store-hive-connector/src/main/java/org/apache/flink/table/store/mapred/TableStoreRecordReader.java
@@ -22,12 +22,13 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.RowDataContainer;
 import org.apache.flink.table.store.file.KeyValue;
 import org.apache.flink.table.store.file.utils.RecordReaderIterator;
-
 import org.apache.flink.table.store.table.source.TableRead;
 import org.apache.flink.table.store.utils.ProjectedRowData;
+
 import org.apache.hadoop.mapred.RecordReader;
 
 import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.List;
 

--- a/flink-table-store-hive/flink-table-store-hive-connector/src/main/java/org/apache/flink/table/store/mapred/TableStoreRecordReader.java
+++ b/flink-table-store-hive/flink-table-store-hive-connector/src/main/java/org/apache/flink/table/store/mapred/TableStoreRecordReader.java
@@ -35,6 +35,10 @@ import java.util.List;
 /**
  * Base {@link RecordReader} for table store. Reads {@link KeyValue}s from data files and picks out
  * {@link RowData} for Hive to consume.
+ *
+ * <p>NOTE: To support projection push down, when {@code selectedColumns} does not match {@code
+ * columnNames} this reader will still produce records of the original schema. However, columns not
+ * in {@code selectedColumns} will be null.
  */
 public class TableStoreRecordReader implements RecordReader<Void, RowDataContainer> {
 
@@ -74,8 +78,7 @@ public class TableStoreRecordReader implements RecordReader<Void, RowDataContain
             return false;
         } else {
             if (reusedProjectedRow != null) {
-                reusedProjectedRow.replaceRow(rowData);
-                value.set(reusedProjectedRow);
+                value.set(reusedProjectedRow.replaceRow(rowData));
             } else {
                 value.set(rowData);
             }


### PR DESCRIPTION
As Hive 2 only provides selected column names and requires the source not to change the schema, we implement projection pushdown by only reading selected columns from files and set the other columns to null.