### PR TITLE
[FLINK-28754] Document that Java 8 is required to build table store

### DIFF
--- a/docs/content/docs/engines/build.md
+++ b/docs/content/docs/engines/build.md
@@ -24,9 +24,13 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Build From Source
+# Build from Source
 
-Clone from git, enter:
+In order to build the Flink Table Store you need the source code. Either [download the source of a release]({{< downloads >}}) or [clone the git repository]({{< github_repo >}}).
+
+In addition, you need **Maven 3** and a **JDK** (Java Development Kit). Flink Table Store requires **Java 8** to build.
+
+To clone from git, enter:
 
 ```bash
 git clone {{< github_repo >}}


### PR DESCRIPTION
Flink Table Store can not be built with Java 11, but the "[build from source](https://nightlies.apache.org/flink/flink-table-store-docs-master/docs/engines/build)" instructions don't mention this restriction.

**The brief change log**
- Add the instructions of built with Java 11 in `build.md`.