### PR TITLE
[FLINK-28580] Predicate supports unknown stats

### DIFF
--- a/flink-table-store-common/src/main/java/org/apache/flink/table/store/file/predicate/LeafPredicate.java
+++ b/flink-table-store-common/src/main/java/org/apache/flink/table/store/file/predicate/LeafPredicate.java
@@ -85,7 +85,16 @@ public class LeafPredicate implements Predicate {
 
     @Override
     public boolean test(long rowCount, FieldStats[] fieldStats) {
-        return function.test(type, rowCount, fieldStats[fieldIndex], literals);
+        FieldStats stats = fieldStats[fieldIndex];
+        if (rowCount != stats.nullCount()) {
+            // not all null
+            // min or max is null
+            // unknown stats
+            if (stats.minValue() == null || stats.maxValue() == null) {
+                return true;
+            }
+        }
+        return function.test(type, rowCount, stats, literals);
     }
 
     @Override

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/predicate/PredicateTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/predicate/PredicateTest.java
@@ -506,4 +506,17 @@ public class PredicateTest {
         assertThat(predicate.negate().orElse(null))
                 .isEqualTo(PredicateBuilder.and(builder.notEqual(0, 3), builder.notEqual(1, 5)));
     }
+
+    @Test
+    public void testUnknownStats() {
+        PredicateBuilder builder = new PredicateBuilder(RowType.of(new IntType()));
+        Predicate predicate = builder.equal(0, 5);
+
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(null, null, 3)}))
+                .isEqualTo(false);
+
+        // unknown stats, we don't know, likely to hit
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(null, null, 4)}))
+                .isEqualTo(true);
+    }
 }


### PR DESCRIPTION
Now there will be a NPE if minValue or maxValue of FieldStats is null.
We can know the stats is unknown in LeafPredicate.test(long rowCount, FieldStats[] fieldStats), and return true directly.