### PR TITLE
[FLINK-28560] Support Spark 3.3 profile for SparkSource

### DIFF
--- a/docs/content/docs/engines/overview.md
+++ b/docs/content/docs/engines/overview.md
@@ -41,5 +41,6 @@ Apache Hive and Apache Spark.
 | Spark     | 3.0      | read                                                 | Projection, Filter |
 | Spark     | 3.1      | read                                                 | Projection, Filter |
 | Spark     | 3.2      | read                                                 | Projection, Filter |
+| Spark     | 3.3      | read                                                 | Projection, Filter |
 | Trino     | 358      | read                                                 | Projection, Filter |
 | Trino     | 388      | read                                                 | Projection, Filter |

--- a/flink-table-store-spark/pom.xml
+++ b/flink-table-store-spark/pom.xml
@@ -77,6 +77,12 @@ under the License.
     <!-- Activate these profiles with -Pspark-x.x to build and test against different Spark versions -->
     <profiles>
         <profile>
+            <id>spark-3.3</id>
+            <properties>
+                <spark.version>3.3.0</spark.version>
+            </properties>
+        </profile>
+        <profile>
             <id>spark-3.2</id>
             <properties>
                 <spark.version>3.2.1</spark.version>

--- a/flink-table-store-spark/src/main/java/org/apache/flink/table/store/spark/SparkCatalog.java
+++ b/flink-table-store-spark/src/main/java/org/apache/flink/table/store/spark/SparkCatalog.java
@@ -185,8 +185,34 @@ public class SparkCatalog implements TableCatalog, SupportsNamespaces {
         throw new UnsupportedOperationException("Alter namespace in Spark is not supported yet.");
     }
 
-    @Override
+    /**
+     * Drop a namespace from the catalog, recursively dropping all objects within the namespace.
+     * This interface implementation only supports the Spark 3.0, 3.1 and 3.2.
+     *
+     * <p>If the catalog implementation does not support this operation, it may throw {@link
+     * UnsupportedOperationException}.
+     *
+     * @param namespace a multi-part namespace
+     * @return true if the namespace was dropped
+     * @throws UnsupportedOperationException If drop is not a supported operation
+     */
     public boolean dropNamespace(String[] namespace) {
+        return dropNamespace(namespace, true);
+    }
+
+    /**
+     * Drop a namespace from the catalog with cascade mode, recursively dropping all objects within
+     * the namespace if cascade is true. This interface implementation supports the Spark 3.3+.
+     *
+     * <p>If the catalog implementation does not support this operation, it may throw {@link
+     * UnsupportedOperationException}.
+     *
+     * @param namespace a multi-part namespace
+     * @param cascade When true, deletes all objects under the namespace
+     * @return true if the namespace was dropped
+     * @throws UnsupportedOperationException If drop is not a supported operation
+     */
+    public boolean dropNamespace(String[] namespace, boolean cascade) {
         throw new UnsupportedOperationException("Drop namespace in Spark is not supported yet.");
     }
 

--- a/flink-table-store-spark/src/test/java/org/apache/flink/table/store/spark/SparkTypeTest.java
+++ b/flink-table-store-spark/src/test/java/org/apache/flink/table/store/spark/SparkTypeTest.java
@@ -73,29 +73,29 @@ public class SparkTypeTest {
         String nestedRowMapType =
                 "StructField(locations,MapType("
                         + "StringType,"
-                        + "StructType(StructField(posX,DoubleType,false), StructField(posY,DoubleType,false)),true),true)";
+                        + "StructType(StructField(posX,DoubleType,false),StructField(posY,DoubleType,false)),true),true)";
         String expected =
                 "StructType("
-                        + "StructField(id,IntegerType,false), "
-                        + "StructField(name,StringType,true), "
-                        + "StructField(salary,DoubleType,false), "
+                        + "StructField(id,IntegerType,false),"
+                        + "StructField(name,StringType,true),"
+                        + "StructField(salary,DoubleType,false),"
                         + nestedRowMapType
-                        + ", "
-                        + "StructField(strArray,ArrayType(StringType,true),true), "
-                        + "StructField(intArray,ArrayType(IntegerType,true),true), "
-                        + "StructField(boolean,BooleanType,true), "
-                        + "StructField(tinyint,ByteType,true), "
-                        + "StructField(smallint,ShortType,true), "
-                        + "StructField(bigint,LongType,true), "
-                        + "StructField(bytes,BinaryType,true), "
-                        + "StructField(timestamp,TimestampType,true), "
-                        + "StructField(date,DateType,true), "
-                        + "StructField(decimal,DecimalType(2,2),true), "
-                        + "StructField(decimal2,DecimalType(38,2),true), "
+                        + ","
+                        + "StructField(strArray,ArrayType(StringType,true),true),"
+                        + "StructField(intArray,ArrayType(IntegerType,true),true),"
+                        + "StructField(boolean,BooleanType,true),"
+                        + "StructField(tinyint,ByteType,true),"
+                        + "StructField(smallint,ShortType,true),"
+                        + "StructField(bigint,LongType,true),"
+                        + "StructField(bytes,BinaryType,true),"
+                        + "StructField(timestamp,TimestampType,true),"
+                        + "StructField(date,DateType,true),"
+                        + "StructField(decimal,DecimalType(2,2),true),"
+                        + "StructField(decimal2,DecimalType(38,2),true),"
                         + "StructField(decimal3,DecimalType(10,1),true))";
 
         StructType sparkType = fromFlinkRowType(ALL_TYPES);
-        assertThat(sparkType.toString()).isEqualTo(expected);
+        assertThat(sparkType.toString().replace(", ", ",")).isEqualTo(expected);
 
         assertThat(toFlinkType(sparkType)).isEqualTo(ALL_TYPES);
     }


### PR DESCRIPTION
flink-table-store-spark module support Spark 3.0~3.2 profile, which has published the Spark 3.3.0 version. Spark 3.3 profile can be introduced for SparkSource to follow the release version of Spark 3.

**The brief change log**

- Introduces the `dropNamespace(namespace, cascade)` implementation for Spark 3.3+ version from [47cf](https://github.com/apache/spark/commit/ec5d2a76a55a4094d7bb48788a917145d81d47cf).

Verified the spark-3.3 profile with `mvn clean install -Pspark-3.3`. The result of the tests is as follows:

![image](https://user-images.githubusercontent.com/10048174/179165223-64b4cd97-d2ae-4a4e-bef0-9a9ac3a3a090.png)

![image](https://user-images.githubusercontent.com/10048174/179166617-946d8ae4-f17e-4f9d-9410-585432406ea9.png)
