### PR TITLE
[FLINK-29070] Provide a option to force the removal of the normalize node when streaming read

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -111,6 +111,12 @@
             <td>Specify the startup mode for log consumer.<br /><br />Possible values:<ul><li>"full": Perform a snapshot on the table upon first startup, and continue to read the latest changes.</li><li>"latest": Start from the latest.</li><li>"from-timestamp": Start from user-supplied timestamp.</li></ul></td>
         </tr>
         <tr>
+            <td><h5>log.scan.remove-normalize</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to force the removal of the normalize node when streaming read. Note: This is dangerous and is likely to cause data errors if downstream is used to calculate aggregation.</td>
+        </tr>
+        <tr>
             <td><h5>log.scan.timestamp-millis</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Long</td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -114,7 +114,7 @@
             <td><h5>log.scan.remove-normalize</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Whether to force the removal of the normalize node when streaming read. Note: This is dangerous and is likely to cause data errors if downstream is used to calculate aggregation.</td>
+            <td>Whether to force the removal of the normalize node when streaming read. Note: This is dangerous and is likely to cause data errors if downstream is used to calculate aggregation and the input is not complete changelog.</td>
         </tr>
         <tr>
             <td><h5>log.scan.timestamp-millis</h5></td>

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/TableStoreSource.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/TableStoreSource.java
@@ -54,6 +54,7 @@ import java.util.List;
 import static org.apache.flink.table.store.CoreOptions.CHANGELOG_PRODUCER;
 import static org.apache.flink.table.store.CoreOptions.LOG_CHANGELOG_MODE;
 import static org.apache.flink.table.store.CoreOptions.LOG_CONSISTENCY;
+import static org.apache.flink.table.store.CoreOptions.LOG_SCAN_REMOVE_NORMALIZE;
 
 /**
  * Table source to create {@link FileStoreSource} under batch mode or change-tracking is disabled.
@@ -119,6 +120,10 @@ public class TableStoreSource
             return ChangelogMode.all();
         } else if (table instanceof ChangelogWithKeyFileStoreTable) {
             Configuration options = Configuration.fromMap(table.schema().options());
+
+            if (options.get(LOG_SCAN_REMOVE_NORMALIZE)) {
+                return ChangelogMode.all();
+            }
 
             if (logStoreTableFactory == null
                     && options.get(CHANGELOG_PRODUCER) != ChangelogProducer.NONE) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
@@ -303,6 +303,15 @@ public class CoreOptions implements Serializable {
                     .defaultValue(LogChangelogMode.AUTO)
                     .withDescription("Specify the log changelog mode for table.");
 
+    public static final ConfigOption<Boolean> LOG_SCAN_REMOVE_NORMALIZE =
+            ConfigOptions.key("log.scan.remove-normalize")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to force the removal of the normalize node when streaming read."
+                                    + " Note: This is dangerous and is likely to cause data errors if downstream"
+                                    + " is used to calculate aggregation.");
+
     public static final ConfigOption<String> LOG_KEY_FORMAT =
             ConfigOptions.key("log.key.format")
                     .stringType()

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
@@ -310,7 +310,7 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Whether to force the removal of the normalize node when streaming read."
                                     + " Note: This is dangerous and is likely to cause data errors if downstream"
-                                    + " is used to calculate aggregation.");
+                                    + " is used to calculate aggregation and the input is not complete changelog.");
 
     public static final ConfigOption<String> LOG_KEY_FORMAT =
             ConfigOptions.key("log.key.format")


### PR DESCRIPTION
There are many jobs that do not require a downstream normalize node, and the key is that the node has a very large cost.

Introduce a option:
Whether to force the removal of the normalize node when streaming read. Note: This is dangerous and is likely to cause data errors if downstream is used to calculate aggregation.