### PR TITLE
[FLINK-28662] Compaction should not block job cancelling

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/AppendOnlyWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/AppendOnlyWriter.java
@@ -144,6 +144,8 @@ public class AppendOnlyWriter implements RecordWriter<RowData> {
 
     @Override
     public List<DataFileMeta> close() throws Exception {
+        // cancel compaction so that it does not block job cancelling
+        compactManager.cancelCompaction();
         sync();
 
         List<DataFileMeta> result = new ArrayList<>();

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeWriter.java
@@ -238,7 +238,10 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
 
     @Override
     public List<DataFileMeta> close() throws Exception {
+        // cancel compaction so that it does not block job cancelling
+        compactManager.cancelCompaction();
         sync();
+
         // delete temporary files
         List<DataFileMeta> delete = new ArrayList<>(newFiles);
         for (DataFileMeta file : compactAfter) {


### PR DESCRIPTION
Currently when cancelling a job, we have to wait for current compaction thread to finish. If the compaction takes too long, the task manager may fail due to job cancelling takes more than 180 seconds.