### PR TITLE
[FLINK-28579] Supports predicate testing for new columns

### DIFF
--- a/docs/content/docs/engines/spark.md
+++ b/docs/content/docs/engines/spark.md
@@ -107,9 +107,3 @@ ALTER TABLE table_store.default.myTable UNSET TBLPROPERTIES ('write-buffer-size'
 ALTER TABLE table_store.default.myTable
 ADD COLUMNS (new_column STRING)
 ```
-
-`ALTER TABLE ... ALTER COLUMN ... TYPE`
-```sql
-ALTER TABLE table_store.default.myTable
-ALTER COLUMN column_name TYPE BIGINT
-```

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AppendOnlyFileStoreScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AppendOnlyFileStoreScan.java
@@ -80,6 +80,8 @@ public class AppendOnlyFileStoreScan extends AbstractFileStoreScan {
         return filter == null
                 || filter.test(
                         entry.file().rowCount(),
-                        entry.file().valueStats().fields(rowStatsConverter));
+                        entry.file()
+                                .valueStats()
+                                .fields(rowStatsConverter, entry.file().rowCount()));
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreScan.java
@@ -79,6 +79,7 @@ public class KeyValueFileStoreScan extends AbstractFileStoreScan {
     protected boolean filterByStats(ManifestEntry entry) {
         return keyFilter == null
                 || keyFilter.test(
-                        entry.file().rowCount(), entry.file().keyStats().fields(keyStatsConverter));
+                        entry.file().rowCount(),
+                        entry.file().keyStats().fields(keyStatsConverter, entry.file().rowCount()));
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaChange.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaChange.java
@@ -37,6 +37,10 @@ public interface SchemaChange {
         return new RemoveOption(key);
     }
 
+    static SchemaChange addColumn(String fieldName, LogicalType logicalType) {
+        return addColumn(fieldName, logicalType, true, null);
+    }
+
     static SchemaChange addColumn(
             String fieldName, LogicalType logicalType, boolean isNullable, String comment) {
         return new AddColumn(fieldName, logicalType, isNullable, comment);

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/stats/BinaryTableStats.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/stats/BinaryTableStats.java
@@ -51,7 +51,10 @@ public class BinaryTableStats {
     }
 
     public BinaryTableStats(
-            BinaryRowData min, BinaryRowData max, long[] nullCounts, FieldStats[] cacheArray) {
+            BinaryRowData min,
+            BinaryRowData max,
+            long[] nullCounts,
+            @Nullable FieldStats[] cacheArray) {
         this.min = min;
         this.max = max;
         this.nullCounts = nullCounts;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/stats/BinaryTableStats.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/stats/BinaryTableStats.java
@@ -59,8 +59,12 @@ public class BinaryTableStats {
     }
 
     public FieldStats[] fields(FieldStatsArraySerializer converter) {
+        return fields(converter, null);
+    }
+
+    public FieldStats[] fields(FieldStatsArraySerializer converter, @Nullable Long rowCount) {
         if (cacheArray == null) {
-            cacheArray = converter.fromBinary(this);
+            cacheArray = converter.fromBinary(this, rowCount);
         }
         return cacheArray;
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RecordReaderUtils.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RecordReaderUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.utils;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+
+/** Utils for {@link RecordReader}. */
+public class RecordReaderUtils {
+
+    /**
+     * Performs the given action for each remaining element in {@link RecordReader} until all
+     * elements have been processed or the action throws an exception.
+     */
+    public static <T> void forEachRemaining(
+            final RecordReader<T> reader, final Consumer<? super T> action) throws IOException {
+        RecordReader.RecordIterator<T> batch;
+        T record;
+
+        try {
+            while ((batch = reader.readBatch()) != null) {
+                while ((record = batch.next()) != null) {
+                    action.accept(record);
+                }
+                batch.releaseBatch();
+            }
+        } finally {
+            reader.close();
+        }
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/SchemaEvolutionTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/SchemaEvolutionTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.table;
+
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.conversion.RowRowConverter;
+import org.apache.flink.table.store.file.predicate.Predicate;
+import org.apache.flink.table.store.file.predicate.PredicateBuilder;
+import org.apache.flink.table.store.file.schema.SchemaChange;
+import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.file.schema.UpdateSchema;
+import org.apache.flink.table.store.file.utils.RecordReader;
+import org.apache.flink.table.store.file.utils.RecordReaderUtils;
+import org.apache.flink.table.store.table.sink.TableWrite;
+import org.apache.flink.table.store.table.source.Split;
+import org.apache.flink.table.store.table.source.TableRead;
+import org.apache.flink.table.store.table.source.TableScan;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.flink.types.Row;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for schema evolution. */
+public class SchemaEvolutionTest {
+
+    @TempDir java.nio.file.Path tempDir;
+
+    private Path tablePath;
+
+    private SchemaManager schemaManager;
+
+    @BeforeEach
+    public void beforeEach() {
+        tablePath = new Path(tempDir.toUri());
+        schemaManager = new SchemaManager(tablePath);
+    }
+
+    @Test
+    public void testAddField() throws Exception {
+        UpdateSchema updateSchema =
+                new UpdateSchema(
+                        RowType.of(new IntType(), new BigIntType()),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        new HashMap<>(),
+                        "");
+        schemaManager.commitNewVersion(updateSchema);
+
+        FileStoreTable table = FileStoreTableFactory.create(tablePath);
+
+        TableWrite write = table.newWrite();
+        write.write(GenericRowData.of(1, 1L));
+        write.write(GenericRowData.of(2, 2L));
+        table.newCommit("").commit("0", write.prepareCommit(true));
+        write.close();
+
+        schemaManager.commitChanges(
+                Collections.singletonList(SchemaChange.addColumn("f3", new BigIntType())));
+        table = FileStoreTableFactory.create(tablePath);
+
+        write = table.newWrite();
+        write.write(GenericRowData.of(3, 3L, 3L));
+        write.write(GenericRowData.of(4, 4L, 4L));
+        table.newCommit("").commit("1", write.prepareCommit(true));
+        write.close();
+
+        // read all
+        List<Row> rows = readRecords(table, null);
+        assertThat(rows)
+                .containsExactlyInAnyOrder(
+                        Row.of(1, 1L, null),
+                        Row.of(2, 2L, null),
+                        Row.of(3, 3L, 3L),
+                        Row.of(4, 4L, 4L));
+
+        PredicateBuilder builder = new PredicateBuilder(table.schema().logicalRowType());
+
+        // read where f0 = 1 (filter on old field)
+        rows = readRecords(table, builder.equal(0, 1));
+        assertThat(rows).containsExactlyInAnyOrder(Row.of(1, 1L, null), Row.of(2, 2L, null));
+
+        // read where f3 is null (filter on new field)
+        rows = readRecords(table, builder.isNull(2));
+        assertThat(rows).containsExactlyInAnyOrder(Row.of(1, 1L, null), Row.of(2, 2L, null));
+
+        // read where f3 = 3 (filter on new field)
+        rows = readRecords(table, builder.equal(2, 3L));
+        assertThat(rows).containsExactlyInAnyOrder(Row.of(3, 3L, 3L), Row.of(4, 4L, 4L));
+    }
+
+    private List<Row> readRecords(FileStoreTable table, Predicate filter) throws IOException {
+        RowRowConverter converter =
+                RowRowConverter.create(
+                        TypeConversions.fromLogicalToDataType(table.schema().logicalRowType()));
+        List<Row> results = new ArrayList<>();
+        forEachRemaining(table, filter, rowData -> results.add(converter.toExternal(rowData)));
+        return results;
+    }
+
+    private void forEachRemaining(
+            FileStoreTable table, Predicate filter, Consumer<RowData> consumer) throws IOException {
+        TableScan scan = table.newScan();
+        if (filter != null) {
+            scan.withFilter(filter);
+        }
+        for (Split split : scan.plan().splits) {
+            TableRead read = table.newRead();
+            if (filter != null) {
+                read.withFilter(filter);
+            }
+            RecordReader<RowData> reader = read.createReader(split);
+            RecordReaderUtils.forEachRemaining(reader, consumer);
+        }
+    }
+}


### PR DESCRIPTION
The currently added column, if there is a filter on it, will cause an error in the RowDataToObjectArrayConverter because the number of columns is not correct
We can make BinaryTableStats supports evolution from shorter rowData.