### PR TITLE
[FLINK-28108] Support "ALTER TABLE ... COMPACT" for append-only table

### DIFF
--- a/flink-table-store-connector/src/main/1.15.0/org/apache/flink/table/store/connector/TableStoreManagedFactory.java
+++ b/flink-table-store-connector/src/main/1.15.0/org/apache/flink/table/store/connector/TableStoreManagedFactory.java
@@ -29,7 +29,6 @@ import org.apache.flink.table.store.file.utils.JsonSerdeUtil;
 import org.apache.flink.table.store.log.LogStoreTableFactory;
 import org.apache.flink.util.Preconditions;
 
-
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.HashMap;
@@ -84,7 +83,8 @@ public class TableStoreManagedFactory extends AbstractTableStoreFactory
                 createOptionalLogStoreFactory(context.getClassLoader(), enrichedOptions);
         logFactory.ifPresent(
                 factory ->
-                        factory.enrichOptions(new TableStoreDynamicContext(context, enrichedOptions))
+                        factory.enrichOptions(
+                                        new TableStoreDynamicContext(context, enrichedOptions))
                                 .forEach(enrichedOptions::putIfAbsent));
 
         return enrichedOptions;
@@ -167,20 +167,13 @@ public class TableStoreManagedFactory extends AbstractTableStoreFactory
             throw new UncheckedIOException(e);
         }
         createOptionalLogStoreFactory(context)
