### PR TITLE
[FLINK-28665] Disable deployment of table store benchmark module

### DIFF
--- a/flink-table-store-benchmark/pom.xml
+++ b/flink-table-store-benchmark/pom.xml
@@ -84,6 +84,14 @@ under the License.
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>


### PR DESCRIPTION
Currently the benchmark module does not have a correct NOTICE file. However this module does not need to be released, so we can just skip its deployment.