### PR TITLE
[FLINK-28705] Update copyright year to 2014-2022 in NOTICE files

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Flink Table Store (flink-table-store)
-Copyright 2014-2021 The Apache Software Foundation
+Copyright 2014-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-table-store-hive/flink-table-store-hive-catalog/src/main/resources/META-INF/NOTICE
+++ b/flink-table-store-hive/flink-table-store-hive-catalog/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-table-store-hive-catalog
-Copyright 2014-2021 The Apache Software Foundation
+Copyright 2014-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
Copyright year of the NOTICE files in Flink Table Store need to be updated to `2014-2022`.

**The brief change log**
- Updates copyright year of the NOTICE files to `2014-2022`.