### PR TITLE
[FLINK-28578] Upgrade Spark version of flink-table-store-spark to 3.2.2

### DIFF
--- a/flink-table-store-spark/pom.xml
+++ b/flink-table-store-spark/pom.xml
@@ -34,7 +34,7 @@ under the License.
     <packaging>jar</packaging>
 
     <properties>
-        <spark.version>3.2.1</spark.version>
+        <spark.version>3.2.2</spark.version>
     </properties>
 
     <dependencies>
@@ -85,7 +85,7 @@ under the License.
         <profile>
             <id>spark-3.2</id>
             <properties>
-                <spark.version>3.2.1</spark.version>
+                <spark.version>3.2.2</spark.version>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
CVE-2022-33891: Apache Spark shell command injection vulnerability via Spark UI. Upgrade to supported Apache Spark maintenance release 3.1.3, 3.2.2 or 3.3.0 or later.

**The brief change log**
- Upgrade Spark version of flink-table-store-spark from 3.2.1 to 3.2.2.