### PR TITLE
[FLINK-28717] Add null checking for all field getters

### DIFF
--- a/flink-table-store-common/src/main/java/org/apache/flink/table/store/utils/RowDataToObjectArrayConverter.java
+++ b/flink-table-store-common/src/main/java/org/apache/flink/table/store/utils/RowDataToObjectArrayConverter.java
@@ -33,7 +33,10 @@ public class RowDataToObjectArrayConverter {
         this.rowType = rowType;
         this.fieldGetters =
                 IntStream.range(0, rowType.getFieldCount())
-                        .mapToObj(i -> RowData.createFieldGetter(rowType.getTypeAt(i), i))
+                        .mapToObj(
+                                i ->
+                                        RowDataUtils.createNullCheckingFieldGetter(
+                                                rowType.getTypeAt(i), i))
                         .toArray(RowData.FieldGetter[]::new);
     }
 

--- a/flink-table-store-common/src/main/java/org/apache/flink/table/store/utils/RowDataUtils.java
+++ b/flink-table-store-common/src/main/java/org/apache/flink/table/store/utils/RowDataUtils.java
@@ -280,4 +280,19 @@ public class RowDataUtils {
         bd = bd.setScale(0, RoundingMode.DOWN);
         return bd.longValue();
     }
+
+    public static RowData.FieldGetter createNullCheckingFieldGetter(
+            LogicalType logicalType, int index) {
+        RowData.FieldGetter getter = RowData.createFieldGetter(logicalType, index);
+        if (logicalType.isNullable()) {
+            return getter;
+        } else {
+            return row -> {
+                if (row.isNullAt(index)) {
+                    return null;
+                }
+                return getter.getFieldOrNull(row);
+            };
+        }
+    }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValue.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValue.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.store.file;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.table.store.utils.RowDataUtils;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.TinyIntType;
@@ -147,7 +148,8 @@ public class KeyValue {
                 .mapToObj(
                         i ->
                                 String.valueOf(
-                                        RowData.createFieldGetter(type.getTypeAt(i), i)
+                                        RowDataUtils.createNullCheckingFieldGetter(
+                                                        type.getTypeAt(i), i)
                                                 .getFieldOrNull(row)))
                 .collect(Collectors.joining(", "));
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/stats/FieldStatsArraySerializer.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/stats/FieldStatsArraySerializer.java
@@ -22,6 +22,7 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.store.format.FieldStats;
+import org.apache.flink.table.store.utils.RowDataUtils;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -47,7 +48,10 @@ public class FieldStatsArraySerializer {
         this.serializer = new RowDataSerializer(safeType);
         this.fieldGetters =
                 IntStream.range(0, safeType.getFieldCount())
-                        .mapToObj(i -> RowData.createFieldGetter(safeType.getTypeAt(i), i))
+                        .mapToObj(
+                                i ->
+                                        RowDataUtils.createNullCheckingFieldGetter(
+                                                safeType.getTypeAt(i), i))
                         .toArray(RowData.FieldGetter[]::new);
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RowDataPartitionComputer.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RowDataPartitionComputer.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.store.file.utils;
 
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.utils.RowDataUtils;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.StringUtils;
 
@@ -41,7 +42,10 @@ public class RowDataPartitionComputer {
         this.partitionFieldGetters =
                 Arrays.stream(partitionColumns)
                         .mapToInt(columnList::indexOf)
-                        .mapToObj(i -> RowData.createFieldGetter(rowType.getTypeAt(i), i))
+                        .mapToObj(
+                                i ->
+                                        RowDataUtils.createNullCheckingFieldGetter(
+                                                rowType.getTypeAt(i), i))
                         .toArray(RowData.FieldGetter[]::new);
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
@@ -46,6 +46,7 @@ import org.apache.flink.table.store.table.source.SplitGenerator;
 import org.apache.flink.table.store.table.source.TableRead;
 import org.apache.flink.table.store.table.source.TableScan;
 import org.apache.flink.table.store.table.source.ValueContentRowDataRecordIterator;
+import org.apache.flink.table.store.utils.RowDataUtils;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 
@@ -83,7 +84,8 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
                 List<LogicalType> fieldTypes = rowType.getChildren();
                 RowData.FieldGetter[] fieldGetters = new RowData.FieldGetter[fieldTypes.size()];
                 for (int i = 0; i < fieldTypes.size(); i++) {
-                    fieldGetters[i] = RowData.createFieldGetter(fieldTypes.get(i), i);
+                    fieldGetters[i] =
+                            RowDataUtils.createNullCheckingFieldGetter(fieldTypes.get(i), i);
                 }
                 mergeFunction = new PartialUpdateMergeFunction(fieldGetters);
                 break;

--- a/flink-table-store-hive/flink-table-store-hive-connector/src/main/java/org/apache/flink/table/store/hive/objectinspector/TableStoreRowDataObjectInspector.java
+++ b/flink-table-store-hive/flink-table-store-hive-connector/src/main/java/org/apache/flink/table/store/hive/objectinspector/TableStoreRowDataObjectInspector.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.store.hive.objectinspector;
 
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.hive.HiveTypeUtils;
+import org.apache.flink.table.store.utils.RowDataUtils;
 import org.apache.flink.table.types.logical.LogicalType;
 
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
@@ -53,7 +54,7 @@ public class TableStoreRowDataObjectInspector extends StructObjectInspector {
                             name,
                             TableStoreObjectInspectorFactory.create(logicalType),
                             i,
-                            RowData.createFieldGetter(logicalType, i),
+                            RowDataUtils.createNullCheckingFieldGetter(logicalType, i),
                             fieldComments.get(i));
             structFields.add(structField);
             structFieldMap.put(name, structField);

--- a/flink-table-store-kafka/src/main/java/org/apache/flink/table/store/kafka/KafkaLogDeserializationSchema.java
+++ b/flink-table-store-kafka/src/main/java/org/apache/flink/table/store/kafka/KafkaLogDeserializationSchema.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.store.utils.ProjectedRowData;
 import org.apache.flink.table.store.utils.Projection;
+import org.apache.flink.table.store.utils.RowDataUtils;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Collector;
@@ -71,7 +72,7 @@ public class KafkaLogDeserializationSchema implements KafkaDeserializationSchema
                 IntStream.range(0, primaryKey.length)
                         .mapToObj(
                                 i ->
-                                        RowData.createFieldGetter(
+                                        RowDataUtils.createNullCheckingFieldGetter(
                                                 physicalType
                                                         .getChildren()
                                                         .get(primaryKey[i])


### PR DESCRIPTION
Table Store Hive connector implement projection pushdown by reading desired fields and setting other unread fields to null. However the nullability of primary key fields are not null, so `RowData.FieldGetter` will not check for null values for these types. This may cause exception when primary key fields are not selected and are set to null.