### PR TITLE
[FLINK-28727] Flink Source supports `SupportsLimitPushDown`

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSource.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSource.java
@@ -58,19 +58,23 @@ public class FileStoreSource
 
     @Nullable private final Predicate predicate;
 
+    @Nullable private final Long limit;
+
     public FileStoreSource(
             FileStoreTable table,
             boolean isContinuous,
             long discoveryInterval,
             boolean latestContinuous,
             @Nullable int[][] projectedFields,
-            @Nullable Predicate predicate) {
+            @Nullable Predicate predicate,
+            @Nullable Long limit) {
         this.table = table;
         this.isContinuous = isContinuous;
         this.discoveryInterval = discoveryInterval;
         this.latestContinuous = latestContinuous;
         this.projectedFields = projectedFields;
         this.predicate = predicate;
+        this.limit = limit;
     }
 
     @Override
@@ -87,7 +91,7 @@ public class FileStoreSource
         if (predicate != null) {
             read.withFilter(predicate);
         }
-        return new FileStoreSourceReader(context, read);
+        return new FileStoreSourceReader(context, read, limit);
     }
 
     @Override

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceReader.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceReader.java
@@ -35,9 +35,10 @@ public final class FileStoreSourceReader
                 FileStoreSourceSplit,
                 FileStoreSourceSplitState> {
 
-    public FileStoreSourceReader(SourceReaderContext readerContext, TableRead tableRead) {
+    public FileStoreSourceReader(
+            SourceReaderContext readerContext, TableRead tableRead, Long limit) {
         super(
-                () -> new FileStoreSourceSplitReader(tableRead),
+                () -> new FileStoreSourceSplitReader(tableRead, limit),
                 (element, output, splitState) -> {
                     output.collect(element.getRecord());
                     splitState.setPosition(element);

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceReader.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceReader.java
@@ -25,6 +25,8 @@ import org.apache.flink.connector.file.src.util.RecordAndPosition;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.table.source.TableRead;
 
+import javax.annotation.Nullable;
+
 import java.util.Map;
 
 /** A {@link SourceReader} that read records from {@link FileStoreSourceSplit}. */
@@ -36,7 +38,7 @@ public final class FileStoreSourceReader
                 FileStoreSourceSplitState> {
 
     public FileStoreSourceReader(
-            SourceReaderContext readerContext, TableRead tableRead, Long limit) {
+            SourceReaderContext readerContext, TableRead tableRead, @Nullable Long limit) {
         super(
                 () -> new FileStoreSourceSplitReader(tableRead, limit),
                 (element, output, splitState) -> {

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitReader.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitReader.java
@@ -43,7 +43,7 @@ public class FileStoreSourceSplitReader
 
     private final TableRead tableRead;
 
-    private final Long limit;
+    @Nullable private final Long limit;
 
     private final Queue<FileStoreSourceSplit> splits;
 
@@ -54,12 +54,12 @@ public class FileStoreSourceSplitReader
     private long currentNumRead;
     private RecordReader.RecordIterator<RowData> currentFirstBatch;
 
-    public FileStoreSourceSplitReader(TableRead tableRead, Long limit) {
+    public FileStoreSourceSplitReader(TableRead tableRead, @Nullable Long limit) {
         this.tableRead = tableRead;
         this.limit = limit;
         this.splits = new LinkedList<>();
         this.pool = new Pool<>(1);
-        this.pool.add(new FileStoreRecordIterator(limit));
+        this.pool.add(new FileStoreRecordIterator());
     }
 
     @Override
@@ -165,16 +165,10 @@ public class FileStoreSourceSplitReader
 
     private class FileStoreRecordIterator implements BulkFormat.RecordIterator<RowData> {
 
-        private final Long limit;
-
         private RecordReader.RecordIterator<RowData> iterator;
 
         private final MutableRecordAndPosition<RowData> recordAndPosition =
                 new MutableRecordAndPosition<>();
-
-        public FileStoreRecordIterator(Long limit) {
-            this.limit = limit;
-        }
 
         public FileStoreRecordIterator replace(RecordReader.RecordIterator<RowData> iterator) {
             this.iterator = iterator;

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FlinkSourceBuilder.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FlinkSourceBuilder.java
@@ -60,6 +60,7 @@ public class FlinkSourceBuilder {
     @Nullable private Predicate predicate;
     @Nullable private LogSourceProvider logSourceProvider;
     @Nullable private Integer parallelism;
+    @Nullable private Long limit;
     @Nullable private WatermarkStrategy<RowData> watermarkStrategy;
 
     public FlinkSourceBuilder(ObjectIdentifier tableIdentifier, FileStoreTable table) {
@@ -85,6 +86,11 @@ public class FlinkSourceBuilder {
 
     public FlinkSourceBuilder withPredicate(Predicate predicate) {
         this.predicate = predicate;
+        return this;
+    }
+
+    public FlinkSourceBuilder withLimit(@Nullable Long limit) {
+        this.limit = limit;
         return this;
     }
 
@@ -115,7 +121,8 @@ public class FlinkSourceBuilder {
                 discoveryIntervalMills(),
                 continuousScanLatest,
                 projectedFields,
-                predicate);
+                predicate,
+                limit);
     }
 
     private Source<RowData, ?, ?> buildSource() {

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceReaderTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceReaderTest.java
@@ -60,7 +60,8 @@ public class FileStoreSourceReaderTest {
     private FileStoreSourceReader createReader(TestingReaderContext context) {
         return new FileStoreSourceReader(
                 context,
-                new TestChangelogDataReadWrite(tempDir.toString(), null).createReadWithKey());
+                new TestChangelogDataReadWrite(tempDir.toString(), null).createReadWithKey(),
+                null);
     }
 
     private static FileStoreSourceSplit createTestFileSplit() {


### PR DESCRIPTION
`FileStoreSource` could support for the `SupportsLimitPushDown` interface.

**The brief change log**
- `FileStoreSource` implements the `SupportsLimitPushDown` interface.