### PR TITLE
[FLINK-28670] Documentation of spark2 is wrong

### DIFF
--- a/docs/content/docs/engines/spark2.md
+++ b/docs/content/docs/engines/spark2.md
@@ -50,11 +50,11 @@ Alternatively, you can copy `flink-table-store-spark2-{{< version >}}.jar` under
 
 ## Read
 
-Table store with Spark 2.4 does not support DDL, you can use the Dataset reader,
-you can register the Dataset as a temporary table.
+Table store with Spark 2.4 does not support DDL, you can use the Dataset reader
+and register the Dataset as a temporary table. In spark shell:
 
-```
-Dataset<Row> dataset = spark.read().format("tablestore").load("file:/tmp/warehouse/default.db/myTable");
-dataset.createOrReplaceTempView("myTable");
-spark.sql("SELECT * FROM myTable");
+```scala
+val dataset = spark.read.format("tablestore").load("file:/tmp/warehouse/default.db/myTable")
+dataset.createOrReplaceTempView("myTable")
+spark.sql("SELECT * FROM myTable")
 ```

--- a/docs/content/docs/engines/spark2.md
+++ b/docs/content/docs/engines/spark2.md
@@ -48,21 +48,13 @@ spark-sql ... --jars flink-table-store-spark2-{{< version >}}.jar
 
 Alternatively, you can copy `flink-table-store-spark2-{{< version >}}.jar` under `spark/jars` in your Spark installation.
 
-## Create Temporary View
+## Read
 
-Use the `CREATE TEMPORARY VIEW` command to create a Spark mapping table on top of
-an existing Table Store table.
+Table store with Spark 2.4 does not support DDL, you can use the Dataset reader,
+you can register the Dataset as a temporary table.
 
-```sql
-CREATE TEMPORARY VIEW myTable
-USING tablestore
-OPTIONS (
-  path "file:/tmp/warehouse/default.db/myTable"
-)
 ```
-
-## Query Table
-
-```sql
-SELECT * FROM myTable;
+Dataset<Row> dataset = spark.read().format("tablestore").load("file:/tmp/warehouse/default.db/myTable");
+dataset.createOrReplaceTempView("myTable");
+spark.sql("SELECT * FROM myTable");
 ```


### PR DESCRIPTION
DDL is not supported. Spark2 just support:
```
spark.read().format("tablestore").load("file:/tmp/warehouse/default.db/myTable")
```

<img width="894" alt="image" src="https://user-images.githubusercontent.com/9601882/180753483-8100b041-2ffd-441e-863a-cfe7d31c80bc.png">
