### PR TITLE
[hotfix] CommitterOperator#endInput should also commit snapshots for batch jobs even if checkpoint interval is set

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/CommitterOperator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/CommitterOperator.java
@@ -59,7 +59,7 @@ public class CommitterOperator extends AbstractStreamOperator<Committable>
      * checkpoint is not enabled we need to commit remaining data in {@link
      * CommitterOperator#endInput}.
      */
-    private final boolean checkpointEnabled;
+    private final boolean streamingCheckpointEnabled;
 
     /** Group the committable by the checkpoint id. */
     private final NavigableMap<Long, ManifestCommittable> committablesPerCheckpoint;
@@ -80,11 +80,11 @@ public class CommitterOperator extends AbstractStreamOperator<Committable>
     private Committer committer;
 
     public CommitterOperator(
-            boolean checkpointEnabled,
+            boolean streamingCheckpointEnabled,
             SerializableFunction<String, Committer> committerFactory,
             SerializableSupplier<SimpleVersionedSerializer<ManifestCommittable>>
                     committableSerializer) {
-        this.checkpointEnabled = checkpointEnabled;
+        this.streamingCheckpointEnabled = streamingCheckpointEnabled;
         this.committableSerializer = committableSerializer;
         this.committablesPerCheckpoint = new TreeMap<>();
         this.committerFactory = checkNotNull(committerFactory);
@@ -165,7 +165,7 @@ public class CommitterOperator extends AbstractStreamOperator<Committable>
 
     @Override
     public void endInput() throws Exception {
-        if (checkpointEnabled) {
+        if (streamingCheckpointEnabled) {
             return;
         }
 

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/FlinkSinkBuilder.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/FlinkSinkBuilder.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.table.store.connector.sink;
 
+import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -106,7 +108,9 @@ public class FlinkSinkBuilder {
                 new StoreSink(
                         tableIdentifier,
                         table,
-                        env.getCheckpointConfig().isCheckpointingEnabled(),
+                        env.getConfiguration().get(ExecutionOptions.RUNTIME_MODE)
+                                        == RuntimeExecutionMode.STREAMING
+                                && env.getCheckpointConfig().isCheckpointingEnabled(),
                         conf.get(FlinkConnectorOptions.COMPACTION_MANUAL_TRIGGERED),
                         getCompactPartSpec(),
                         lockFactory,

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSink.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSink.java
@@ -50,7 +50,7 @@ public class StoreSink implements Serializable {
 
     private final FileStoreTable table;
 
-    private final boolean checkpointEnabled;
+    private final boolean streamingCheckpointEnabled;
 
     private final boolean compactionTask;
 
@@ -65,7 +65,7 @@ public class StoreSink implements Serializable {
     public StoreSink(
             ObjectIdentifier tableIdentifier,
             FileStoreTable table,
-            boolean checkpointEnabled,
+            boolean streamingCheckpointEnabled,
             boolean compactionTask,
             @Nullable Map<String, String> compactPartitionSpec,
             @Nullable CatalogLock.Factory lockFactory,
@@ -73,7 +73,7 @@ public class StoreSink implements Serializable {
             @Nullable LogSinkFunction logSinkFunction) {
         this.tableIdentifier = tableIdentifier;
         this.table = table;
-        this.checkpointEnabled = checkpointEnabled;
+        this.streamingCheckpointEnabled = streamingCheckpointEnabled;
         this.compactionTask = compactionTask;
         this.compactPartitionSpec = compactPartitionSpec;
         this.lockFactory = lockFactory;
@@ -124,7 +124,7 @@ public class StoreSink implements Serializable {
                                 GLOBAL_COMMITTER_NAME,
                                 typeInfo,
                                 new CommitterOperator(
-                                        checkpointEnabled,
+                                        streamingCheckpointEnabled,
                                         this::createCommitter,
                                         ManifestCommittableSerializer::new))
                         .setParallelism(1)


### PR DESCRIPTION
Current implementation of `CommitterOperator#endInput` only checks for checkpoint interval but forgets to check if this job is also a batch job. This PR fixes this issue.