### PR TITLE
[FLINK-27103] Don't store redundant primary key fields

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileReader.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileReader.java
@@ -83,7 +83,9 @@ public class DataFileReader {
             long fileSize = FileUtils.getFileSize(path);
             FileSourceSplit split = new FileSourceSplit("ignore", path, 0, fileSize);
             this.reader = readerFactory.createReader(FileUtils.DEFAULT_READER_CONFIG, split);
-            this.serializer = new KeyValueSerializer(keyType, valueType);
+            this.serializer =
+                    new KeyValueSerializer(
+                            keyType, valueType, schemaManager.schemaIfExists(schemaId));
         }
 
         @Nullable

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeWriter.java
@@ -28,9 +28,12 @@ import org.apache.flink.table.store.file.memory.MemoryOwner;
 import org.apache.flink.table.store.file.mergetree.compact.CompactManager;
 import org.apache.flink.table.store.file.mergetree.compact.CompactResult;
 import org.apache.flink.table.store.file.mergetree.compact.MergeFunction;
+import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.writer.RecordWriter;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.CloseableIterator;
+
+import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -71,6 +74,8 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
 
     private final LinkedHashSet<DataFileMeta> compactAfter;
 
+    private final @Nullable TableSchema tableSchema;
+
     private long newSequenceNumber;
 
     private MemTable memTable;
@@ -86,7 +91,8 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
             DataFileWriter dataFileWriter,
             boolean commitForceCompact,
             int numSortedRunStopTrigger,
-            boolean enableChangelogFile) {
+            boolean enableChangelogFile,
+            @Nullable TableSchema tableSchema) {
         this.keyType = keyType;
         this.valueType = valueType;
         this.compactManager = compactManager;
@@ -101,6 +107,7 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
         this.newFiles = new LinkedHashSet<>();
         this.compactBefore = new LinkedHashMap<>();
         this.compactAfter = new LinkedHashSet<>();
+        this.tableSchema = tableSchema;
     }
 
     private long newSequenceNumber() {
@@ -114,7 +121,7 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
 
     @Override
     public void setMemoryPool(MemorySegmentPool memoryPool) {
-        this.memTable = new SortBufferMemTable(keyType, valueType, memoryPool);
+        this.memTable = new SortBufferMemTable(keyType, valueType, memoryPool, tableSchema);
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreWrite.java
@@ -37,6 +37,7 @@ import org.apache.flink.table.store.file.mergetree.compact.CompactUnit;
 import org.apache.flink.table.store.file.mergetree.compact.MergeFunction;
 import org.apache.flink.table.store.file.mergetree.compact.UniversalCompaction;
 import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 import org.apache.flink.table.store.file.utils.RecordReaderIterator;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
@@ -61,6 +62,7 @@ public class KeyValueFileStoreWrite extends AbstractFileStoreWrite<KeyValue> {
     private final Supplier<Comparator<RowData>> keyComparatorSupplier;
     private final MergeFunction mergeFunction;
     private final CoreOptions options;
+    private final TableSchema tableSchema;
 
     public KeyValueFileStoreWrite(
             SchemaManager schemaManager,
@@ -89,6 +91,7 @@ public class KeyValueFileStoreWrite extends AbstractFileStoreWrite<KeyValue> {
         this.keyComparatorSupplier = keyComparatorSupplier;
         this.mergeFunction = mergeFunction;
         this.options = options;
+        this.tableSchema = schemaManager.schemaIfExists(schemaId);
     }
 
     @Override
@@ -143,7 +146,8 @@ public class KeyValueFileStoreWrite extends AbstractFileStoreWrite<KeyValue> {
                 dataFileWriter,
                 options.commitForceCompact(),
                 options.numSortedRunStopTrigger(),
-                options.enableChangelogFile());
+                options.enableChangelogFile(),
+                tableSchema);
     }
 
     private CompactManager createCompactManager(

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.store.file.utils.JsonSerdeUtil;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Preconditions;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
@@ -156,6 +157,10 @@ public class SchemaManager implements Serializable {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    public TableSchema schemaIfExists(long id) {
+        return new File(toSchemaPath(id).getPath()).exists() ? schema(id) : null;
     }
 
     private Path schemaDirectory() {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
@@ -94,15 +94,16 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
                         tableSchema.id(),
                         new CoreOptions(conf),
                         tableSchema.logicalPartitionType(),
-                        addKeyNamePrefix(tableSchema.logicalBucketKeyType()),
-                        addKeyNamePrefix(tableSchema.logicalTrimmedPrimaryKeysType()),
+                        addKeyNamePrefix(false, tableSchema.logicalBucketKeyType()),
+                        addKeyNamePrefix(true, tableSchema.logicalTrimmedPrimaryKeysType()),
                         rowType,
                         mergeFunction);
     }
 
-    private RowType addKeyNamePrefix(RowType type) {
+    private RowType addKeyNamePrefix(boolean isNullable, RowType type) {
         // add prefix to avoid conflict with value
         return new RowType(
+                isNullable,
                 type.getFields().stream()
                         .map(
                                 f ->

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/SinkRecord.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/SinkRecord.java
@@ -22,6 +22,8 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.types.RowKind;
 
+import javax.annotation.Nullable;
+
 import static org.apache.flink.util.Preconditions.checkArgument;
 
 /** A sink record contains key, row and partition, bucket information. */
@@ -31,9 +33,18 @@ public class SinkRecord {
 
     private final int bucket;
 
-    private final BinaryRowData primaryKey;
+    private final @Nullable BinaryRowData primaryKey;
 
     private final RowData row;
+
+    public SinkRecord(BinaryRowData partition, int bucket, RowData row) {
+        checkArgument(partition.getRowKind() == RowKind.INSERT);
+        this.partition = partition;
+        this.bucket = bucket;
+        this.row = row;
+        // Avoid redundant storage for primary key.
+        this.primaryKey = null;
+    }
 
     public SinkRecord(BinaryRowData partition, int bucket, BinaryRowData primaryKey, RowData row) {
         checkArgument(partition.getRowKind() == RowKind.INSERT);

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/SinkRecordConverter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/SinkRecordConverter.java
@@ -78,9 +78,8 @@ public class SinkRecordConverter {
 
     public SinkRecord convert(RowData row) {
         BinaryRowData partition = partProjection.apply(row);
-        BinaryRowData primaryKey = primaryKey(row);
-        int bucket = bucket(row, bucketKey(row, primaryKey));
-        return new SinkRecord(partition, bucket, primaryKey, row);
+        int bucket = bucket(row, bucketKey(row, primaryKey(row)));
+        return new SinkRecord(partition, bucket, row);
     }
 
     public SinkRecord convertToLogSinkRecord(SinkRecord record) {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/MergeTreeTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/MergeTreeTest.java
@@ -278,7 +278,8 @@ public class MergeTreeTest {
                         dataFileWriter,
                         options.commitForceCompact(),
                         options.numSortedRunStopTrigger(),
-                        false);
+                        false,
+                        null);
         writer.setMemoryPool(
                 new HeapMemorySegmentPool(options.writeBufferSize(), options.pageSize()));
         return writer;

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/SortBufferMemTableTestBase.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/SortBufferMemTableTestBase.java
@@ -55,7 +55,8 @@ public abstract class SortBufferMemTableTestBase {
                     new RowType(
                             Collections.singletonList(
                                     new RowType.RowField("value", new BigIntType()))),
-                    new HeapMemorySegmentPool(32 * 1024 * 3L, 32 * 1024));
+                    new HeapMemorySegmentPool(32 * 1024 * 3L, 32 * 1024),
+                    null);
 
     protected abstract boolean addOnly();
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTableTest.java
@@ -66,7 +66,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         List<Split> splits = table.newScan().plan().splits;
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING))
-                .isEqualTo(Arrays.asList("1|10|200", "1|11|101"));
+                .isEqualTo(Arrays.asList("1|10|100", "1|11|101", "1|10|200", "1|11|55"));
     }
 
     @Test
@@ -79,7 +79,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING))
                 .isEqualTo(Collections.singletonList("1|10|1000"));
         assertThat(getResult(read, splits, binaryRow(2), 0, BATCH_ROW_TO_STRING))
-                .isEqualTo(Arrays.asList("2|21|20001", "2|22|202"));
+                .isEqualTo(Arrays.asList("2|20|200", "2|21|20001", "2|22|202", "2|21|2001"));
     }
 
     @Test
@@ -92,7 +92,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_PROJECTED_ROW_TO_STRING))
                 .isEqualTo(Collections.singletonList("1000|10"));
         assertThat(getResult(read, splits, binaryRow(2), 0, BATCH_PROJECTED_ROW_TO_STRING))
-                .isEqualTo(Arrays.asList("20001|21", "202|22"));
+                .isEqualTo(Arrays.asList("200|20", "20001|21", "202|22", "2001|21"));
     }
 
     @Test
