### PR TITLE
[FLINK-29189] Pass KeyValue to MergeFunction

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/SortBufferMemTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/SortBufferMemTable.java
@@ -172,7 +172,7 @@ public class SortBufferMemTable implements MemTable {
                     return;
                 }
                 mergeFunctionHelper.reset();
-                mergeFunctionHelper.add(previous.getReusedKv().value());
+                mergeFunctionHelper.add(previous.getReusedKv());
 
                 while (readOnce()) {
                     if (keyComparator.compare(
@@ -180,7 +180,7 @@ public class SortBufferMemTable implements MemTable {
                             != 0) {
                         break;
                     }
-                    mergeFunctionHelper.add(current.getReusedKv().value());
+                    mergeFunctionHelper.add(current.getReusedKv());
                     swapSerializers();
                 }
                 result = mergeFunctionHelper.getValue();

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/DeduplicateMergeFunction.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/DeduplicateMergeFunction.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.store.file.mergetree.compact;
 
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.file.KeyValue;
 
 import javax.annotation.Nullable;
 
@@ -38,8 +39,8 @@ public class DeduplicateMergeFunction implements MergeFunction {
     }
 
     @Override
-    public void add(RowData value) {
-        latestValue = value;
+    public void add(KeyValue kv) {
+        latestValue = kv.value();
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/MergeFunction.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/MergeFunction.java
@@ -31,8 +31,8 @@ public interface MergeFunction extends Serializable {
     /** Reset the merge function to its default state. */
     void reset();
 
-    /** Add the given {@link RowData} to the merge function. */
-    void add(RowData value);
+    /** Add the given {@link KeyValue} to the merge function. */
+    void add(KeyValue kv);
 
     /** Get current merged value. Return null if this merged result should be skipped. */
     @Nullable

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/MergeFunctionHelper.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/MergeFunctionHelper.java
@@ -26,7 +26,7 @@ public class MergeFunctionHelper {
 
     private final MergeFunction mergeFunction;
 
-    private KeyValue firstKV;
+    private KeyValue initialKV;
     private boolean isInitialized;
 
     public MergeFunctionHelper(MergeFunction mergeFunction) {
@@ -35,18 +35,18 @@ public class MergeFunctionHelper {
 
     /** Resets the {@link MergeFunction} helper to its default state. */
     public void reset() {
-        firstKV = null;
+        initialKV = null;
         mergeFunction.reset();
         isInitialized = false;
     }
 
     /** Adds the given {@link KeyValue} to the {@link MergeFunction} helper. */
     public void add(KeyValue kv) {
-        if (firstKV == null) {
-            firstKV = kv;
+        if (initialKV == null) {
+            initialKV = kv;
         } else {
             if (!isInitialized) {
-                merge(firstKV);
+                merge(initialKV);
                 isInitialized = true;
             }
             merge(kv);
@@ -59,6 +59,6 @@ public class MergeFunctionHelper {
 
     /** Get current value of the {@link MergeFunction} helper. */
     public RowData getValue() {
-        return isInitialized ? mergeFunction.getValue() : firstKV.value();
+        return isInitialized ? mergeFunction.getValue() : initialKV.value();
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/MergeFunctionHelper.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/MergeFunctionHelper.java
@@ -19,48 +19,46 @@
 package org.apache.flink.table.store.file.mergetree.compact;
 
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.file.KeyValue;
 
 /** Helper functions for the interaction with {@link MergeFunction}. */
 public class MergeFunctionHelper {
 
     private final MergeFunction mergeFunction;
 
-    private RowData rowData;
+    private KeyValue firstKV;
     private boolean isInitialized;
 
     public MergeFunctionHelper(MergeFunction mergeFunction) {
         this.mergeFunction = mergeFunction;
     }
 
-    /**
-     * Resets the {@link MergeFunction} helper to its default state: 1. Clears the one record which
-     * the helper maintains. 2. Resets the {@link MergeFunction} to its default state. 3. Clears the
-     * initialized state of the {@link MergeFunction}.
-     */
+    /** Resets the {@link MergeFunction} helper to its default state. */
     public void reset() {
-        rowData = null;
+        firstKV = null;
         mergeFunction.reset();
         isInitialized = false;
     }
 
-    /** Adds the given {@link RowData} to the {@link MergeFunction} helper. */
-    public void add(RowData value) {
-        if (rowData == null) {
-            rowData = value;
+    /** Adds the given {@link KeyValue} to the {@link MergeFunction} helper. */
+    public void add(KeyValue kv) {
+        if (firstKV == null) {
+            firstKV = kv;
         } else {
             if (!isInitialized) {
-                mergeFunction.add(rowData);
+                merge(firstKV);
                 isInitialized = true;
             }
-            mergeFunction.add(value);
+            merge(kv);
         }
     }
 
-    /**
-     * Get current value of the {@link MergeFunction} helper. Return null if the value should be
-     * skipped.
-     */
+    protected void merge(KeyValue kv) {
+        mergeFunction.add(kv);
+    }
+
+    /** Get current value of the {@link MergeFunction} helper. */
     public RowData getValue() {
-        return isInitialized ? mergeFunction.getValue() : rowData;
+        return isInitialized ? mergeFunction.getValue() : firstKV.value();
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/PartialUpdateMergeFunction.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/PartialUpdateMergeFunction.java
@@ -52,7 +52,7 @@ public class PartialUpdateMergeFunction implements MergeFunction {
     public void add(KeyValue kv) {
         checkArgument(
                 kv.valueKind() == RowKind.INSERT || kv.valueKind() == RowKind.UPDATE_AFTER,
-                "Partial update only accept insert only records.");
+                "Partial update can not accept delete records. Partial delete is not supported!");
         for (int i = 0; i < getters.length; i++) {
             Object field = getters[i].getFieldOrNull(kv.value());
             if (field != null) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/PartialUpdateMergeFunction.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/PartialUpdateMergeFunction.java
@@ -20,8 +20,12 @@ package org.apache.flink.table.store.file.mergetree.compact;
 
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.file.KeyValue;
+import org.apache.flink.types.RowKind;
 
 import javax.annotation.Nullable;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * A {@link MergeFunction} where key is primary key (unique) and value is the partial record, update
@@ -45,9 +49,12 @@ public class PartialUpdateMergeFunction implements MergeFunction {
     }
 
     @Override
-    public void add(RowData value) {
+    public void add(KeyValue kv) {
+        checkArgument(
+                kv.valueKind() == RowKind.INSERT || kv.valueKind() == RowKind.UPDATE_AFTER,
+                "Partial update only accept insert only records.");
         for (int i = 0; i < getters.length; i++) {
-            Object field = getters[i].getFieldOrNull(value);
+            Object field = getters[i].getFieldOrNull(kv.value());
             if (field != null) {
                 row.setField(i, field);
             }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/SortMergeReader.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/SortMergeReader.java
@@ -177,7 +177,7 @@ public class SortMergeReader implements RecordReader<KeyValue> {
                     break;
                 }
                 minHeap.poll();
-                mergeFunctionHelper.add(element.kv.value());
+                mergeFunctionHelper.add(element.kv);
                 polled.add(element);
             }
             return true;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/ValueCountMergeFunction.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/ValueCountMergeFunction.java
@@ -46,7 +46,7 @@ public class ValueCountMergeFunction implements MergeFunction {
     public void add(KeyValue kv) {
         checkArgument(
                 kv.valueKind() == RowKind.INSERT,
-                "In value count mode, only insert records coming. This is a bug. Please file an issue.");
+                "In value count mode, only insert records come. This is a bug. Please file an issue.");
         total += count(kv.value());
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/ValueCountMergeFunction.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/ValueCountMergeFunction.java
@@ -45,7 +45,8 @@ public class ValueCountMergeFunction implements MergeFunction {
     @Override
     public void add(KeyValue kv) {
         checkArgument(
-                kv.valueKind() == RowKind.INSERT, "Value count only accept insert only records.");
+                kv.valueKind() == RowKind.INSERT,
+                "In value count mode, only insert records coming. This is a bug. Please file an issue.");
         total += count(kv.value());
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/ValueCountMergeFunction.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/ValueCountMergeFunction.java
@@ -20,6 +20,8 @@ package org.apache.flink.table.store.file.mergetree.compact;
 
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.file.KeyValue;
+import org.apache.flink.types.RowKind;
 
 import javax.annotation.Nullable;
 
@@ -41,8 +43,10 @@ public class ValueCountMergeFunction implements MergeFunction {
     }
 
     @Override
-    public void add(RowData value) {
-        total += count(value);
+    public void add(KeyValue kv) {
+        checkArgument(
+                kv.valueKind() == RowKind.INSERT, "Value count only accept insert only records.");
+        total += count(kv.value());
     }
 
     @Override


### PR DESCRIPTION
We should pass KeyValue to MergeFunction, give MergeFunction more capabilities, such as throwing an exception when it sees an unreasonable RowKind.