### PR TITLE
[hotfix] Fix the partial update SQL example

### DIFF
--- a/docs/content/docs/development/create-table.md
+++ b/docs/content/docs/development/create-table.md
@@ -253,8 +253,8 @@ CREATE TABLE MyTable (
 );
 
 INSERT INTO MyTable
-SELECT product_id, price, number, NULL FROM Src1 UNION ALL
-SELECT product_id, NULL, NULL, detail FROM Src2;
+SELECT product_id, price, number, CAST(NULL AS STRING) FROM Src1 UNION ALL
+SELECT product_id, CAST(NULL AS DOUBLE), CAST(NULL AS BIGINT), detail FROM Src2;
 ```
 
 The value fields are updated to the latest data one by one


### PR DESCRIPTION
Without the explicit cast, the SQL will throw the exception like 
```
[ERROR] Could not execute SQL statement. Reason:
org.apache.calcite.sql.validate.SqlValidatorException: Illegal use of 'NULL'
```