### PR TITLE
[FLINK-29129] Try best to push down value filters

### DIFF
--- a/flink-table-store-common/src/main/java/org/apache/flink/table/store/format/FileFormat.java
+++ b/flink-table-store-common/src/main/java/org/apache/flink/table/store/format/FileFormat.java
@@ -29,6 +29,8 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.file.predicate.Predicate;
 import org.apache.flink.table.types.logical.RowType;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -59,7 +61,7 @@ public abstract class FileFormat {
      * @param filters A list of filters in conjunctive form for filtering on a best-effort basis.
      */
     public abstract BulkFormat<RowData, FileSourceSplit> createReaderFactory(
-            RowType type, int[][] projection, List<Predicate> filters);
+            RowType type, int[][] projection, @Nullable List<Predicate> filters);
 
     /** Create a {@link BulkWriter.Factory} from the type. */
     public abstract BulkWriter.Factory<RowData> createWriterFactory(RowType type);

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceReaderTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceReaderTest.java
@@ -19,10 +19,18 @@
 package org.apache.flink.table.store.connector.source;
 
 import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.file.schema.UpdateSchema;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.RowType;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 import static org.apache.flink.table.store.connector.source.FileStoreSourceSplitSerializerTest.newSourceSplit;
@@ -33,6 +41,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class FileStoreSourceReaderTest {
 
     @TempDir java.nio.file.Path tempDir;
+
+    @BeforeEach
+    public void beforeEach() throws Exception {
+        SchemaManager schemaManager = new SchemaManager(new Path(tempDir.toUri()));
+        schemaManager.commitNewVersion(
+                new UpdateSchema(
+                        new RowType(
+                                Arrays.asList(
+                                        new RowType.RowField("k", new BigIntType()),
+                                        new RowType.RowField("v", new BigIntType()),
+                                        new RowType.RowField("default", new IntType()))),
+                        Collections.singletonList("default"),
+                        Arrays.asList("k", "default"),
+                        Collections.emptyMap(),
+                        null));
+    }
 
     @Test
     public void testRequestSplitWhenNoSplitRestored() throws Exception {

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitReaderTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitReaderTest.java
@@ -23,15 +23,22 @@ import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
 import org.apache.flink.connector.file.src.util.RecordAndPosition;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.file.KeyValue;
 import org.apache.flink.table.store.file.data.DataFileMeta;
+import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.file.schema.UpdateSchema;
 import org.apache.flink.table.store.file.writer.RecordWriter;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.RowKind;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -65,6 +72,22 @@ public class FileStoreSourceSplitReaderTest {
     public static void after() {
         service.shutdownNow();
         service = null;
+    }
+
+    @BeforeEach
+    public void beforeEach() throws Exception {
+        SchemaManager schemaManager = new SchemaManager(new Path(tempDir.toUri()));
+        schemaManager.commitNewVersion(
+                new UpdateSchema(
+                        new RowType(
+                                Arrays.asList(
+                                        new RowType.RowField("k", new BigIntType()),
+                                        new RowType.RowField("v", new BigIntType()),
+                                        new RowType.RowField("default", new IntType()))),
+                        Collections.singletonList("default"),
+                        Arrays.asList("k", "default"),
+                        Collections.emptyMap(),
+                        null));
     }
 
     @Test

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileReader.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/data/DataFileReader.java
@@ -178,7 +178,10 @@ public class DataFileReader {
         }
 
         public DataFileReader create(
-                BinaryRowData partition, int bucket, boolean projectKeys, List<Predicate> filters) {
+                BinaryRowData partition,
+                int bucket,
+                boolean projectKeys,
+                @Nullable List<Predicate> filters) {
             int[][] keyProjection = projectKeys ? this.keyProjection : fullKeyProjection;
             RowType projectedKeyType = projectKeys ? this.projectedKeyType : keyType;
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeReader.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeReader.java
@@ -62,10 +62,10 @@ public class MergeTreeReader implements RecordReader<KeyValue> {
         this.reader = ConcatRecordReader.create(readers);
     }
 
-    public MergeTreeReader(boolean dropDelete, List<ReaderSupplier<KeyValue>> readers)
+    public MergeTreeReader(boolean dropDelete, List<ReaderSupplier<KeyValue>> sectionReaders)
             throws IOException {
         this.dropDelete = dropDelete;
-        this.reader = ConcatRecordReader.create(readers);
+        this.reader = ConcatRecordReader.create(sectionReaders);
     }
 
     @Nullable

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeReader.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeReader.java
@@ -62,6 +62,12 @@ public class MergeTreeReader implements RecordReader<KeyValue> {
         this.reader = ConcatRecordReader.create(readers);
     }
 
+    public MergeTreeReader(boolean dropDelete, List<ReaderSupplier<KeyValue>> readers)
+            throws IOException {
+        this.dropDelete = dropDelete;
+        this.reader = ConcatRecordReader.create(readers);
+    }
+
     @Nullable
     @Override
     public RecordIterator<KeyValue> readBatch() throws IOException {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AppendOnlyFileStoreRead.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AppendOnlyFileStoreRead.java
@@ -34,6 +34,8 @@ import org.apache.flink.table.store.table.source.Split;
 import org.apache.flink.table.store.utils.Projection;
 import org.apache.flink.table.types.logical.RowType;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -51,7 +53,7 @@ public class AppendOnlyFileStoreRead implements FileStoreRead<RowData> {
 
     private int[][] projection;
 
-    private List<Predicate> filters;
+    @Nullable private List<Predicate> filters;
 
     public AppendOnlyFileStoreRead(
             SchemaManager schemaManager,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.store.file.schema;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.store.CoreOptions;
@@ -314,7 +315,8 @@ public class SchemaManager implements Serializable {
         return new Path(tableRoot + "/schema");
     }
 
-    private Path toSchemaPath(long id) {
+    @VisibleForTesting
+    public Path toSchemaPath(long id) {
         return new Path(tableRoot + "/schema/" + SCHEMA_PREFIX + id);
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
@@ -164,19 +164,22 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
 
             @Override
             public TableRead withFilter(Predicate predicate) {
-                List<Predicate> predicates = new ArrayList<>();
+                List<Predicate> keyPredicates = new ArrayList<>();
+                List<Predicate> valuePredicates = new ArrayList<>();
                 for (Predicate sub : splitAnd(predicate)) {
-                    // TODO support value filter
                     if (containsFields(sub, nonPrimaryKeys)) {
-                        continue;
+                        valuePredicates.add(sub);
+                    } else {
+                        // TODO Actually, the index is wrong, but it is OK. The orc filter
+                        // just use name instead of index.
+                        keyPredicates.add(sub);
                     }
-
-                    // TODO Actually, the index is wrong, but it is OK. The orc filter
-                    // just use name instead of index.
-                    predicates.add(sub);
                 }
-                if (predicates.size() > 0) {
-                    read.withFilter(and(predicates));
+                if (keyPredicates.size() > 0) {
+                    read.withFilter(and(keyPredicates));
+                }
+                if (valuePredicates.size() > 0) {
+                    read.withValueFilter(and(valuePredicates));
                 }
                 return this;
             }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -378,14 +378,19 @@ public class TestFileStore extends KeyValueFileStore {
     }
 
     private Set<Path> getFilesInUse() {
+        Set<Path> result = new HashSet<>();
         FileStorePathFactory pathFactory = pathFactory();
         ManifestList manifestList = manifestListFactory().create();
         FileStoreScan scan = newScan();
 
+        SchemaManager schemaManager = new SchemaManager(options.path());
+        schemaManager.listAllIds().forEach(id -> result.add(schemaManager.toSchemaPath(id)));
+
         SnapshotManager snapshotManager = snapshotManager();
         Long latestSnapshotId = snapshotManager.latestSnapshotId();
+
         if (latestSnapshotId == null) {
-            return Collections.emptySet();
+            return result;
         }
 
         long firstInUseSnapshotId = Snapshot.FIRST_SNAPSHOT_ID;
@@ -396,7 +401,6 @@ public class TestFileStore extends KeyValueFileStore {
             }
         }
 
-        Set<Path> result = new HashSet<>();
         for (long id = firstInUseSnapshotId; id <= latestSnapshotId; id++) {
             Path snapshotPath = snapshotManager.snapshotPath(id);
             Snapshot snapshot = Snapshot.fromPath(snapshotPath);

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileTestUtils.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/data/DataFileTestUtils.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.store.file.data;
 
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.data.writer.BinaryRowWriter;
+import org.apache.flink.table.store.file.stats.StatsTestUtils;
 
 /** Utils for {@link DataFileMeta}. */
 public class DataFileTestUtils {
@@ -45,6 +46,21 @@ public class DataFileTestUtils {
                 maxSeq,
                 0L,
                 DataFileMeta.DUMMY_LEVEL);
+    }
+
+    public static DataFileMeta newFile() {
+        return new DataFileMeta(
+                "",
+                0,
+                0,
+                DataFileMeta.EMPTY_MIN_KEY,
+                DataFileMeta.EMPTY_MAX_KEY,
+                StatsTestUtils.newEmptyTableStats(),
+                StatsTestUtils.newEmptyTableStats(),
+                0,
+                0,
+                0,
+                0);
     }
 
     public static DataFileMeta newFile(

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/format/FileStatsExtractingAvroFormat.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/format/FileStatsExtractingAvroFormat.java
@@ -29,6 +29,8 @@ import org.apache.flink.table.store.format.FileFormat;
 import org.apache.flink.table.store.format.FileStatsExtractor;
 import org.apache.flink.table.types.logical.RowType;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -44,7 +46,7 @@ public class FileStatsExtractingAvroFormat extends FileFormat {
 
     @Override
     public BulkFormat<RowData, FileSourceSplit> createReaderFactory(
-            RowType type, int[][] projection, List<Predicate> filters) {
+            RowType type, int[][] projection, @Nullable List<Predicate> filters) {
         return avro.createReaderFactory(type, projection, filters);
     }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/format/FlushingFileFormat.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/format/FlushingFileFormat.java
@@ -27,6 +27,8 @@ import org.apache.flink.table.store.file.predicate.Predicate;
 import org.apache.flink.table.store.format.FileFormat;
 import org.apache.flink.table.types.logical.RowType;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.List;
 
@@ -42,7 +44,7 @@ public class FlushingFileFormat extends FileFormat {
 
     @Override
     public BulkFormat<RowData, FileSourceSplit> createReaderFactory(
-            RowType type, int[][] projection, List<Predicate> filters) {
+            RowType type, int[][] projection, @Nullable List<Predicate> filters) {
         return format.createReaderFactory(type, projection, filters);
     }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreExpireTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreExpireTest.java
@@ -29,6 +29,8 @@ import org.apache.flink.table.store.file.data.DataFileMeta;
 import org.apache.flink.table.store.file.manifest.FileKind;
 import org.apache.flink.table.store.file.manifest.ManifestEntry;
 import org.apache.flink.table.store.file.mergetree.compact.DeduplicateMergeFunction;
+import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.file.schema.UpdateSchema;
 import org.apache.flink.table.store.file.utils.FileUtils;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
 
@@ -40,6 +42,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
@@ -56,7 +59,7 @@ public class FileStoreExpireTest {
     private SnapshotManager snapshotManager;
 
     @BeforeEach
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws Exception {
         gen = new TestKeyValueGenerator();
         store =
                 TestFileStore.create(
@@ -68,6 +71,15 @@ public class FileStoreExpireTest {
                         TestKeyValueGenerator.DEFAULT_ROW_TYPE,
                         new DeduplicateMergeFunction());
         snapshotManager = store.snapshotManager();
+        SchemaManager schemaManager = new SchemaManager(new Path(tempDir.toUri()));
+        schemaManager.commitNewVersion(
+                new UpdateSchema(
+                        TestKeyValueGenerator.DEFAULT_ROW_TYPE,
+                        TestKeyValueGenerator.DEFAULT_PART_TYPE.getFieldNames(),
+                        TestKeyValueGenerator.getPrimaryKeys(
+                                TestKeyValueGenerator.GeneratorMode.MULTI_PARTITIONED),
+                        Collections.emptyMap(),
+                        null));
     }
 
     @AfterEach

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreReadTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreReadTest.java
@@ -18,18 +18,32 @@
 
 package org.apache.flink.table.store.file.operation;
 
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.data.GenericArrayData;
 import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.data.writer.BinaryRowWriter;
+import org.apache.flink.table.runtime.typeutils.ArrayDataSerializer;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.store.file.KeyValue;
 import org.apache.flink.table.store.file.TestFileStore;
 import org.apache.flink.table.store.file.TestKeyValueGenerator;
+import org.apache.flink.table.store.file.data.DataFileMeta;
+import org.apache.flink.table.store.file.data.DataFileTestUtils;
 import org.apache.flink.table.store.file.manifest.ManifestEntry;
 import org.apache.flink.table.store.file.mergetree.compact.DeduplicateMergeFunction;
 import org.apache.flink.table.store.file.mergetree.compact.MergeFunction;
 import org.apache.flink.table.store.file.mergetree.compact.ValueCountMergeFunction;
+import org.apache.flink.table.store.file.predicate.PredicateBuilder;
+import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.file.schema.UpdateSchema;
+import org.apache.flink.table.store.file.stats.BinaryTableStats;
+import org.apache.flink.table.store.file.stats.FieldStatsArraySerializer;
+import org.apache.flink.table.store.file.stats.StatsTestUtils;
 import org.apache.flink.table.store.file.utils.RecordReader;
 import org.apache.flink.table.store.file.utils.RecordReaderIterator;
+import org.apache.flink.table.store.format.FieldStats;
 import org.apache.flink.table.store.table.source.Split;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.IntType;
@@ -42,12 +56,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -175,6 +191,145 @@ public class KeyValueFileStoreReadTest {
         }
     }
 
+    @Test
+    public void testAcceptFilterUnderValueCountMode() throws Exception {
+        TestFileStore store =
+                createStore(
+                        TestKeyValueGenerator.DEFAULT_PART_TYPE,
+                        TestKeyValueGenerator.DEFAULT_ROW_TYPE,
+                        RowType.of(
+                                new LogicalType[] {new BigIntType(false)},
+                                new String[] {"_VALUE_COUNT"}),
+                        new ValueCountMergeFunction());
+        // no filter
+        KeyValueFileStoreRead read = store.newRead();
+        assertThat(read.acceptFilter(true).test(DataFileTestUtils.newFile())).isTrue();
+        assertThat(read.acceptFilter(false).test(DataFileTestUtils.newFile())).isTrue();
+
+        // test filter
+        PredicateBuilder builder = new PredicateBuilder(TestKeyValueGenerator.DEFAULT_ROW_TYPE);
+        DataFileMeta file =
+                new DataFileMeta(
+                        "",
+                        100,
+                        100,
+                        rowData(10),
+                        rowData(200),
+                        rowStats(),
+                        StatsTestUtils.newEmptyTableStats(), // not used
+                        0,
+                        100,
+                        0,
+                        0);
+
+        // test shopId = 123
+        read.withFilter(builder.equal(2, 123));
+        assertThat(read.acceptFilter(true).test(file)).isTrue();
+        assertThat(read.acceptFilter(false).test(file)).isTrue();
+
+        // test shopId = 321
+        read.withFilter(builder.equal(2, 321));
+        assertThat(read.acceptFilter(true).test(file)).isFalse();
+        assertThat(read.acceptFilter(false).test(file)).isFalse();
+    }
+
+    @Test
+    public void testAcceptFilterUnderPrimaryKeyMode() throws Exception {
+        TestFileStore store =
+                createStore(
+                        TestKeyValueGenerator.DEFAULT_PART_TYPE,
+                        TestKeyValueGenerator.KEY_TYPE,
+                        TestKeyValueGenerator.DEFAULT_ROW_TYPE,
+                        new DeduplicateMergeFunction());
+        // no filter
+        KeyValueFileStoreRead read = store.newRead();
+        assertThat(read.acceptFilter(true).test(DataFileTestUtils.newFile())).isTrue();
+        assertThat(read.acceptFilter(false).test(DataFileTestUtils.newFile())).isTrue();
+
+        // test filter
+        PredicateBuilder builder = new PredicateBuilder(TestKeyValueGenerator.DEFAULT_ROW_TYPE);
+        DataFileMeta file =
+                new DataFileMeta(
+                        "",
+                        100,
+                        100,
+                        rowData(10),
+                        rowData(200),
+                        new FieldStatsArraySerializer(TestKeyValueGenerator.KEY_TYPE)
+                                .toBinary(
+                                        new FieldStats[] {
+                                            new FieldStats(10, 200, 0),
+                                            new FieldStats(100L, 100L, 0)
+                                        }),
+                        rowStats(),
+                        0,
+                        100,
+                        0,
+                        0);
+
+        // shopId = 123 (key only)
+        read.withFilter(builder.equal(2, 123));
+        assertThat(read.acceptFilter(true).test(file)).isTrue();
+        assertThat(read.acceptFilter(false).test(file)).isTrue();
+
+        // shopId = 321 (key only)
+        read = store.newRead();
+        read.withFilter(builder.equal(2, 321));
+        assertThat(read.acceptFilter(true).test(file)).isFalse();
+        assertThat(read.acceptFilter(false).test(file)).isFalse();
+
+        // hr = 20 (value only)
+        read = store.newRead();
+        read.withFilter(builder.equal(1, 20));
+        assertThat(read.acceptFilter(true).test(file)).isTrue();
+        assertThat(read.acceptFilter(false).test(file)).isTrue();
+
+        // hr = 21 (value only)
+        read = store.newRead();
+        read.withFilter(builder.equal(1, 21));
+        assertThat(read.acceptFilter(true).test(file)).isFalse();
+        assertThat(read.acceptFilter(false).test(file)).isTrue();
+
+        // hr = 21 and shopId = 123 (key and value)
+        read = store.newRead();
+        read.withFilter(PredicateBuilder.and(builder.equal(1, 21), builder.equal(2, 123)));
+        assertThat(read.acceptFilter(true).test(file)).isFalse();
+        assertThat(read.acceptFilter(false).test(file)).isTrue();
+    }
+
+    private static BinaryRowData rowData(int value) {
+        BinaryRowData row =
+                new BinaryRowData(TestKeyValueGenerator.DEFAULT_ROW_TYPE.getFieldCount());
+        BinaryRowWriter writer = new BinaryRowWriter(row);
+        writer.writeString(0, StringData.fromString("2022-08-30"));
+        writer.writeInt(1, 20);
+        writer.writeInt(2, value);
+        writer.writeLong(3, 100L);
+        writer.writeLong(4, 200L);
+        writer.writeArray(
+                5, new GenericArrayData(new int[0]), new ArrayDataSerializer(new IntType()));
+        writer.writeString(6, StringData.fromString("a comment"));
+        writer.complete();
+        return row;
+    }
+
+    private static BinaryTableStats rowStats() {
+        return new FieldStatsArraySerializer(TestKeyValueGenerator.DEFAULT_ROW_TYPE)
+                .toBinary(
+                        new FieldStats[] {
+                            new FieldStats(
+                                    StringData.fromString("2022-08-29"),
+                                    StringData.fromString("2022-08-30"),
+                                    0),
+                            new FieldStats(20, 20, 0),
+                            new FieldStats(10, 200, 0),
+                            new FieldStats(100L, 100L, 0),
+                            new FieldStats(200L, 200L, 0),
+                            new FieldStats(null, null, 0), // not used
+                            new FieldStats(null, null, 0)
+                        });
+    }
+
     private List<KeyValue> writeThenRead(
             List<KeyValue> data,
             int[][] keyProjection,
@@ -222,10 +377,23 @@ public class KeyValueFileStoreReadTest {
     }
 
     private TestFileStore createStore(
-            RowType partitionType,
-            RowType keyType,
-            RowType valueType,
-            MergeFunction mergeFunction) {
+            RowType partitionType, RowType keyType, RowType valueType, MergeFunction mergeFunction)
+            throws Exception {
+        SchemaManager schemaManager = new SchemaManager(new Path(tempDir.toUri()));
+        boolean valueCountMode = mergeFunction instanceof ValueCountMergeFunction;
+        schemaManager.commitNewVersion(
+                new UpdateSchema(
+                        valueCountMode ? keyType : valueType,
+                        partitionType.getFieldNames(),
+                        valueCountMode
+                                ? Collections.emptyList()
+                                : Stream.concat(
+                                                keyType.getFieldNames().stream()
+                                                        .map(field -> field.replace("key_", "")),
+                                                partitionType.getFieldNames().stream())
+                                        .collect(Collectors.toList()),
+                        Collections.emptyMap(),
+                        null));
         return TestFileStore.create(
                 "avro", tempDir.toString(), 1, partitionType, keyType, valueType, mergeFunction);
     }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreScanTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreScanTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.store.file.operation;
 
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.store.file.KeyValue;
 import org.apache.flink.table.store.file.Snapshot;
@@ -27,6 +28,8 @@ import org.apache.flink.table.store.file.manifest.ManifestFileMeta;
 import org.apache.flink.table.store.file.manifest.ManifestList;
 import org.apache.flink.table.store.file.mergetree.compact.DeduplicateMergeFunction;
 import org.apache.flink.table.store.file.predicate.PredicateBuilder;
+import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.file.schema.UpdateSchema;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
@@ -37,6 +40,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +61,7 @@ public class KeyValueFileStoreScanTest {
     private SnapshotManager snapshotManager;
 
     @BeforeEach
-    public void beforeEach() {
+    public void beforeEach() throws Exception {
         gen = new TestKeyValueGenerator();
         store =
                 TestFileStore.create(
@@ -69,6 +73,16 @@ public class KeyValueFileStoreScanTest {
                         TestKeyValueGenerator.DEFAULT_ROW_TYPE,
                         new DeduplicateMergeFunction());
         snapshotManager = store.snapshotManager();
+
+        SchemaManager schemaManager = new SchemaManager(new Path(tempDir.toUri()));
+        schemaManager.commitNewVersion(
+                new UpdateSchema(
+                        TestKeyValueGenerator.DEFAULT_ROW_TYPE,
+                        TestKeyValueGenerator.DEFAULT_PART_TYPE.getFieldNames(),
+                        TestKeyValueGenerator.getPrimaryKeys(
+                                TestKeyValueGenerator.GeneratorMode.MULTI_PARTITIONED),
+                        Collections.emptyMap(),
+                        null));
     }
 
     @Test

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTableTest.java
@@ -190,7 +190,6 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         List<Split> splits =
                 table.newScan().withFilter(partitionFilter).withBucket(bucket).plan().splits;
         TableRead read = table.newRead();
-        getResult(read, splits, binaryRow(partition), bucket, STREAMING_ROW_TO_STRING);
 
         assertThat(getResult(read, splits, binaryRow(partition), bucket, STREAMING_ROW_TO_STRING))
                 .containsExactlyElementsOf(

--- a/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/avro/AvroFileFormat.java
+++ b/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/avro/AvroFileFormat.java
@@ -46,6 +46,8 @@ import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumWriter;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
@@ -65,7 +67,7 @@ public class AvroFileFormat extends FileFormat {
 
     @Override
     public BulkFormat<RowData, FileSourceSplit> createReaderFactory(
-            RowType type, int[][] projection, List<Predicate> filters) {
+            RowType type, int[][] projection, @Nullable List<Predicate> filters) {
         // avro is a file format that keeps schemas in file headers,
         // if the schema given to the reader is not equal to the schema in header,
         // reader will automatically map the fields and give back records with our desired

--- a/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/orc/OrcFileFormat.java
+++ b/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/orc/OrcFileFormat.java
@@ -38,6 +38,8 @@ import org.apache.flink.table.types.logical.RowType;
 
 import org.apache.orc.TypeDescription;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -67,7 +69,7 @@ public class OrcFileFormat extends FileFormat {
 
     @Override
     public BulkFormat<RowData, FileSourceSplit> createReaderFactory(
-            RowType type, int[][] projection, List<Predicate> filters) {
+            RowType type, int[][] projection, @Nullable List<Predicate> filters) {
         List<OrcFilters.Predicate> orcPredicates = new ArrayList<>();
 
         if (filters != null) {


### PR DESCRIPTION
As an improvement, value filters can be pushed down when generated splits do not have key range overlap.