### PR TITLE
[FLINK-28903] flink-table-store-hive-catalog could not shade hive-shims-0.23

### DIFF
--- a/flink-table-store-dist/pom.xml
+++ b/flink-table-store-dist/pom.xml
@@ -185,10 +185,6 @@ under the License.
                                     <shadedPattern>org.apache.flink.table.store.shaded.streaming.util.serialization.TypeInformationKeyValueSerializationSchema</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>org.apache.hadoop.security.token.delegation.HiveDelegationTokenSupport</pattern>
-                                    <shadedPattern>org.apache.flink.table.store.shaded.org.apache.hadoop.security.token.delegation.HiveDelegationTokenSupport</shadedPattern>
-                                </relocation>
-                                <relocation>
                                     <pattern>org.apache.kafka</pattern>
                                     <shadedPattern>org.apache.flink.table.store.shaded.org.apache.kafka</shadedPattern>
                                 </relocation>

--- a/flink-table-store-hive/flink-table-store-hive-catalog/pom.xml
+++ b/flink-table-store-hive/flink-table-store-hive-catalog/pom.xml
@@ -476,7 +476,6 @@ under the License.
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <minimizeJar>true</minimizeJar>
                             <artifactSet>
                                 <includes>
                                     <include>org.apache.flink:flink-table-store-hive-common</include>
@@ -485,6 +484,7 @@ under the License.
                                     <include>com.google.guava:guava</include>
                                     <include>org.apache.hive:hive-common</include>
                                     <include>org.apache.hive.shims:hive-shims-common</include>
+                                    <include>org.apache.hive.shims:hive-shims-0.23</include>
                                     <include>org.apache.hive:hive-serde</include>
                                     <include>org.apache.hive:hive-metastore</include>
                                 </includes>
@@ -501,6 +501,14 @@ under the License.
                                 <relocation>
                                     <pattern>org.apache.hadoop.hive</pattern>
                                     <shadedPattern>org.apache.flink.table.store.shaded.org.apache.hadoop.hive</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.hadoop.fs.ProxyLocalFileSystem</pattern>
+                                    <shadedPattern>org.apache.flink.table.store.shaded.org.apache.hadoop.fs.ProxyLocalFileSystem</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.hadoop.security.token.delegation.HiveDelegationTokenSupport</pattern>
+                                    <shadedPattern>org.apache.flink.table.store.shaded.org.apache.hadoop.security.token.delegation.HiveDelegationTokenSupport</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.apache.hive</pattern>

--- a/flink-table-store-hive/flink-table-store-hive-catalog/pom.xml
+++ b/flink-table-store-hive/flink-table-store-hive-catalog/pom.xml
@@ -507,6 +507,18 @@ under the License.
                                     <shadedPattern>org.apache.flink.table.store.shaded.org.apache.hadoop.fs.ProxyLocalFileSystem</shadedPattern>
                                 </relocation>
                                 <relocation>
+                                    <pattern>org.apache.hadoop.fs.ProxyFileSystem</pattern>
+                                    <shadedPattern>org.apache.flink.table.store.shaded.org.apache.hadoop.fs.ProxyFileSystem</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.hadoop.fs.DefaultFileAccess</pattern>
+                                    <shadedPattern>org.apache.flink.table.store.shaded.org.apache.hadoop.fs.DefaultFileAccess</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.hadoop.mapred.WebHCatJTShim23</pattern>
+                                    <shadedPattern>org.apache.flink.table.store.shaded.org.apache.hadoop.mapred.WebHCatJTShim23</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>org.apache.hadoop.security.token.delegation.HiveDelegationTokenSupport</pattern>
                                     <shadedPattern>org.apache.flink.table.store.shaded.org.apache.hadoop.security.token.delegation.HiveDelegationTokenSupport</shadedPattern>
                                 </relocation>


### PR DESCRIPTION
flink-table-store-hive-catalog could not shade hive-shims-0.23 because `artifactSet` doesn't include `hive-shims-0.23` and the `hive-shims-0.23` isn't specifically included with filters

**The brief change log**
- The `filters` and `artifactSet` of flink-table-store-hive-catalog module includes the `hive-shims-0.23`.