### PR TITLE
[FLINK-28730] Add Tez execution engine test for Table Store Hive connector

### DIFF
--- a/docs/content/docs/engines/hive.md
+++ b/docs/content/docs/engines/hive.md
@@ -34,6 +34,10 @@ Table Store currently supports the following features related with Hive:
 
 Table Store currently supports Hive 2.x.
 
+## Execution Engine
+
+Table Store currently supports MR and Tez execution engine for Hive.
+
 ## Install
 
 {{< stable >}}

--- a/flink-table-store-hive/flink-table-store-hive-connector/pom.xml
+++ b/flink-table-store-hive/flink-table-store-hive-connector/pom.xml
@@ -198,10 +198,6 @@ under the License.
                     <artifactId>hive-webhcat-java-client</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.apache.tez</groupId>
-                    <artifactId>tez-common</artifactId>
-                </exclusion>
-                <exclusion>
                     <!-- This dependency is no longer shipped with the JDK since Java 9.-->
                     <groupId>jdk.tools</groupId>
                     <artifactId>jdk.tools</artifactId>
@@ -245,10 +241,6 @@ under the License.
                 <exclusion>
                     <artifactId>hadoop-yarn-server-web-proxy</artifactId>
                     <groupId>org.apache.hadoop</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>hadoop-shim</artifactId>
-                    <groupId>org.apache.tez</groupId>
                 </exclusion>
                 <exclusion>
                     <artifactId>jms</artifactId>

--- a/flink-table-store-hive/flink-table-store-hive-connector/src/main/java/org/apache/flink/table/store/mapred/TableStoreInputFormat.java
+++ b/flink-table-store-hive/flink-table-store-hive-connector/src/main/java/org/apache/flink/table/store/mapred/TableStoreInputFormat.java
@@ -73,7 +73,7 @@ public class TableStoreInputFormat implements InputFormat<Void, RowDataContainer
                 read,
                 split,
                 table.schema().fieldNames(),
-                Arrays.asList(ColumnProjectionUtils.getReadColumnNames(jobConf)));
+                Arrays.asList(getSelectedColumns(jobConf)));
     }
 
     private FileStoreTable createFileStoreTable(JobConf jobConf) {
@@ -96,5 +96,13 @@ public class TableStoreInputFormat implements InputFormat<Void, RowDataContainer
                 new SearchArgumentToPredicateConverter(
                         sarg, tableSchema.fieldNames(), tableSchema.logicalRowType().getChildren());
         return converter.convert();
+    }
+
+    private String[] getSelectedColumns(JobConf jobConf) {
+        // when using tez engine or when same table is joined multiple times,
+        // it is possible that some selected columns are duplicated
+        return Arrays.stream(ColumnProjectionUtils.getReadColumnNames(jobConf))
+                .distinct()
+                .toArray(String[]::new);
     }
 }


### PR DESCRIPTION
Table Store Hive connector is supposed to support both MR and Tez engine. However current tests only runs on MR. We need to add Tez tests.