### PR TITLE
[FLINK-28715] Throw better exception when file not found in reading

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/AppendOnlyReader.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/AppendOnlyReader.java
@@ -37,9 +37,7 @@ public class AppendOnlyReader implements RecordReader<RowData> {
 
     public AppendOnlyReader(Path path, BulkFormat<RowData, FileSourceSplit> readerFactory)
             throws IOException {
-        long fileSize = FileUtils.getFileSize(path);
-        FileSourceSplit split = new FileSourceSplit("ignore", path, 0, fileSize);
-        this.reader = readerFactory.createReader(FileUtils.DEFAULT_READER_CONFIG, split);
+        this.reader = FileUtils.createFormatReader(readerFactory, path);
     }
 
     @Nullable

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileReader.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileReader.java
@@ -83,9 +83,7 @@ public class DataFileReader {
         private final KeyValueSerializer serializer;
 
         private DataFileRecordReader(Path path) throws IOException {
-            long fileSize = FileUtils.getFileSize(path);
-            FileSourceSplit split = new FileSourceSplit("ignore", path, 0, fileSize);
-            this.reader = readerFactory.createReader(FileUtils.DEFAULT_READER_CONFIG, split);
+            this.reader = FileUtils.createFormatReader(readerFactory, path);
             this.serializer = new KeyValueSerializer(keyType, valueType);
         }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/FileUtils.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/FileUtils.java
@@ -187,8 +187,10 @@ public class FileUtils {
             throw new FileNotFoundException(
                     String.format(
                             "File '%s' not found, Possible causes: "
-                                    + "1.consumption is too slow, you can improve the performance of consumption. "
-                                    + "2.snapshot expires too fast, you can configure a larger snapshot.time-retained.",
+                                    + "1.snapshot expires too fast, you can configure 'snapshot.time-retained'"
+                                    + " option with a larger value. "
+                                    + "2.consumption is too slow, you can improve the performance of consumption"
+                                    + " (For example, increasing parallelism).",
                             file));
         }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/FileUtils.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/FileUtils.java
@@ -54,7 +54,7 @@ public class FileUtils {
     private static final Logger LOG = LoggerFactory.getLogger(FileUtils.class);
     private static final int LIST_MAX_RETRY = 30;
 
-    public static final Configuration DEFAULT_READER_CONFIG = new Configuration();
+    private static final Configuration DEFAULT_READER_CONFIG = new Configuration();
 
     static {
         DEFAULT_READER_CONFIG.setInteger(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY, 1);
@@ -82,11 +82,9 @@ public class FileUtils {
             BulkFormat<RowData, FileSourceSplit> readerFactory)
             throws IOException {
         List<T> result = new ArrayList<>();
-        long fileSize = FileUtils.getFileSize(path);
-        FileSourceSplit split = new FileSourceSplit("ignore", path, 0, fileSize);
-        BulkFormat.Reader<RowData> reader =
-                readerFactory.createReader(DEFAULT_READER_CONFIG, split);
-        Utils.forEachRemaining(reader, row -> result.add(serializer.fromRow(row)));
+        Utils.forEachRemaining(
+                createFormatReader(readerFactory, path),
+                row -> result.add(serializer.fromRow(row)));
         return result;
     }
 
@@ -181,5 +179,21 @@ public class FileUtils {
                 .map(Path::getName)
                 .filter(name -> name.startsWith(prefix))
                 .map(name -> Long.parseLong(name.substring(prefix.length())));
+    }
+
+    public static BulkFormat.Reader<RowData> createFormatReader(
+            BulkFormat<RowData, FileSourceSplit> format, Path file) throws IOException {
+        if (!file.getFileSystem().exists(file)) {
+            throw new FileNotFoundException(
+                    String.format(
+                            "File '%s' not found, Possible causes: "
+                                    + "1.consumption is too slow, you can improve the performance of consumption. "
+                                    + "2.snapshot expires too fast, you can configure a larger snapshot.time-retained.",
+                            file));
+        }
+
+        long fileSize = FileUtils.getFileSize(file);
+        FileSourceSplit split = new FileSourceSplit("ignore", file, 0, fileSize);
+        return format.createReader(FileUtils.DEFAULT_READER_CONFIG, split);
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileTest.java
@@ -54,6 +54,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link DataFileReader} and {@link DataFileWriter}. */
 public class DataFileTest {
@@ -62,6 +63,13 @@ public class DataFileTest {
             DataFileTestDataGenerator.builder().memTableCapacity(20).build();
 
     @TempDir java.nio.file.Path tempDir;
+
+    @Test
+    public void testReadNonExistentFile() {
+        DataFileReader reader = createDataFileReader(tempDir.toString(), "avro", null, null);
+        assertThatThrownBy(() -> reader.read("dummy_file"))
+                .hasMessageContaining("you can configure a larger snapshot.time-retained");
+    }
 
     @RepeatedTest(10)
     public void testWriteAndReadDataFileWithStatsCollectingRollingFile() throws Exception {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileTest.java
@@ -68,7 +68,8 @@ public class DataFileTest {
     public void testReadNonExistentFile() {
         DataFileReader reader = createDataFileReader(tempDir.toString(), "avro", null, null);
         assertThatThrownBy(() -> reader.read("dummy_file"))
-                .hasMessageContaining("you can configure a larger snapshot.time-retained");
+                .hasMessageContaining(
+                        "you can configure 'snapshot.time-retained' option with a larger value.");
     }
 
     @RepeatedTest(10)


### PR DESCRIPTION
When reading a file, if it is found that the file does not exist, it directly throws a file not found exception, which is often difficult for users to understand.
We can make it more clear in the exception message, e.g.
The file cannot be found, this may be because the read is too slow and the previous snapshot expired, you can configure a larger snapshot.time-retained or speed up your read.

```
Caused by: java.io.FileNotFoundException: File does not exist:
at org.apache.flink.table.store.file.utils.FileUtils.getFileSize(FileUtils.java:94) ~[flink-table-store-dist-0.2.jar:0.2-SNAPSHOT]
at org.apache.flink.table.store.file.data.DataFileReader$DataFileRecordReader.<init>(DataFileReader.java:86) ~[flink-table-store-dist-0.2.jar:0.2-SNAPSHOT]
```