### PR TITLE
[FLINK-28700] Table store sink fails to commit for Flink 1.14 batch job

### DIFF
--- a/flink-table-store-connector/src/main/1.14.5/org/apache/flink/table/store/connector/utils/StreamExecutionEnvironmentUtils.java
+++ b/flink-table-store-connector/src/main/1.14.5/org/apache/flink/table/store/connector/utils/StreamExecutionEnvironmentUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector.utils;
+
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+import java.lang.reflect.Field;
+
+/** Utility methods for {@link StreamExecutionEnvironment}. */
+public class StreamExecutionEnvironmentUtils {
+
+    public static ReadableConfig getConfiguration(StreamExecutionEnvironment env) {
+        // For Flink 1.14 we have to use reflection to get configuration from execution environment.
+        // See FLINK-26709 for more info.
+        if (env.getClass()
+                .getName()
+                .equals("org.apache.flink.table.planner.utils.DummyStreamExecutionEnvironment")) {
+            try {
+                Field realExecEnvField = env.getClass().getDeclaredField("realExecEnv");
+                realExecEnvField.setAccessible(true);
+                env = (StreamExecutionEnvironment) realExecEnvField.get(env);
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                throw new RuntimeException(
+                        "Failed to get realExecEnv from DummyStreamExecutionEnvironment "
+                                + "by Java reflection. This is unexpected.",
+                        e);
+            }
+        }
+        return env.getConfiguration();
+    }
+}

--- a/flink-table-store-connector/src/main/1.15.0/org/apache/flink/table/store/connector/utils/StreamExecutionEnvironmentUtils.java
+++ b/flink-table-store-connector/src/main/1.15.0/org/apache/flink/table/store/connector/utils/StreamExecutionEnvironmentUtils.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector.utils;
+
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+/** Utility methods for {@link StreamExecutionEnvironment}. */
+public class StreamExecutionEnvironmentUtils {
+
+    public static ReadableConfig getConfiguration(StreamExecutionEnvironment env) {
+        return env.getConfiguration();
+    }
+}

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSink.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSink.java
@@ -28,6 +28,7 @@ import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.connector.utils.StreamExecutionEnvironmentUtils;
 import org.apache.flink.table.store.file.catalog.CatalogLock;
 import org.apache.flink.table.store.file.manifest.ManifestCommittableSerializer;
 import org.apache.flink.table.store.file.operation.Lock;
@@ -103,7 +104,8 @@ public class StoreSink implements Serializable {
 
         StreamExecutionEnvironment env = input.getExecutionEnvironment();
         boolean streamingCheckpointEnabled =
-                env.getConfiguration().get(ExecutionOptions.RUNTIME_MODE)
+                StreamExecutionEnvironmentUtils.getConfiguration(env)
+                                        .get(ExecutionOptions.RUNTIME_MODE)
                                 == RuntimeExecutionMode.STREAMING
                         && env.getCheckpointConfig().isCheckpointingEnabled();
         SingleOutputStreamOperator<?> committed =


### PR DESCRIPTION
We can't get configurations from `DummyStreamExecutionEnvironment` in Flink 1.14 (this is fixed by FLINK-26709 in Flink 1.15) so we have to use Java reflection to check if this execution environment is for batch job or for streaming job.