### PR TITLE
[FLINK-28687] BucketSelector is wrong when hashcode is negative

### DIFF
--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/PredicateITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/PredicateITCase.java
@@ -48,6 +48,10 @@ public class PredicateITCase extends CatalogITCaseBase {
 
     private void innerTest() throws Exception {
         sql("INSERT INTO T VALUES (1, 2), (3, 4), (5, 6), (7, 8), (9, 10)");
+        assertThat(sql("SELECT * FROM T WHERE a = 1")).containsExactlyInAnyOrder(Row.of(1, 2));
+        assertThat(sql("SELECT * FROM T WHERE a = 3")).containsExactlyInAnyOrder(Row.of(3, 4));
         assertThat(sql("SELECT * FROM T WHERE a = 5")).containsExactlyInAnyOrder(Row.of(5, 6));
+        assertThat(sql("SELECT * FROM T WHERE a = 7")).containsExactlyInAnyOrder(Row.of(7, 8));
+        assertThat(sql("SELECT * FROM T WHERE a = 9")).containsExactlyInAnyOrder(Row.of(9, 10));
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/SinkRecordConverter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/SinkRecordConverter.java
@@ -115,19 +115,28 @@ public class SinkRecordConverter {
     }
 
     private int bucket(RowData row, BinaryRowData bucketKey) {
-        int hash = bucketKey.getArity() == 0 ? hashRow(row) : bucketKey.hashCode();
-        return Math.abs(hash % numBucket);
+        int hash = bucketKey.getArity() == 0 ? hashRow(row) : hashcode(bucketKey);
+        return bucket(hash, numBucket);
     }
 
     private int hashRow(RowData row) {
         if (row instanceof BinaryRowData) {
             RowKind rowKind = row.getRowKind();
             row.setRowKind(RowKind.INSERT);
-            int hash = row.hashCode();
+            int hash = hashcode((BinaryRowData) row);
             row.setRowKind(rowKind);
             return hash;
         } else {
-            return allProjection.apply(row).hashCode();
+            return hashcode(allProjection.apply(row));
         }
+    }
+
+    public static int hashcode(BinaryRowData rowData) {
+        assert rowData.getRowKind() == RowKind.INSERT;
+        return rowData.hashCode();
+    }
+
+    public static int bucket(int hashcode, int numBucket) {
+        return Math.abs(hashcode % numBucket);
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/predicate/BucketSelectorTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/predicate/BucketSelectorTest.java
@@ -69,6 +69,7 @@ public class BucketSelectorTest {
                 newSelector(and(builder.equal(0, 0), builder.equal(1, 1), builder.equal(2, 2)))
                         .get();
         assertThat(selector.hashCodes()).containsExactly(1141287431);
+        assertThat(selector.createBucketSet(20)).containsExactly(11);
     }
 
     @Test
@@ -81,6 +82,7 @@ public class BucketSelectorTest {
                                         builder.equal(2, 2)))
                         .get();
         assertThat(selector.hashCodes()).containsExactly(-1272936927, 582056914, -1234868890);
+        assertThat(selector.createBucketSet(20)).containsExactly(7, 14, 10);
     }
 
     @Test
@@ -96,6 +98,7 @@ public class BucketSelectorTest {
                                         builder.equal(2, 2)))
                         .get();
         assertThat(selector.hashCodes()).containsExactly(-1272936927, 582056914, -1234868890);
+        assertThat(selector.createBucketSet(20)).containsExactly(7, 14, 10);
     }
 
     @Test
@@ -108,6 +111,7 @@ public class BucketSelectorTest {
                                         builder.equal(2, 2)))
                         .get();
         assertThat(selector.hashCodes()).containsExactly(-1272936927, 582056914, -1234868890);
+        assertThat(selector.createBucketSet(20)).containsExactly(7, 14, 10);
     }
 
     @Test
@@ -122,6 +126,7 @@ public class BucketSelectorTest {
         assertThat(selector.hashCodes())
                 .containsExactly(
                         -1272936927, -1567268077, 582056914, 2124429589, -1234868890, 1063796399);
+        assertThat(selector.createBucketSet(20)).containsExactly(7, 17, 14, 9, 10, 19);
     }
 
     @Test
@@ -139,6 +144,7 @@ public class BucketSelectorTest {
         assertThat(selector.hashCodes())
                 .containsExactly(
                         -1272936927, -1567268077, 582056914, 2124429589, -1234868890, 1063796399);
+        assertThat(selector.createBucketSet(20)).containsExactly(7, 17, 14, 9, 10, 19);
     }
 
     private Optional<BucketSelector> newSelector(Predicate predicate) {


### PR DESCRIPTION
The calculation of bucket should be `Math.abs(hashcode % numBucket)` instead of `hashcode % numBucket`.

