### PR TITLE
[FLINK-28642] Cannot create sink for Temporary table in table store catalog

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/AbstractTableStoreFactory.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/AbstractTableStoreFactory.java
@@ -23,6 +23,8 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.factories.DynamicTableFactory;
 import org.apache.flink.table.factories.DynamicTableSinkFactory;
 import org.apache.flink.table.factories.DynamicTableSourceFactory;
@@ -58,7 +60,7 @@ public abstract class AbstractTableStoreFactory
         implements DynamicTableSourceFactory, DynamicTableSinkFactory {
 
     @Override
-    public TableStoreSource createDynamicTableSource(Context context) {
+    public DynamicTableSource createDynamicTableSource(Context context) {
         return new TableStoreSource(
                 context.getObjectIdentifier(),
                 buildFileStoreTable(context),
@@ -69,7 +71,7 @@ public abstract class AbstractTableStoreFactory
     }
 
     @Override
-    public TableStoreSink createDynamicTableSink(Context context) {
+    public DynamicTableSink createDynamicTableSink(Context context) {
         return new TableStoreSink(
                 context.getObjectIdentifier(),
                 buildFileStoreTable(context),

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreConnectorFactory.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreConnectorFactory.java
@@ -18,7 +18,10 @@
 
 package org.apache.flink.table.store.connector;
 
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.factories.DynamicTableFactory;
+import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.store.connector.sink.TableStoreSink;
 import org.apache.flink.table.store.file.catalog.CatalogLock;
 
@@ -45,9 +48,39 @@ public class TableStoreConnectorFactory extends AbstractTableStoreFactory {
     }
 
     @Override
-    public TableStoreSink createDynamicTableSink(Context context) {
-        TableStoreSink sink = super.createDynamicTableSink(context);
+    public DynamicTableSource createDynamicTableSource(Context context) {
+        if (isFlinkTable(context)) {
+            // only 1.14 temporary table sink will come here
+            return FactoryUtil.createTableSource(
+                    null,
+                    context.getObjectIdentifier(),
+                    context.getCatalogTable(),
+                    context.getConfiguration(),
+                    context.getClassLoader(),
+                    context.isTemporary());
+        }
+        return super.createDynamicTableSource(context);
+    }
+
+    @Override
+    public DynamicTableSink createDynamicTableSink(Context context) {
+        if (isFlinkTable(context)) {
+            // only 1.14 temporary table sink will come here
+            return FactoryUtil.createTableSink(
+                    null,
+                    context.getObjectIdentifier(),
+                    context.getCatalogTable(),
+                    context.getConfiguration(),
+                    context.getClassLoader(),
+                    context.isTemporary());
+        }
+        TableStoreSink sink = (TableStoreSink) super.createDynamicTableSink(context);
         sink.setLockFactory(lockFactory);
         return sink;
+    }
+
+    private boolean isFlinkTable(Context context) {
+        String identifier = context.getCatalogTable().getOptions().get(FactoryUtil.CONNECTOR.key());
+        return identifier != null && !IDENTIFIER.equals(identifier);
     }
 }

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreConnectorFactory.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreConnectorFactory.java
@@ -50,7 +50,7 @@ public class TableStoreConnectorFactory extends AbstractTableStoreFactory {
     @Override
     public DynamicTableSource createDynamicTableSource(Context context) {
         if (isFlinkTable(context)) {
-            // only 1.14 temporary table sink will come here
+            // only Flink 1.14 temporary table will come here
             return FactoryUtil.createTableSource(
                     null,
                     context.getObjectIdentifier(),
@@ -65,7 +65,7 @@ public class TableStoreConnectorFactory extends AbstractTableStoreFactory {
     @Override
     public DynamicTableSink createDynamicTableSink(Context context) {
         if (isFlinkTable(context)) {
-            // only 1.14 temporary table sink will come here
+            // only Flink 1.14 temporary table will come here
             return FactoryUtil.createTableSink(
                     null,
                     context.getObjectIdentifier(),


### PR DESCRIPTION
Using Flink 1.14. Temporary table in table store catalog will use the Factory provided by catalog.
We need to do some delegate work like HiveDynamicTableFactory.