### PR TITLE
[FLINK-29181] log.system can be congiured by dynamic options

### DIFF
--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -12,7 +12,7 @@
             <td><h5>log.system</h5></td>
             <td style="word-wrap: break-word;">"none"</td>
             <td>String</td>
-            <td>The log system used to keep changes of the table.</td>
+            <td>The log system used to keep changes of the table.<br /><br />Possible values:<br /><ul><li>"none": No log system, the data is written only to file store, and the streaming read will be directly read from the file store.</li></ul><ul><li>"kafka": Kafka log system, the data is double written to file store and kafka, and the streaming read will be read from kafka.</li></ul></td>
         </tr>
         <tr>
             <td><h5>scan.parallelism</h5></td>

--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -10,7 +10,7 @@
     <tbody>
         <tr>
             <td><h5>log.system</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
+            <td style="word-wrap: break-word;">"none"</td>
             <td>String</td>
             <td>The log system used to keep changes of the table.</td>
         </tr>

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/AbstractTableStoreFactory.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/AbstractTableStoreFactory.java
@@ -54,6 +54,7 @@ import static org.apache.flink.table.store.CoreOptions.LOG_CHANGELOG_MODE;
 import static org.apache.flink.table.store.CoreOptions.LOG_CONSISTENCY;
 import static org.apache.flink.table.store.CoreOptions.LOG_SCAN;
 import static org.apache.flink.table.store.connector.FlinkConnectorOptions.LOG_SYSTEM;
+import static org.apache.flink.table.store.connector.FlinkConnectorOptions.NONE;
 import static org.apache.flink.table.store.log.LogStoreTableFactory.discoverLogStoreFactory;
 
 /** Abstract table store factory to create table source and table sink. */
@@ -106,7 +107,7 @@ public abstract class AbstractTableStoreFactory
         Configuration configOptions = new Configuration();
         options.forEach(configOptions::setString);
 
-        if (configOptions.get(LOG_SYSTEM) == null) {
+        if (configOptions.get(LOG_SYSTEM).equalsIgnoreCase(NONE)) {
             // Use file store continuous reading
             validateFileStoreContinuous(configOptions);
             return Optional.empty();

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/FlinkConnectorOptions.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/FlinkConnectorOptions.java
@@ -34,6 +34,8 @@ public class FlinkConnectorOptions {
 
     public static final String TABLE_STORE_PREFIX = "table-store.";
 
+    public static final String NONE = "none";
+
     @Internal
     @Documentation.ExcludeFromDocumentation("Internal use only")
     public static final ConfigOption<String> ROOT_PATH =
@@ -63,7 +65,7 @@ public class FlinkConnectorOptions {
     public static final ConfigOption<String> LOG_SYSTEM =
             ConfigOptions.key("log.system")
                     .stringType()
-                    .noDefaultValue()
+                    .defaultValue(NONE)
                     .withDescription("The log system used to keep changes of the table.");
 
     public static final ConfigOption<Integer> SINK_PARALLELISM = FactoryUtil.SINK_PARALLELISM;

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/FlinkConnectorOptions.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/FlinkConnectorOptions.java
@@ -22,6 +22,8 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.description.Description;
+import org.apache.flink.configuration.description.TextElement;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.factories.FactoryUtil;
 
@@ -66,7 +68,22 @@ public class FlinkConnectorOptions {
             ConfigOptions.key("log.system")
                     .stringType()
                     .defaultValue(NONE)
-                    .withDescription("The log system used to keep changes of the table.");
+                    .withDescription(
+                            Description.builder()
+                                    .text("The log system used to keep changes of the table.")
+                                    .linebreak()
+                                    .linebreak()
+                                    .text("Possible values:")
+                                    .linebreak()
+                                    .list(
+                                            TextElement.text(
+                                                    "\"none\": No log system, the data is written only to file store,"
+                                                            + " and the streaming read will be directly read from the file store."))
+                                    .list(
+                                            TextElement.text(
+                                                    "\"kafka\": Kafka log system, the data is double written to file"
+                                                            + " store and kafka, and the streaming read will be read from kafka."))
+                                    .build());
 
     public static final ConfigOption<Integer> SINK_PARALLELISM = FactoryUtil.SINK_PARALLELISM;
 

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreTestBase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreTestBase.java
@@ -50,6 +50,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.apache.flink.table.store.connector.FlinkConnectorOptions.LOG_SYSTEM;
+import static org.apache.flink.table.store.connector.FlinkConnectorOptions.NONE;
 import static org.apache.flink.table.store.connector.FlinkConnectorOptions.ROOT_PATH;
 import static org.apache.flink.table.store.connector.FlinkConnectorOptions.TABLE_STORE_PREFIX;
 import static org.apache.flink.table.store.connector.FlinkConnectorOptions.relativeTablePath;
@@ -114,7 +115,7 @@ public abstract class TableStoreTestBase extends KafkaTableTestBase {
         if (enableLogStore) {
             configuration.setString(TABLE_STORE_PREFIX + LOG_SYSTEM.key(), "kafka");
         } else {
-            configuration.setString(TABLE_STORE_PREFIX + LOG_SYSTEM.key(), "none");
+            configuration.setString(TABLE_STORE_PREFIX + LOG_SYSTEM.key(), NONE);
         }
     }
 

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreTestBase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreTestBase.java
@@ -113,6 +113,8 @@ public abstract class TableStoreTestBase extends KafkaTableTestBase {
                 TABLE_STORE_PREFIX + BOOTSTRAP_SERVERS.key(), getBootstrapServers());
         if (enableLogStore) {
             configuration.setString(TABLE_STORE_PREFIX + LOG_SYSTEM.key(), "kafka");
+        } else {
+            configuration.setString(TABLE_STORE_PREFIX + LOG_SYSTEM.key(), "none");
         }
     }
 


### PR DESCRIPTION
Now log.system default value is null, it can not be configured by dynamic option.
We can let default value is 'none'.