### PR TITLE
[FLINK-28573] Nested type will lose nullability when converting from TableSchema

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/ArrayDataType.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/ArrayDataType.java
@@ -29,8 +29,8 @@ public class ArrayDataType extends DataType {
 
     private final DataType elementType;
 
-    public ArrayDataType(DataType elementType) {
-        super(new ArrayType(elementType.logicalType));
+    public ArrayDataType(boolean isNullable, DataType elementType) {
+        super(new ArrayType(isNullable, elementType.logicalType));
         this.elementType = elementType;
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/MapDataType.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/MapDataType.java
@@ -31,8 +31,8 @@ public class MapDataType extends DataType {
 
     private final DataType valueType;
 
-    public MapDataType(DataType keyType, DataType valueType) {
-        super(new MapType(keyType.logicalType, valueType.logicalType));
+    public MapDataType(boolean isNullable, DataType keyType, DataType valueType) {
+        super(new MapType(isNullable, keyType.logicalType, valueType.logicalType));
         this.keyType = keyType;
         this.valueType = valueType;
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/MultisetDataType.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/MultisetDataType.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.store.file.schema;
 
-import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.MultisetType;
 
 import java.util.Objects;
 
@@ -29,8 +29,8 @@ public class MultisetDataType extends DataType {
 
     private final DataType elementType;
 
-    public MultisetDataType(DataType elementType) {
-        super(new ArrayType(elementType.logicalType));
+    public MultisetDataType(boolean isNullable, DataType elementType) {
+        super(new MultisetType(isNullable, elementType.logicalType));
         this.elementType = elementType;
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/RowDataType.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/RowDataType.java
@@ -32,18 +32,22 @@ public class RowDataType extends DataType {
     private final List<DataField> fields;
 
     public RowDataType(List<DataField> fields) {
-        super(toRowType(fields));
+        this(true, fields);
+    }
+
+    public RowDataType(boolean isNullable, List<DataField> fields) {
+        super(toRowType(isNullable, fields));
         this.fields = fields;
     }
 
-    private static RowType toRowType(List<DataField> fields) {
+    private static RowType toRowType(boolean isNullable, List<DataField> fields) {
         List<RowType.RowField> typeFields = new ArrayList<>(fields.size());
         for (DataField field : fields) {
             typeFields.add(
                     new RowType.RowField(
                             field.name(), field.type().logicalType, field.description()));
         }
-        return new RowType(typeFields);
+        return new RowType(isNullable, typeFields);
     }
 
     public List<DataField> fields() {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/TableSchema.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/TableSchema.java
@@ -173,7 +173,7 @@ public class TableSchema implements Serializable {
     }
 
     public RowType logicalRowType() {
-        return (RowType) new RowDataType(fields).logicalType;
+        return (RowType) new RowDataType(false, fields).logicalType;
     }
 
     public RowType logicalPartitionType() {
@@ -204,6 +204,7 @@ public class TableSchema implements Serializable {
         List<String> fieldNames = fieldNames();
         return (RowType)
                 new RowDataType(
+                                false,
                                 projectedFieldNames.stream()
                                         .map(k -> fields.get(fieldNames.indexOf(k)))
                                         .collect(Collectors.toList()))
@@ -253,15 +254,15 @@ public class TableSchema implements Serializable {
         if (type instanceof ArrayType) {
             DataType element =
                     toDataType(((ArrayType) type).getElementType(), currentHighestFieldId);
-            return new ArrayDataType(element);
+            return new ArrayDataType(type.isNullable(), element);
         } else if (type instanceof MultisetType) {
             DataType element =
                     toDataType(((MultisetType) type).getElementType(), currentHighestFieldId);
-            return new MultisetDataType(element);
+            return new MultisetDataType(type.isNullable(), element);
         } else if (type instanceof MapType) {
             DataType key = toDataType(((MapType) type).getKeyType(), currentHighestFieldId);
             DataType value = toDataType(((MapType) type).getValueType(), currentHighestFieldId);
-            return new MapDataType(key, value);
+            return new MapDataType(type.isNullable(), key, value);
         } else if (type instanceof RowType) {
             List<DataField> fields = new ArrayList<>();
             for (RowType.RowField field : ((RowType) type).getFields()) {
@@ -274,7 +275,7 @@ public class TableSchema implements Serializable {
                                 fieldType,
                                 field.getDescription().orElse(null)));
             }
-            return new RowDataType(fields);
+            return new RowDataType(type.isNullable(), fields);
         } else {
             return new AtomicDataType(type);
         }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/schema/TableSchemaSerializationTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/schema/TableSchemaSerializationTest.java
@@ -40,10 +40,13 @@ public class TableSchemaSerializationTest {
         List<DataField> fields =
                 Arrays.asList(
                         new DataField(0, "f0", new AtomicDataType(new IntType())),
-                        new DataField(1, "f1", newRowType(2)),
-                        new DataField(3, "f2", new ArrayDataType(newRowType(4))),
-                        new DataField(5, "f3", new MultisetDataType(newRowType(6))),
-                        new DataField(7, "f4", new MapDataType(newRowType(8), newRowType(9))));
+                        new DataField(1, "f1", newRowType(false, 2)),
+                        new DataField(3, "f2", new ArrayDataType(false, newRowType(true, 4))),
+                        new DataField(5, "f3", new MultisetDataType(true, newRowType(false, 6))),
+                        new DataField(
+                                7,
+                                "f4",
+                                new MapDataType(true, newRowType(true, 8), newRowType(false, 9))));
         List<String> partitionKeys = Collections.singletonList("f0");
         List<String> primaryKeys = Arrays.asList("f0", "f1");
         Map<String, String> options = new HashMap<>();

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/schema/TableSchemaTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/schema/TableSchemaTest.java
@@ -80,31 +80,36 @@ public class TableSchemaTest {
                 RowType.of(
                         new LogicalType[] {
                             new IntType(),
-                            newLogicalRowType(),
-                            new ArrayType(newLogicalRowType()),
-                            new MultisetType(newLogicalRowType()),
-                            new MapType(newLogicalRowType(), newLogicalRowType())
+                            newLogicalRowType(true),
+                            new ArrayType(false, newLogicalRowType(false)),
+                            new MultisetType(true, newLogicalRowType(false)),
+                            new MapType(false, newLogicalRowType(true), newLogicalRowType(false))
                         },
                         new String[] {"f0", "f1", "f2", "f3", "f4"});
 
         List<DataField> fields =
                 Arrays.asList(
                         new DataField(0, "f0", new AtomicDataType(new IntType())),
-                        new DataField(1, "f1", newRowType(2)),
-                        new DataField(3, "f2", new ArrayDataType(newRowType(4))),
-                        new DataField(5, "f3", new MultisetDataType(newRowType(6))),
-                        new DataField(7, "f4", new MapDataType(newRowType(8), newRowType(9))));
+                        new DataField(1, "f1", newRowType(true, 2)),
+                        new DataField(3, "f2", new ArrayDataType(false, newRowType(false, 4))),
+                        new DataField(5, "f3", new MultisetDataType(true, newRowType(false, 6))),
+                        new DataField(
+                                7,
+                                "f4",
+                                new MapDataType(false, newRowType(true, 8), newRowType(false, 9))));
 
         assertThat(TableSchema.newFields(type)).isEqualTo(fields);
     }
 
-    static RowType newLogicalRowType() {
+    static RowType newLogicalRowType(boolean isNullable) {
         return new RowType(
+                isNullable,
                 Collections.singletonList(new RowType.RowField("nestedField", new IntType())));
     }
 
-    static RowDataType newRowType(int fieldId) {
+    static RowDataType newRowType(boolean isNullable, int fieldId) {
         return new RowDataType(
+                isNullable,
                 Collections.singletonList(
                         new DataField(fieldId, "nestedField", new AtomicDataType(new IntType()))));
     }


### PR DESCRIPTION
Fix the nullability loss for `ArrayDataType`, `MultisetDataType`, `MapDataType` and `RowDataType`