### PR TITLE
[FLINK-28565] Create `NOTICE` file for `flink-table-store-hive-catalog`

### DIFF
--- a/flink-table-store-hive/flink-table-store-hive-catalog/src/main/resources/META-INF/NOTICE
+++ b/flink-table-store-hive/flink-table-store-hive-catalog/src/main/resources/META-INF/NOTICE
@@ -6,55 +6,10 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.hive:hive-metastore:2.3.4
-
-This project bundles the following dependencies under the BSD license.
-See bundled license files for details.
-
-- org.antlr:antlr-runtime:3.5.2
-
-The bundled Apache Hive org.apache.hive:hive-metastore dependency bundles the following dependencies under
-the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 - com.google.guava:guava:14.0.1
-- com.tdunning:json:1.8
-- commons-lang:commons-lang:2.6
-- io.airlift:aircompressor:0.3
-- javax.jdo:jdo-api:3.0.1
-- joda-time:joda-time:2.8.1
-- net.sf.opencsv:opencsv:2.3
-- org.apache.avro:avro-mapred:1.11.0
-- org.apache.avro:avro:1.11.0
-- org.apache.commons:commons-lang3:3.3.2
-- org.apache.hive.shims:hive-shims-0.23:2.3.4
-- org.apache.hive.shims:hive-shims-common:2.3.4
 - org.apache.hive:hive-common:2.3.4
-- org.apache.hive:hive-llap-client:2.3.4
-- org.apache.hive:hive-llap-common:2.3.4
 - org.apache.hive:hive-metastore:2.3.4
 - org.apache.hive:hive-serde:2.3.4
-- org.apache.hive:hive-service-rpc:2.3.4
-- org.apache.hive:hive-storage-api:2.4.0
-- org.apache.hive:spark-client:2.3.4
-- org.apache.orc:orc-core:1.3.3
-- org.apache.orc:orc-tools:1.3.3
-- org.apache.parquet:parquet-hadoop-bundle:1.8.1
+- org.apache.hive.shims:hive-shims-common:2.3.4
+- org.apache.thrift:libfb303:0.9.3
 - org.apache.thrift:libthrift:0.9.3
-- org.codehaus.jackson:jackson-core-asl:1.9.13
-- org.codehaus.jackson:jackson-mapper-asl:1.9.13
-- org.objenesis:objenesis:2.1
-
-The bundled Apache Hive org.apache.hive:hive-metastore dependency bundles the following dependencies under the BSD license.
-See bundled license files for details.
-
-- com.esotericsoftware:kryo-shaded:3.0.3
-- com.esotericsoftware:minlog:1.3.0
-- com.esotericsoftware:reflectasm:1.10.1
-- com.google.protobuf:protobuf-java:2.5.0
-- javolution:javolution:5.5.1
-- org.jodd:jodd-core:3.5.2
-
-The bundled Apache Hive org.apache.hive:hive-metastore dependency bundles the following dependencies under the MIT/X11 license.
-See bundled license files for details.
-
-- org.slf4j:slf4j-api:1.7.15

--- a/flink-table-store-hive/flink-table-store-hive-catalog/src/main/resources/META-INF/NOTICE
+++ b/flink-table-store-hive/flink-table-store-hive-catalog/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,60 @@
+flink-table-store-hive-catalog
+Copyright 2014-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- org.apache.hive:hive-metastore:2.3.4
+
+This project bundles the following dependencies under the BSD license.
+See bundled license files for details.
+
+- org.antlr:antlr-runtime:3.5.2
+
+The bundled Apache Hive org.apache.hive:hive-metastore dependency bundles the following dependencies under
+the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- com.google.guava:guava:14.0.1
+- com.tdunning:json:1.8
+- commons-lang:commons-lang:2.6
+- io.airlift:aircompressor:0.3
+- javax.jdo:jdo-api:3.0.1
+- joda-time:joda-time:2.8.1
+- net.sf.opencsv:opencsv:2.3
+- org.apache.avro:avro-mapred:1.11.0
+- org.apache.avro:avro:1.11.0
+- org.apache.commons:commons-lang3:3.3.2
+- org.apache.hive.shims:hive-shims-0.23:2.3.4
+- org.apache.hive.shims:hive-shims-common:2.3.4
+- org.apache.hive:hive-common:2.3.4
+- org.apache.hive:hive-llap-client:2.3.4
+- org.apache.hive:hive-llap-common:2.3.4
+- org.apache.hive:hive-metastore:2.3.4
+- org.apache.hive:hive-serde:2.3.4
+- org.apache.hive:hive-service-rpc:2.3.4
+- org.apache.hive:hive-storage-api:2.4.0
+- org.apache.hive:spark-client:2.3.4
+- org.apache.orc:orc-core:1.3.3
+- org.apache.orc:orc-tools:1.3.3
+- org.apache.parquet:parquet-hadoop-bundle:1.8.1
+- org.apache.thrift:libthrift:0.9.3
+- org.codehaus.jackson:jackson-core-asl:1.9.13
+- org.codehaus.jackson:jackson-mapper-asl:1.9.13
+- org.objenesis:objenesis:2.1
+
+The bundled Apache Hive org.apache.hive:hive-metastore dependency bundles the following dependencies under the BSD license.
+See bundled license files for details.
+
+- com.esotericsoftware:kryo-shaded:3.0.3
+- com.esotericsoftware:minlog:1.3.0
+- com.esotericsoftware:reflectasm:1.10.1
+- com.google.protobuf:protobuf-java:2.5.0
+- javolution:javolution:5.5.1
+- org.jodd:jodd-core:3.5.2
+
+The bundled Apache Hive org.apache.hive:hive-metastore dependency bundles the following dependencies under the MIT/X11 license.
+See bundled license files for details.
+
+- org.slf4j:slf4j-api:1.7.15


### PR DESCRIPTION
`NOTICE` file is need to be created for `flink-table-store-hive-catalog`.

**The brief change log**
- Introduces the `NOTICE` file in `flink-table-store-hive-catalog`.