### PR TITLE
[hotfix][docs] Optimizing Spark documentation about engines.

### DIFF
--- a/docs/content/docs/engines/spark3.md
+++ b/docs/content/docs/engines/spark3.md
@@ -1,9 +1,9 @@
 ---
-title: "Spark"
+title: "Spark3"
 weight: 3
 type: docs
 aliases:
-- /engines/spark.html
+- /engines/spark3.html
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
@@ -24,7 +24,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Spark
+# Spark3
 
 Table Store supports reading table store tables through Spark.
 


### PR DESCRIPTION
# What is the purpose of the change
- Modify _Spark_ in "engine" documentation to _Spark3_.


# Brief change log
- Optimizing Spark documentation about engines.
# Verifying this change
- This change is a trivial rework / code cleanup without any test coverage.