### PR TITLE
[FLINK-29071] Fix Table Store Hive CDH support

### DIFF
--- a/.github/workflows/build-different-versions.yml
+++ b/.github/workflows/build-different-versions.yml
@@ -24,7 +24,7 @@ jobs:
           mvn clean install -Dmaven.test.skip=true -Phive-2.1 -f flink-table-store-hive
       - name: Build Hive 2.1 CDH 6.3
         run: |
-          mvn clean install -Dmaven.test.skip=true -Phive-2.1 -f flink-table-store-hive
+          mvn clean install -Dmaven.test.skip=true -Phive-2.1-cdh-6.3 -f flink-table-store-hive
       - name: Build Flink 1.14
         run: |
           mvn clean install -Dmaven.test.skip=true -Pflink-1.14

--- a/.github/workflows/build-different-versions.yml
+++ b/.github/workflows/build-different-versions.yml
@@ -22,9 +22,6 @@ jobs:
       - name: Build Hive 2.1
         run: |
           mvn clean install -Dmaven.test.skip=true -Phive-2.1 -f flink-table-store-hive
-      - name: Build Hive 2.1 CDH 6.3
-        run: |
-          mvn clean install -Dmaven.test.skip=true -Phive-2.1-cdh-6.3 -f flink-table-store-hive
       - name: Build Flink 1.14
         run: |
           mvn clean install -Dmaven.test.skip=true -Pflink-1.14

--- a/.github/workflows/build-different-versions.yml
+++ b/.github/workflows/build-different-versions.yml
@@ -16,10 +16,13 @@ jobs:
       - name: Build Flink 1.15
         run: |
           mvn clean install -Dmaven.test.skip=true
-      - name: Build Flink 1.15 & Hive 2.2
+      - name: Build Hive 2.2
         run: |
           mvn clean install -Dmaven.test.skip=true -Phive-2.2 -f flink-table-store-hive
-      - name: Build Flink 1.15 & Hive 2.1
+      - name: Build Hive 2.1
+        run: |
+          mvn clean install -Dmaven.test.skip=true -Phive-2.1 -f flink-table-store-hive
+      - name: Build Hive 2.1 CDH 6.3
         run: |
           mvn clean install -Dmaven.test.skip=true -Phive-2.1 -f flink-table-store-hive
       - name: Build Flink 1.14

--- a/docs/content/docs/engines/build.md
+++ b/docs/content/docs/engines/build.md
@@ -62,6 +62,12 @@ To build with Hive 2.1, run the following command.
 mvn clean install -Dmaven.test.skip=true -Phive-2.1
 ```
 
+To build with Hive 2.1 CDH 6.3, run the following command.
+
+```bash
+mvn clean install -Dmaven.test.skip=true -Phive-2.1-cdh-6.3
+```
+
 You can find Hive catalog jar in `./flink-table-store-hive/flink-table-store-hive-catalog/target/flink-table-store-hive-catalog-{{< version >}}.jar`. 
 
 You can find Hive connector jar in `./flink-table-store-hive/flink-table-store-hive-connector/target/flink-table-store-hive-connector-{{< version >}}.jar`.

--- a/docs/content/docs/engines/hive.md
+++ b/docs/content/docs/engines/hive.md
@@ -58,6 +58,8 @@ You are using an unreleased version of Table Store. See [Build From Source]({{< 
 
 {{< /unstable >}}
 
+If you're aiming for Hive 2.1 CDH 6.3, see [Build From Source]({{< ref "docs/engines/build" >}}) for more information.
+
 To enable Table Store Hive Catalog support in Flink, you can pick one of the following two methods.
 * Copy the jar file into the `lib` directory of your Flink installation directory. Note that this must be done before starting your Flink cluster.
 * If you're using Flink's SQL client, append `--jar /path/to/flink-table-store-hive-catalog-{{< version >}}.jar` to the starting command of SQL client.
@@ -79,6 +81,8 @@ Download the jar file with corresponding version.
 You are using an unreleased version of Table Store. See [Build From Source]({{< ref "docs/engines/build" >}}) for how to build and find Table Store Hive connector jar file.
 
 {{< /unstable >}}
+
+If you're aiming for Hive 2.1 CDH 6.3, see [Build From Source]({{< ref "docs/engines/build" >}}) for more information.
 
 There are several ways to add this jar to Hive.
 

--- a/docs/content/docs/engines/overview.md
+++ b/docs/content/docs/engines/overview.md
@@ -37,6 +37,7 @@ Apache Hive and Apache Spark.
 | Flink     | 1.14     | read, write, create/drop table, create/drop database | Projection, Filter |
 | Flink     | 1.15     | read, write, create/drop table, create/drop database | Projection, Filter |
 | Hive      | 2.1      | read                                                 | Projection, Filter |
+| Hive      | 2.1 CDH 6.3 | read                                                 | Projection, Filter |
 | Hive      | 2.2      | read                                                 | Projection, Filter |
 | Hive      | 2.3      | read                                                 | Projection, Filter |
 | Spark     | 2.4      | read                                                 | Projection, Filter |

--- a/flink-table-store-hive/pom.xml
+++ b/flink-table-store-hive/pom.xml
@@ -59,6 +59,19 @@ under the License.
                 <hive.version>2.2.0</hive.version>
             </properties>
         </profile>
+
+        <profile>
+            <id>hive-2.1-cdh-6.3</id>
+            <properties>
+                <hive.version>2.1.1-cdh6.3.4</hive.version>
+            </properties>
+            <repositories>
+                <repository>
+                    <id>cloudera</id>
+                    <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+                </repository>
+            </repositories>
+        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
Currently Table Store Hive catalog and connectors cannot run against Hive 2.1 CDH 6.3. We should fix this support.