-                .ifPresent(
-                        factory ->
-                                factory.onDropTable(context, ignoreIfNotExists));
+                .ifPresent(factory -> factory.onDropTable(context, ignoreIfNotExists));
     }
 
     @Override
     public Map<String, String> onCompactTable(
             Context context, CatalogPartitionSpec catalogPartitionSpec) {
         Map<String, String> newOptions = new HashMap<>(context.getCatalogTable().getOptions());
-        if (APPEND_ONLY.toString().equals(newOptions.get(CoreOptions.WRITE_MODE.key()))) {
-            throw new UnsupportedOperationException(
-                    "ALTER TABLE COMPACT is not yet supported for append only table.");
-        }
-
         newOptions.put(COMPACTION_MANUAL_TRIGGERED.key(), String.valueOf(true));
         newOptions.put(
                 COMPACTION_PARTITION_SPEC.key(),

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreManagedFactoryTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreManagedFactoryTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.factories.DynamicTableFactory;
 import org.apache.flink.table.factories.FactoryUtil;
-import org.apache.flink.table.store.CoreOptions;
 import org.apache.flink.table.store.file.utils.JsonSerdeUtil;
 import org.apache.flink.table.store.table.FileStoreTable;
 import org.apache.flink.table.types.logical.RowType;
@@ -69,7 +68,6 @@ import static org.apache.flink.table.store.file.TestKeyValueGenerator.DEFAULT_PA
 import static org.apache.flink.table.store.file.TestKeyValueGenerator.DEFAULT_ROW_TYPE;
 import static org.apache.flink.table.store.file.TestKeyValueGenerator.GeneratorMode.MULTI_PARTITIONED;
 import static org.apache.flink.table.store.file.TestKeyValueGenerator.getPrimaryKeys;
-import static org.apache.flink.table.store.file.WriteMode.APPEND_ONLY;
 import static org.apache.flink.table.store.kafka.KafkaLogOptions.BOOTSTRAP_SERVERS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -244,20 +242,6 @@ public class TableStoreManagedFactoryTest {
                 .containsEntry(COMPACTION_MANUAL_TRIGGERED.key(), String.valueOf(true));
         assertThat(newOptions)
                 .containsEntry(COMPACTION_PARTITION_SPEC.key(), JsonSerdeUtil.toJson(partSpec));
-    }
-
-    @Test
-    public void testOnCompactAppendOnlyTable() {
-        context =
-                createEnrichedContext(
-                        Collections.singletonMap(
-                                CoreOptions.WRITE_MODE.key(), APPEND_ONLY.toString()));
-        assertThatThrownBy(
-                        () ->
-                                tableStoreManagedFactory.onCompactTable(
-                                        context, new CatalogPartitionSpec(Collections.emptyMap())))
-                .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessage("ALTER TABLE COMPACT is not yet supported for append only table.");
     }
 
     // ~ Tools ------------------------------------------------------------------

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AppendOnlyFileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AppendOnlyFileStoreWrite.java
@@ -95,8 +95,15 @@ public class AppendOnlyFileStoreWrite extends AbstractFileStoreWrite<RowData> {
     @Override
     public Callable<CompactResult> createCompactWriter(
             BinaryRowData partition, int bucket, @Nullable List<DataFileMeta> compactFiles) {
-        throw new UnsupportedOperationException(
-                "Currently append only write mode does not support compaction.");
+        if (compactFiles == null) {
+            compactFiles = scanExistingFileMetas(partition, bucket);
+        }
+        return new AppendOnlyCompactManager.RollingCompactTask(
+                compactFiles,
+                targetFileSize,
+                minFileNum,
+                maxFileNum,
+                compactRewriter(partition, bucket));
     }
 
     private RecordWriter<RowData> createWriter(

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AppendOnlyFileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AppendOnlyFileStoreWrite.java
@@ -98,12 +98,13 @@ public class AppendOnlyFileStoreWrite extends AbstractFileStoreWrite<RowData> {
         if (compactFiles == null) {
             compactFiles = scanExistingFileMetas(partition, bucket);
         }
-        return new AppendOnlyCompactManager.RollingCompactTask(
+        return new AppendOnlyCompactManager.IterativeCompactTask(
                 compactFiles,
                 targetFileSize,
                 minFileNum,
                 maxFileNum,
-                compactRewriter(partition, bucket));
+                compactRewriter(partition, bucket),
+                pathFactory.createDataFilePathFactory(partition, bucket));
     }
 
     private RecordWriter<RowData> createWriter(

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/AppendOnlyCompactManagerTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/AppendOnlyCompactManagerTest.java
@@ -200,12 +200,13 @@ public class AppendOnlyCompactManagerTest {
         long targetFileSize = 1024;
         AppendOnlyCompactManager manager =
                 new AppendOnlyCompactManager(
-                        null,
+                        null, // not used
                         new LinkedList<>(toCompactBeforePick),
                         minFileNum,
                         maxFileNum,
                         targetFileSize,
-                        null);
+                        null // not used
+                        );
         Optional<List<DataFileMeta>> actual = manager.pickCompactBefore();
         assertThat(actual.isPresent()).isEqualTo(expectedPresent);
         if (expectedPresent) {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/RollingCompactTaskTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/RollingCompactTaskTest.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.data;
+
+import org.apache.flink.table.store.file.compact.CompactResult;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.table.store.file.data.DataFileTestUtils.newFile;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/** Test for {@link RollingCompactTaskTest}. */
+public class RollingCompactTaskTest {
+
+    private static final long TARGET_FILE_SIZE = 1024L;
+    private static final int MIN_FILE_NUM = 3;
+    private static final int MAX_FILE_NUM = 10;
+
+    @Test
+    public void testNoCompact() {
+        // empty
+        innerTest(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+
+        // single small file
+        innerTest(
+                Collections.singletonList(newFile(1L, 10L)),
+                Collections.emptyList(),
+                Collections.emptyList());
+
+        // single large file
+        innerTest(
+                Collections.singletonList(newFile(1L, 1024L)),
+                Collections.emptyList(),
+                Collections.emptyList());
+
+        // almost-full files
+        innerTest(
+                Arrays.asList(newFile(1L, 1024L), newFile(2L, 2048L)),
+                Collections.emptyList(),
+                Collections.emptyList());
+
+        // large files
+        innerTest(
+                Arrays.asList(newFile(1L, 1000L), newFile(1001L, 1100L)),
+                Collections.emptyList(),
+                Collections.emptyList());
+    }
+
+    @Test
+    public void testCompactOnce() {
+        // small files on the head
+        innerTest(
+                Arrays.asList(
+                        newFile(1L, 500L),
+                        newFile(501L, 1000L),
+                        newFile(1001L, 1010L),
+                        newFile(1011L, 1024L),
+                        newFile(1025L, 3000L)),
+                Arrays.asList(
+                        newFile(1L, 500L),
+                        newFile(501L, 1000L),
+                        newFile(1001L, 1010L),
+                        newFile(1011L, 1024L)),
+                Collections.singletonList(newFile(1L, 1024L)));
+
+        innerTest(
+                Arrays.asList(
+                        newFile(1L, 500L),
+                        newFile(501L, 1000L),
+                        newFile(1001L, 1010L),
+                        newFile(1011L, 2000L),
+                        newFile(2001L, 3000L)),
+                Arrays.asList(
+                        newFile(1L, 500L),
+                        newFile(501L, 1000L),
+                        newFile(1001L, 1010L),
+                        newFile(1011L, 2000L)),
+                Arrays.asList(newFile(1L, 1024L), newFile(1025L, 2000L)));
+
+        // small files in the middle
+        innerTest(
+                Arrays.asList(
+                        newFile(1L, 2000L),
+                        newFile(2001L, 4000L),
+                        newFile(4001L, 4500L),
+                        newFile(4501L, 4600L),
+                        newFile(4601L, 4700L),
+                        newFile(4701L, 5024L),
+                        newFile(5025L, 7000L)),
+                Arrays.asList(
+                        newFile(4001L, 4500L),
+                        newFile(4501L, 4600L),
+                        newFile(4601L, 4700L),
+                        newFile(4701L, 5024L)),
+                Collections.singletonList(newFile(4001L, 5024L)));
+
+        // small files on the tail
+        innerTest(
+                Arrays.asList(
+                        newFile(1L, 2000L),
+                        newFile(2001L, 4000L),
+                        newFile(4001L, 4010L),
+                        newFile(4011L, 4020L),
+                        newFile(4021L, 4030L),
+                        newFile(4031L, 4040L),
+                        newFile(4041L, 4050L),
+                        newFile(4051L, 4060L),
+                        newFile(4061L, 4070L),
+                        newFile(4071L, 4080L),
+                        newFile(4081L, 4090L),
+                        newFile(4091L, 4110L)),
+                Arrays.asList(
+                        newFile(4001L, 4010L),
+                        newFile(4011L, 4020L),
+                        newFile(4021L, 4030L),
+                        newFile(4031L, 4040L),
+                        newFile(4041L, 4050L),
+                        newFile(4051L, 4060L),
+                        newFile(4061L, 4070L),
+                        newFile(4071L, 4080L),
+                        newFile(4081L, 4090L),
+                        newFile(4091L, 4110L)),
+                Collections.singletonList(newFile(4001L, 4110L)));
+    }
+
+    @Test
+    public void testCompactMultiple() {
+        // continuous compact
+        innerTest(
+                Arrays.asList(
+                        newFile(1L, 2000L),
+                        newFile(2001L, 4000L),
+                        // 4001~4010, ..., 4091~4110
+                        newFile(4001L, 4010L),
+                        newFile(4011L, 4020L),
+                        newFile(4021L, 4030L),
+                        newFile(4031L, 4040L),
+                        newFile(4041L, 4050L),
+                        newFile(4051L, 4060L),
+                        newFile(4061L, 4070L),
+                        newFile(4071L, 4080L),
+                        newFile(4081L, 4090L),
+                        newFile(4091L, 4110L),
+                        // 4001~4110, 5015~5024
+                        newFile(4111L, 5000L),
+                        newFile(5001L, 5014L),
+                        newFile(5015L, 5024L)),
+                Arrays.asList(
+                        newFile(4001L, 4010L),
+                        newFile(4011L, 4020L),
+                        newFile(4021L, 4030L),
+                        newFile(4031L, 4040L),
+                        newFile(4041L, 4050L),
+                        newFile(4051L, 4060L),
+                        newFile(4061L, 4070L),
+                        newFile(4071L, 4080L),
+                        newFile(4081L, 4090L),
+                        newFile(4091L, 4110L),
+                        newFile(4111L, 5000L),
+                        newFile(5001L, 5014L),
+                        newFile(5015L, 5024L)),
+                Collections.singletonList(newFile(4001L, 5024L)));
+
+        // alternate compact
+        innerTest(
+                Arrays.asList(
+                        newFile(1L, 2000L),
+                        newFile(2001L, 4000L),
+                        // 4001~4500, ..., 4701~6000
+                        newFile(4001L, 4500L),
+                        newFile(4501L, 4600L),
+                        newFile(4601L, 4700L),
+                        newFile(4701L, 6000L),
+                        newFile(6001L, 7500L),
+                        // 7501~8000, 8201~8900
+                        newFile(7501L, 8000L),
+                        newFile(8001L, 8200L),
+                        newFile(8201L, 8900L),
+                        newFile(8901L, 9550L)),
+                Arrays.asList(
+                        newFile(4001L, 4500L),
+                        newFile(4501L, 4600L),
+                        newFile(4601L, 4700L),
+                        newFile(4701L, 6000L),
+                        newFile(7501L, 8000L),
+                        newFile(8001L, 8200L),
+                        newFile(8201L, 8900L)),
+                Arrays.asList(
+                        newFile(4001L, 5024L),
+                        newFile(5025L, 6000L),
+                        newFile(7501L, 8524L),
+                        newFile(8525L, 8900L)));
+    }
+
+    private void innerTest(
+            List<DataFileMeta> compactFiles,
+            List<DataFileMeta> expectBefore,
+            List<DataFileMeta> expectAfter) {
+        AppendOnlyCompactManager.RollingCompactTask task =
+                new AppendOnlyCompactManager.RollingCompactTask(
+                        compactFiles, TARGET_FILE_SIZE, MIN_FILE_NUM, MAX_FILE_NUM, rewriter());
+        try {
+            CompactResult actual = task.doCompact(compactFiles);
+            assertThat(actual.before()).containsExactlyInAnyOrderElementsOf(expectBefore);
+            assertThat(actual.after()).containsExactlyInAnyOrderElementsOf(expectAfter);
+        } catch (Exception e) {
+            fail("This should not happen");
+        }
+    }
+
+    private AppendOnlyCompactManager.CompactRewriter rewriter() {
+        return compactBefore -> {
+            List<DataFileMeta> compactAfter = new ArrayList<>();
+            long totalFileSize = 0L;
+            long minSeq = -1L;
+            for (int i = 0; i < compactBefore.size(); i++) {
+                DataFileMeta file = compactBefore.get(i);
+                if (i == 0) {
+                    minSeq = file.minSequenceNumber();
+                }
+                totalFileSize += file.fileSize();
+                if (totalFileSize >= TARGET_FILE_SIZE) {
+                    compactAfter.add(newFile(minSeq, minSeq + TARGET_FILE_SIZE - 1));
+                    minSeq += TARGET_FILE_SIZE;
+                }
+                if (i == compactBefore.size() - 1 && minSeq <= file.maxSequenceNumber()) {
+                    compactAfter.add(newFile(minSeq, file.maxSequenceNumber()));
+                }
+            }
+            return compactAfter;
+        };
+    }
+}


### PR DESCRIPTION
Compact tasks differ between auto-compact and "ALTER TABLE ... COMPACT"
- auto-compact task will pick the first qualified candidates to rewrite, and the AppendOnlyWriter must invoke the next compaction.
- "ALTER TABLE ... COMPACT" will perform a whole scan of the input, and within one task, there might be multiple times of rewrite happens.