### PR TITLE
[FLINK-28582] Check LSM tree structure when multiple jobs are committing into the same bucket

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSink.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSink.java
@@ -91,7 +91,7 @@ public class StoreSink implements Serializable {
         return new StoreCommitter(
                 table.newCommit(user)
                         .withOverwritePartition(overwritePartition)
-                        .withCommitEmptyNewFiles(commitEmptyNewFiles)
+                        .withCreateEmptyCommit(commitEmptyNewFiles)
                         .withLock(lock));
     }
 

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSink.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSink.java
@@ -86,12 +86,12 @@ public class StoreSink implements Serializable {
         return new StoreWriteOperator(table, overwritePartition, logSinkFunction);
     }
 
-    private StoreCommitter createCommitter(String user, boolean commitEmptyNewFiles) {
+    private StoreCommitter createCommitter(String user, boolean createEmptyCommit) {
         Lock lock = Lock.fromCatalog(lockFactory, tableIdentifier.toObjectPath());
         return new StoreCommitter(
                 table.newCommit(user)
                         .withOverwritePartition(overwritePartition)
-                        .withCreateEmptyCommit(commitEmptyNewFiles)
+                        .withCreateEmptyCommit(createEmptyCommit)
                         .withLock(lock));
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/AbstractFileStore.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/AbstractFileStore.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.store.file;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.CoreOptions;
 import org.apache.flink.table.store.file.manifest.ManifestFile;
 import org.apache.flink.table.store.file.manifest.ManifestList;
@@ -28,6 +29,8 @@ import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
 import org.apache.flink.table.types.logical.RowType;
+
+import java.util.Comparator;
 
 /**
  * Base {@link FileStore} implementation.
@@ -103,7 +106,8 @@ public abstract class AbstractFileStore<T> implements FileStore<T> {
                 newScan(),
                 options.bucket(),
                 options.manifestTargetSize(),
-                options.manifestMergeMinCount());
+                options.manifestMergeMinCount(),
+                newKeyComparator());
     }
 
     @Override
@@ -117,4 +121,6 @@ public abstract class AbstractFileStore<T> implements FileStore<T> {
                 manifestFileFactory(),
                 manifestListFactory());
     }
+
+    public abstract Comparator<RowData> newKeyComparator();
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/AppendOnlyFileStore.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/AppendOnlyFileStore.java
@@ -26,6 +26,8 @@ import org.apache.flink.table.store.file.operation.AppendOnlyFileStoreWrite;
 import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.types.logical.RowType;
 
+import java.util.Comparator;
+
 /** {@link FileStore} for reading and writing {@link RowData}. */
 public class AppendOnlyFileStore extends AbstractFileStore<RowData> {
 
@@ -81,5 +83,10 @@ public class AppendOnlyFileStore extends AbstractFileStore<RowData> {
                 manifestListFactory(),
                 options.bucket(),
                 checkNumOfBuckets);
+    }
+
+    @Override
+    public Comparator<RowData> newKeyComparator() {
+        return null;
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValueFileStore.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValueFileStore.java
@@ -104,6 +104,7 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
                 checkNumOfBuckets);
     }
 
+    @Override
     public Comparator<RowData> newKeyComparator() {
         return keyComparatorSupplier.get();
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileWriter.java
@@ -189,6 +189,10 @@ public class DataFileWriter {
 
             updateMinSeqNumber(kv);
             updateMaxSeqNumber(kv);
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Write key value " + kv.toString(keyType, valueType));
+            }
         }
 
         private void updateMinKey(KeyValue kv) {
@@ -211,6 +215,10 @@ public class DataFileWriter {
 
         @Override
         protected DataFileMeta createResult(Path path, Metric metric) throws IOException {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Closing data file " + path);
+            }
+
             FieldStats[] rowStats = metric.fieldStats();
             int numKeyFields = keyType.getFieldCount();
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommit.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommit.java
@@ -29,7 +29,7 @@ public interface FileStoreCommit {
     /** With global lock. */
     FileStoreCommit withLock(Lock lock);
 
-    FileStoreCommit withCommitEmptyNewFiles(boolean commitEmptyNewFiles);
+    FileStoreCommit withCreateEmptyCommit(boolean commitEmptyNewFiles);
 
     /** Find out which manifest committable need to be retried when recovering from the failure. */
     List<ManifestCommittable> filterCommitted(List<ManifestCommittable> committableList);

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommit.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommit.java
@@ -29,6 +29,8 @@ public interface FileStoreCommit {
     /** With global lock. */
     FileStoreCommit withLock(Lock lock);
 
+    FileStoreCommit withCommitEmptyNewFiles(boolean commitEmptyNewFiles);
+
     /** Find out which manifest committable need to be retried when recovering from the failure. */
     List<ManifestCommittable> filterCommitted(List<ManifestCommittable> committableList);
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommit.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommit.java
@@ -29,7 +29,7 @@ public interface FileStoreCommit {
     /** With global lock. */
     FileStoreCommit withLock(Lock lock);
 
-    FileStoreCommit withCreateEmptyCommit(boolean commitEmptyNewFiles);
+    FileStoreCommit withCreateEmptyCommit(boolean createEmptyCommit);
 
     /** Find out which manifest committable need to be retried when recovering from the failure. */
     List<ManifestCommittable> filterCommitted(List<ManifestCommittable> committableList);

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreExpireImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreExpireImpl.java
@@ -33,7 +33,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -134,12 +133,8 @@ public class FileStoreExpireImpl implements FileStoreExpire {
             // No expire happens:
             // write the hint file in order to see the earliest snapshot directly next time
             // should avoid duplicate writes when the file exists
-            try {
-                if (snapshotManager.readHint(SnapshotManager.EARLIEST) == null) {
-                    writeEarliestHint(endExclusiveId);
-                }
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
+            if (snapshotManager.readHint(SnapshotManager.EARLIEST) == null) {
+                writeEarliestHint(endExclusiveId);
             }
 
             // fast exit

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/SnapshotManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/SnapshotManager.java
@@ -22,6 +22,9 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.store.file.Snapshot;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -32,6 +35,8 @@ import static org.apache.flink.table.store.file.utils.FileUtils.listVersionedFil
 
 /** Manager for {@link Snapshot}, providing utility methods related to paths and snapshot hints. */
 public class SnapshotManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SnapshotManager.class);
 
     private static final String SNAPSHOT_PREFIX = "snapshot-";
     public static final String EARLIEST = "EARLIEST";
@@ -109,11 +114,16 @@ public class SnapshotManager {
         return findByListFiles(Math::min);
     }
 
-    public Long readHint(String fileName) throws IOException {
+    public Long readHint(String fileName) {
         Path snapshotDir = snapshotDirectory();
         Path path = new Path(snapshotDir, fileName);
-        if (path.getFileSystem().exists(path)) {
-            return Long.parseLong(FileUtils.readFileUtf8(path));
+        try {
+            if (path.getFileSystem().exists(path)) {
+                return Long.parseLong(FileUtils.readFileUtf8(path));
+            }
+        } catch (Exception e) {
+            LOG.info(
+                    "Failed to read hint file " + fileName + ". Falling back to listing files.", e);
         }
         return null;
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableCommit.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableCommit.java
@@ -59,6 +59,11 @@ public class TableCommit implements AutoCloseable {
         return this;
     }
 
+    public TableCommit withCommitEmptyNewFiles(boolean commitEmptyNewFiles) {
+        commit.withCommitEmptyNewFiles(commitEmptyNewFiles);
+        return this;
+    }
+
     public List<ManifestCommittable> filterCommitted(List<ManifestCommittable> committables) {
         return commit.filterCommitted(committables);
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableCommit.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableCommit.java
@@ -59,8 +59,8 @@ public class TableCommit implements AutoCloseable {
         return this;
     }
 
-    public TableCommit withCommitEmptyNewFiles(boolean commitEmptyNewFiles) {
-        commit.withCommitEmptyNewFiles(commitEmptyNewFiles);
+    public TableCommit withCreateEmptyCommit(boolean createEmptyCommit) {
+        commit.withCreateEmptyCommit(createEmptyCommit);
         return this;
     }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -197,7 +197,7 @@ public class TestFileStore extends KeyValueFileStore {
         for (KeyValue kv : kvs) {
             BinaryRowData partition = partitionCalculator.apply(kv);
             int bucket = bucketCalculator.apply(kv);
-            writers.compute(partition, (p, m) -> m == null ? new HashMap<>() : m)
+            writers.computeIfAbsent(partition, p -> new HashMap<>())
                     .compute(
                             bucket,
                             (b, w) -> {
@@ -281,8 +281,8 @@ public class TestFileStore extends KeyValueFileStore {
                 new HashMap<>();
         for (ManifestEntry entry : entries) {
             filesPerPartitionAndBucket
-                    .compute(entry.partition(), (p, m) -> m == null ? new HashMap<>() : m)
-                    .compute(entry.bucket(), (b, l) -> l == null ? new ArrayList<>() : l)
+                    .computeIfAbsent(entry.partition(), p -> new HashMap<>())
+                    .computeIfAbsent(entry.bucket(), b -> new ArrayList<>())
                     .add(entry.file());
         }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -185,7 +185,7 @@ public class TestFileStore extends KeyValueFileStore {
                         commit.overwrite(partition, committable, Collections.emptyMap()));
     }
 
-    private List<Snapshot> commitDataImpl(
+    public List<Snapshot> commitDataImpl(
             List<KeyValue> kvs,
             Function<KeyValue, BinaryRowData> partitionCalculator,
             Function<KeyValue, Integer> bucketCalculator,

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -309,6 +309,18 @@ public class TestFileStore extends KeyValueFileStore {
     }
 
     public Map<BinaryRowData, BinaryRowData> toKvMap(List<KeyValue> kvs) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(
+                    "Compacting list of key values to kv map\n"
+                            + kvs.stream()
+                                    .map(
+                                            kv ->
+                                                    kv.toString(
+                                                            TestKeyValueGenerator.KEY_TYPE,
+                                                            TestKeyValueGenerator.DEFAULT_ROW_TYPE))
+                                    .collect(Collectors.joining("\n")));
+        }
+
         Map<BinaryRowData, BinaryRowData> result = new HashMap<>();
         for (KeyValue kv : kvs) {
             BinaryRowData key = keySerializer.toBinaryRow(kv.key()).copy();

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreCommitTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreCommitTest.java
@@ -163,9 +163,7 @@ public class FileStoreCommitTest {
             for (KeyValue kv : entry.getValue()) {
                 dataPerThread
                         .get(Math.abs(kv.key().hashCode()) % numThreads)
-                        .compute(
-                                entry.getKey(),
-                                (p, list) -> list == null ? new ArrayList<>() : list)
+                        .computeIfAbsent(entry.getKey(), p -> new ArrayList<>())
                         .add(kv);
             }
         }
@@ -335,7 +333,7 @@ public class FileStoreCommitTest {
                 kv -> 0,
                 false,
                 (commit, committable) -> {
-                    commit.withCommitEmptyNewFiles(true);
+                    commit.withCreateEmptyCommit(true);
                     commit.commit(committable, Collections.emptyMap());
                 });
         assertThat(store.snapshotManager().findLatest()).isEqualTo(snapshot.id() + 1);
@@ -371,7 +369,7 @@ public class FileStoreCommitTest {
         Map<BinaryRowData, List<KeyValue>> data = new HashMap<>();
         for (int i = 0; i < numRecords; i++) {
             KeyValue kv = gen.next();
-            data.compute(gen.getPartition(kv), (p, l) -> l == null ? new ArrayList<>() : l).add(kv);
+            data.computeIfAbsent(gen.getPartition(kv), p -> new ArrayList<>()).add(kv);
         }
         return data;
     }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
@@ -170,7 +170,7 @@ public class TestCommitThread extends Thread {
     private void writeData() throws Exception {
         List<KeyValue> changes = new ArrayList<>();
         BinaryRowData partition = pickData(changes);
-        result.compute(partition, (p, l) -> l == null ? new ArrayList<>() : l).addAll(changes);
+        result.computeIfAbsent(partition, p -> new ArrayList<>()).addAll(changes);
 
         if (LOG.isDebugEnabled()) {
             LOG.debug(
@@ -180,8 +180,7 @@ public class TestCommitThread extends Thread {
                                     .collect(Collectors.joining("\n")));
         }
 
-        MergeTreeWriter writer =
-                writers.compute(partition, (p, w) -> w == null ? createWriter(p, false) : w);
+        MergeTreeWriter writer = writers.computeIfAbsent(partition, p -> createWriter(p, false));
         for (KeyValue kv : changes) {
             writer.write(kv);
         }
@@ -191,7 +190,7 @@ public class TestCommitThread extends Thread {
         List<KeyValue> changes = new ArrayList<>();
         BinaryRowData partition = pickData(changes);
         List<KeyValue> resultOfPartition =
-                result.compute(partition, (p, l) -> l == null ? new ArrayList<>() : l);
+                result.computeIfAbsent(partition, p -> new ArrayList<>());
         resultOfPartition.clear();
         resultOfPartition.addAll(changes);
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
@@ -25,11 +25,13 @@ import org.apache.flink.table.store.file.TestKeyValueGenerator;
 import org.apache.flink.table.store.file.manifest.ManifestCommittable;
 import org.apache.flink.table.store.file.memory.HeapMemorySegmentPool;
 import org.apache.flink.table.store.file.mergetree.MergeTreeWriter;
+import org.apache.flink.table.types.logical.RowType;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -39,6 +41,7 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.table.store.file.TestFileStore.PAGE_SIZE;
 import static org.apache.flink.table.store.file.TestFileStore.WRITE_BUFFER_SIZE;
@@ -49,6 +52,9 @@ public class TestCommitThread extends Thread {
 
     private static final Logger LOG = LoggerFactory.getLogger(TestCommitThread.class);
 
+    private final RowType keyType;
+    private final RowType valueType;
+    private final boolean enableOverwrite;
     private final Map<BinaryRowData, List<KeyValue>> data;
     private final Map<BinaryRowData, List<KeyValue>> result;
     private final Map<BinaryRowData, MergeTreeWriter> writers;
@@ -57,26 +63,41 @@ public class TestCommitThread extends Thread {
     private final FileStoreCommit commit;
 
     public TestCommitThread(
+            RowType keyType,
+            RowType valueType,
+            boolean enableOverwrite,
             Map<BinaryRowData, List<KeyValue>> data,
             TestFileStore testStore,
             TestFileStore safeStore) {
+        this.keyType = keyType;
+        this.valueType = valueType;
+        this.enableOverwrite = enableOverwrite;
         this.data = data;
         this.result = new HashMap<>();
         this.writers = new HashMap<>();
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(
+                    "Test commit thread is given these data:\n"
+                            + data.values().stream()
+                                    .flatMap(Collection::stream)
+                                    .map(kv -> kv.toString(keyType, valueType))
+                                    .collect(Collectors.joining("\n")));
+        }
 
         this.write = safeStore.newWrite();
         this.commit = testStore.newCommit(UUID.randomUUID().toString());
     }
 
-    public Map<BinaryRowData, List<KeyValue>> getResult() {
-        return result;
+    public List<KeyValue> getResult() {
+        return result.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
     }
 
     @Override
     public void run() {
         while (!data.isEmpty()) {
             try {
-                if (ThreadLocalRandom.current().nextInt(5) == 0) {
+                if (enableOverwrite && ThreadLocalRandom.current().nextInt(5) == 0) {
                     // 20% probability to overwrite
                     doOverwrite();
                 } else {
@@ -151,6 +172,14 @@ public class TestCommitThread extends Thread {
         BinaryRowData partition = pickData(changes);
         result.compute(partition, (p, l) -> l == null ? new ArrayList<>() : l).addAll(changes);
 
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(
+                    "Test commit thread will write data\n"
+                            + changes.stream()
+                                    .map(kv -> kv.toString(keyType, valueType))
+                                    .collect(Collectors.joining("\n")));
+        }
+
         MergeTreeWriter writer =
                 writers.compute(partition, (p, w) -> w == null ? createWriter(p, false) : w);
         for (KeyValue kv : changes) {
@@ -165,6 +194,14 @@ public class TestCommitThread extends Thread {
                 result.compute(partition, (p, l) -> l == null ? new ArrayList<>() : l);
         resultOfPartition.clear();
         resultOfPartition.addAll(changes);
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(
+                    "Test commit thread will overwrite data\n"
+                            + changes.stream()
+                                    .map(kv -> kv.toString(keyType, valueType))
+                                    .collect(Collectors.joining("\n")));
+        }
 
         if (writers.containsKey(partition)) {
             MergeTreeWriter oldWriter = writers.get(partition);

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/TestAtomicRenameFileSystem.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/TestAtomicRenameFileSystem.java
@@ -31,9 +31,9 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.DirectoryNotEmptyException;
-import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
@@ -59,13 +59,15 @@ public class TestAtomicRenameFileSystem extends LocalFileSystem {
         dstParent.mkdirs();
         try {
             renameLock.lock();
-            Files.move(srcFile.toPath(), dstFile.toPath());
+            if (dstFile.exists()) {
+                return false;
+            }
+            Files.move(srcFile.toPath(), dstFile.toPath(), StandardCopyOption.ATOMIC_MOVE);
             return true;
         } catch (NoSuchFileException
                 | AccessDeniedException
                 | DirectoryNotEmptyException
-                | SecurityException
-                | FileAlreadyExistsException e) {
+                | SecurityException e) {
             return false;
         } finally {
             renameLock.unlock();


### PR DESCRIPTION
Currently `FileStoreCommitImpl` only checks for conflicts by checking the files we're going to delete (due to compaction) are still there.

However, consider two jobs committing into the same LSM tree at the same time. For their first compaction no conflict is detected because they'll only delete their own level 0 files. But they will both produce level 1 files and the key ranges of these files may overlap. This is not correct for our LSM tree structure.

This PR fixes this issue.