@@ -110,7 +110,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
                         Arrays.asList(
                                 // only filter on key should be performed,
                                 // and records from the same file should also be selected
-                                "2|21|20001", "2|22|202"));
+                                "2|21|20001", "2|22|202", "2|21|2001"));
     }
 
     @Test
@@ -123,7 +123,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_ROW_TO_STRING))
                 .isEqualTo(Collections.singletonList("-1|11|1001"));
         assertThat(getResult(read, splits, binaryRow(2), 0, STREAMING_ROW_TO_STRING))
-                .isEqualTo(Arrays.asList("-2|20|200", "+2|21|20001", "+2|22|202"));
+                .isEqualTo(Arrays.asList("+2|21|20001", "+2|22|202", "-2|20|200"));
     }
 
     @Test
@@ -137,7 +137,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_PROJECTED_ROW_TO_STRING))
                 .isEqualTo(Collections.singletonList("-1001|11"));
         assertThat(getResult(read, splits, binaryRow(2), 0, STREAMING_PROJECTED_ROW_TO_STRING))
-                .isEqualTo(Arrays.asList("-200|20", "+20001|21", "+202|22"));
+                .isEqualTo(Arrays.asList("+20001|21", "+202|22", "-200|20"));
     }
 
     @Test
@@ -156,7 +156,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
                         Arrays.asList(
                                 // only filter on key should be performed,
                                 // and records from the same file should also be selected
-                                "-2|20|200", "+2|21|20001", "+2|22|202"));
+                                "+2|21|20001", "+2|22|202", "-2|20|200"));
     }
 
     @Test


### PR DESCRIPTION
`ChangelogWithKeyFileStoreTable` currently stores the primary key redundantly in the file, which could directly use the primary key field in the original fields to avoid redundant storage.

**The brief change log**
- The `primaryKey` of `SinkRecord` is set to null for `ChangelogWithKeyFileStoreTable` and `KeyValueSerializer` reads the primary key from the value.