### PR TITLE
[FLINK-28840] Introduce roadmap document of Flink Table Store

### DIFF
--- a/docs/content/docs/development/roadmap.md
+++ b/docs/content/docs/development/roadmap.md
@@ -1,0 +1,40 @@
+---
+title: "Roadmap"
+weight: 8
+type: docs
+aliases:
+- /development/roadmap.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Flink Table Store Roadmap
+
+This page is intended to present an overview of the general direction of the Flink Table Store project, and the larger new features on our radar.
+It's not a comprehensive list and might be slightly outdated at any given time. Please check JIRA for the actual work items and the Flink mailing lists for feature planning and discussion.
+
+## What’s Next?
+
+- Concurrent write support for table store
+- Changelog producer supports full-compaction and lookup
+- Pre-aggregated merge support [FLIP-255](https://cwiki.apache.org/confluence/display/FLINK/FLIP-255+Introduce+pre-aggregated+merge+to+Table+Store)
+- Lookup dim join support
+- Completed schema evolution support
+- Batch writing improvement
+- Time traveling support


### PR DESCRIPTION
The Flink Table Store subproject needs its own roadmap document to present an overview of the general direction.

**The brief change log**
- Introduces roadmap document `roadmap.md` of Flink Table Store.