### PR TITLE
[FLINK-28760] Enable table store support in Hive by creating auxlib directory

### DIFF
--- a/docs/content/docs/engines/hive.md
+++ b/docs/content/docs/engines/hive.md
@@ -103,6 +103,7 @@ SELECT * FROM test_table;
 Run the following Hive SQL in Hive CLI to access the created table.
 
 ```sql
+-- Assume that flink-table-store-hive-connector-{{< version >}}.jar is already in auxlib directory.
 -- List tables in Hive
 -- (you might need to switch to "default" database if you're not there by default)
 
@@ -129,6 +130,7 @@ OK
 To access existing table store table, you can also register them as external tables in Hive. Run the following Hive SQL in Hive CLI.
 
 ```sql
+-- Assume that flink-table-store-hive-connector-{{< version >}}.jar is already in auxlib directory.
 -- Let's use the test_table created in the above section.
 -- To create an external table, you don't need to specify any column or table properties.
 -- Pointing the location to the path of table is enough.

--- a/docs/content/docs/engines/hive.md
+++ b/docs/content/docs/engines/hive.md
@@ -49,7 +49,7 @@ You are using an unreleased version of Table Store. See [Build From Source]({{< 
 
 {{< /unstable >}}
 
-Copy table store Hive connector bundle jar to a path accessible by Hive, then use `add jar /path/to/flink-table-store-hive-connector-{{< version >}}.jar` to enable table store support in Hive.
+Create an `auxlib` folder under the root directory of Hive, and copy `flink-table-store-hive-connector-{{< version >}}.jar` into `auxlib`.
 
 ## Using Table Store Hive Catalog
 
@@ -100,10 +100,6 @@ SELECT * FROM test_table;
 Run the following Hive SQL in Hive CLI to access the created table.
 
 ```sql
--- Enable table store support in Hive
-
-ADD JAR /path/to/flink-table-store-hive-connector-{{< version >}}.jar;
-
 -- List tables in Hive
 -- (you might need to switch to "default" database if you're not there by default)
 
@@ -130,10 +126,6 @@ OK
 To access existing table store table, you can also register them as external tables in Hive. Run the following Hive SQL in Hive CLI.
 
 ```sql
--- Enable table store support in Hive
-
-ADD JAR /path/to/flink-table-store-hive-connector-{{< version >}}.jar;
-
 -- Let's use the test_table created in the above section.
 -- To create an external table, you don't need to specify any column or table properties.
 -- Pointing the location to the path of table is enough.

--- a/docs/content/docs/engines/hive.md
+++ b/docs/content/docs/engines/hive.md
@@ -49,7 +49,10 @@ You are using an unreleased version of Table Store. See [Build From Source]({{< 
 
 {{< /unstable >}}
 
-Create an `auxlib` folder under the root directory of Hive, and copy `flink-table-store-hive-connector-{{< version >}}.jar` into `auxlib`.
+There are several ways to add this jar to Hive.
+
+* You can create an `auxlib` folder under the root directory of Hive, and copy `flink-table-store-hive-connector-{{< version >}}.jar` into `auxlib`.
+* You can also copy this jar to a path accessible by Hive, then use `add jar /path/to/flink-table-store-hive-connector-{{< version >}}.jar` to enable table store support in Hive. Note that this method is not recommended. If you're using the MR execution engine and running a join statement, you may be faced with the exception `org.apache.hive.com.esotericsoftware.kryo.kryoexception: unable to find class`.
 
 ## Using Table Store Hive Catalog
 

--- a/flink-table-store-e2e-tests/pom.xml
+++ b/flink-table-store-e2e-tests/pom.xml
@@ -31,6 +31,10 @@ under the License.
     <artifactId>flink-table-store-e2e-tests</artifactId>
     <name>Flink Table Store : End to End Tests</name>
 
+    <properties>
+        <flink.shaded.hadoop.version>2.8.3-10.0</flink.shaded.hadoop.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
@@ -100,7 +104,7 @@ under the License.
                             <destFileName>flink-table-store.jar</destFileName>
                             <type>jar</type>
                             <overWrite>true</overWrite>
-                            <outputDirectory>${project.build.directory}/dependencies
+                            <outputDirectory>/tmp/flink-table-store-e2e-tests-jars
                             </outputDirectory>
                         </artifactItem>
                         <artifactItem>
@@ -110,17 +114,17 @@ under the License.
                             <destFileName>flink-table-store-hive-connector.jar</destFileName>
                             <type>jar</type>
                             <overWrite>true</overWrite>
-                            <outputDirectory>${project.build.directory}/dependencies
+                            <outputDirectory>/tmp/flink-table-store-e2e-tests-jars
                             </outputDirectory>
                         </artifactItem>
                         <artifactItem>
                             <groupId>org.apache.flink</groupId>
                             <artifactId>flink-shaded-hadoop-2-uber</artifactId>
-                            <version>2.8.3-10.0</version>
+                            <version>${flink.shaded.hadoop.version}</version>
                             <destFileName>bundled-hadoop.jar</destFileName>
                             <type>jar</type>
                             <overWrite>true</overWrite>
-                            <outputDirectory>${project.build.directory}/dependencies
+                            <outputDirectory>/tmp/flink-table-store-e2e-tests-jars
                             </outputDirectory>
                         </artifactItem>
                     </artifactItems>

--- a/flink-table-store-e2e-tests/src/test/java/org/apache/flink/table/store/tests/E2eTestBase.java
+++ b/flink-table-store-e2e-tests/src/test/java/org/apache/flink/table/store/tests/E2eTestBase.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.table.store.tests;
 
-import org.apache.flink.table.store.tests.utils.TestUtils;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
@@ -30,7 +28,6 @@ import org.testcontainers.containers.DockerComposeContainer;
 import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.utility.MountableFile;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -63,11 +60,6 @@ public abstract class E2eTestBase {
         this.withKafka = withKafka;
         this.withHive = withHive;
     }
-
-    private static final String TABLE_STORE_JAR_NAME = "flink-table-store.jar";
-    protected static final String TABLE_STORE_HIVE_CONNECTOR_JAR_NAME =
-            "flink-table-store-hive-connector.jar";
-    private static final String BUNDLED_HADOOP_JAR_NAME = "bundled-hadoop.jar";
 
     protected static final String TEST_DATA_DIR = "/test-data";
     protected static final String HDFS_ROOT = "hdfs://namenode:8020";
@@ -121,10 +113,6 @@ public abstract class E2eTestBase {
         environment.start();
         jobManager = environment.getContainerByServiceName("jobmanager_1").get();
         jobManager.execInContainer("chown", "-R", "flink:flink", TEST_DATA_DIR);
-
-        copyResource(TABLE_STORE_JAR_NAME);
-        copyResource(TABLE_STORE_HIVE_CONNECTOR_JAR_NAME);
-        copyResource(BUNDLED_HADOOP_JAR_NAME);
     }
 
     @AfterEach
@@ -132,12 +120,6 @@ public abstract class E2eTestBase {
         if (environment != null) {
             environment.stop();
         }
-    }
-
-    private void copyResource(String resourceName) {
-        jobManager.copyFileToContainer(
-                MountableFile.forHostPath(TestUtils.getResource(resourceName).toString()),
-                TEST_DATA_DIR + "/" + resourceName);
     }
 
     protected void writeSharedFile(String filename, String content) throws Exception {
@@ -172,20 +154,7 @@ public abstract class E2eTestBase {
                         "su",
                         "flink",
                         "-c",
-                        "bin/sql-client.sh -f "
-                                + TEST_DATA_DIR
-                                + "/"
-                                + fileName
-                                // run with table store jar
-                                + " --jar "
-                                + TEST_DATA_DIR
-                                + "/"
-                                + TABLE_STORE_JAR_NAME
-                                // run with bundled hadoop jar
-                                + " --jar "
-                                + TEST_DATA_DIR
-                                + "/"
-                                + BUNDLED_HADOOP_JAR_NAME);
+                        "bin/sql-client.sh -f " + TEST_DATA_DIR + "/" + fileName);
         LOG.info(execResult.getStdout());
         LOG.info(execResult.getStderr());
         if (execResult.getExitCode() != 0) {

--- a/flink-table-store-e2e-tests/src/test/resources-filtered/docker-compose.yaml
+++ b/flink-table-store-e2e-tests/src/test/resources-filtered/docker-compose.yaml
@@ -28,7 +28,8 @@ services:
     image: apache/flink:${flink.version}-java8
     volumes:
       - testdata:/test-data
-    entrypoint: /bin/bash -c "wget -P /opt/flink/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-shaded-hadoop-2-uber/2.8.3-10.0/flink-shaded-hadoop-2-uber-2.8.3-10.0.jar && /docker-entrypoint.sh jobmanager"
+      - /tmp/flink-table-store-e2e-tests-jars:/jars
+    entrypoint: /bin/bash -c "cp /jars/flink-table-store.jar /jars/bundled-hadoop.jar /opt/flink/lib && /docker-entrypoint.sh jobmanager"
     env_file:
       - ./flink.env
     networks:
@@ -42,7 +43,8 @@ services:
     image: apache/flink:${flink.version}-java8
     volumes:
       - testdata:/test-data
-    entrypoint: /bin/bash -c "wget -P /opt/flink/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-shaded-hadoop-2-uber/2.8.3-10.0/flink-shaded-hadoop-2-uber-2.8.3-10.0.jar && /docker-entrypoint.sh taskmanager"
+      - /tmp/flink-table-store-e2e-tests-jars:/jars
+    entrypoint: /bin/bash -c "cp /jars/flink-table-store.jar /jars/bundled-hadoop.jar /opt/flink/lib && /docker-entrypoint.sh taskmanager"
     env_file:
       - ./flink.env
     networks:
@@ -130,6 +132,7 @@ services:
     image: bde2020/hive:2.3.2-postgresql-metastore
     volumes:
       - testdata:/test-data
+      - /tmp/flink-table-store-e2e-tests-jars:/jars
     networks:
       testnetwork:
         aliases:


### PR DESCRIPTION
Current table store Hive document states that, to enable support in Hive, we should use ADD JAR statement to add hive connector jar.

However some types of queries, for example join statements in MR engine, may still throw ClassNotFound exception. The correct way to enable table store support is to create an auxlib directory under the root directory of Hive and copy jar into that directory.