### PR TITLE
[FLINK-29252]Support create table-store table with 'connector'='table-store'

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/FlinkCatalog.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/FlinkCatalog.java
@@ -54,6 +54,7 @@ import java.util.Optional;
 
 import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
 import static org.apache.flink.table.store.CoreOptions.PATH;
+import static org.apache.flink.table.store.connector.FlinkCatalogFactory.IDENTIFIER;
 
 /** Catalog for table store. */
 public class FlinkCatalog extends AbstractCatalog {
@@ -174,7 +175,8 @@ public class FlinkCatalog extends AbstractCatalog {
         }
         CatalogTable catalogTable = (CatalogTable) table;
         Map<String, String> options = table.getOptions();
-        if (options.containsKey(CONNECTOR.key())) {
+        if (options.containsKey(CONNECTOR.key())
+                && !options.get(CONNECTOR.key()).equals(IDENTIFIER)) {
             throw new CatalogException(
                     String.format(
                             "Table Store Catalog only supports table store tables, not '%s' connector."

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreConnectorFactory.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/TableStoreConnectorFactory.java
@@ -18,6 +18,13 @@
 
 package org.apache.flink.table.store.connector;
 
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
+import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.factories.DynamicTableFactory;
@@ -27,10 +34,28 @@ import org.apache.flink.table.store.file.catalog.CatalogLock;
 
 import javax.annotation.Nullable;
 
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.flink.table.store.CoreOptions.PATH;
+import static org.apache.flink.table.store.connector.FlinkCatalogFactory.DEFAULT_DATABASE;
 import static org.apache.flink.table.store.connector.FlinkCatalogFactory.IDENTIFIER;
 
 /** A table store {@link DynamicTableFactory} to create source and sink. */
 public class TableStoreConnectorFactory extends AbstractTableStoreFactory {
+
+    protected static final ConfigOption<String> CATALOG_NAME =
+            ConfigOptions.key("catalog-name")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Table-store catalog name.");
+
+    protected static final ConfigOption<String> CATALOG_TABLE =
+            ConfigOptions.key("catalog-table")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Table-store catalog table name.");
 
     @Nullable private final CatalogLock.Factory lockFactory;
 
@@ -49,7 +74,8 @@ public class TableStoreConnectorFactory extends AbstractTableStoreFactory {
 
     @Override
     public DynamicTableSource createDynamicTableSource(Context context) {
-        if (isFlinkTable(context)) {
+        String identifier = context.getCatalogTable().getOptions().get(FactoryUtil.CONNECTOR.key());
+        if (identifier != null && !IDENTIFIER.equals(identifier)) {
             // only Flink 1.14 temporary table will come here
             return FactoryUtil.createTableSource(
                     null,
@@ -58,13 +84,17 @@ public class TableStoreConnectorFactory extends AbstractTableStoreFactory {
                     context.getConfiguration(),
                     context.getClassLoader(),
                     context.isTemporary());
+        } else if (IDENTIFIER.equals(identifier)) { // create table-store table with connector='table-store'
+            createTableLoader(context);
         }
+
         return super.createDynamicTableSource(context);
     }
 
     @Override
     public DynamicTableSink createDynamicTableSink(Context context) {
-        if (isFlinkTable(context)) {
+        String identifier = context.getCatalogTable().getOptions().get(FactoryUtil.CONNECTOR.key());
+        if (identifier != null && !IDENTIFIER.equals(identifier)) {
             // only Flink 1.14 temporary table will come here
             return FactoryUtil.createTableSink(
                     null,
@@ -73,14 +103,53 @@ public class TableStoreConnectorFactory extends AbstractTableStoreFactory {
                     context.getConfiguration(),
                     context.getClassLoader(),
                     context.isTemporary());
+        } else if (IDENTIFIER.equals(identifier)) { // create table-store table with connector='table-store'
+            createTableLoader(context);
         }
+
         TableStoreSink sink = (TableStoreSink) super.createDynamicTableSink(context);
         sink.setLockFactory(lockFactory);
         return sink;
     }
 
-    private boolean isFlinkTable(Context context) {
-        String identifier = context.getCatalogTable().getOptions().get(FactoryUtil.CONNECTOR.key());
-        return identifier != null && !IDENTIFIER.equals(identifier);
+    private static void createTableLoader(Context context) {
+        ObjectPath defaultObjectPath = context.getObjectIdentifier().toObjectPath();
+        Map<String, String> tableOpts = context.getCatalogTable().getOptions();
+
+        String catalogName = tableOpts.get(CATALOG_NAME.key());
+        String catalogDatabase = tableOpts.getOrDefault(DEFAULT_DATABASE.key(), defaultObjectPath.getDatabaseName());
+        String catalogTable = tableOpts.getOrDefault(CATALOG_TABLE.key(), defaultObjectPath.getObjectName());
+
+        FlinkCatalog catalog = FlinkCatalogFactory.createCatalog(catalogName, Configuration.fromMap(tableOpts));
+
+        ObjectPath objectPath = new ObjectPath(catalogDatabase, catalogTable);
+
+        if (!catalog.tableExists(objectPath)) {
+            try {
+                catalog.createTable(objectPath, context.getCatalogTable(), false);
+            } catch (TableAlreadyExistException e) {
+                throw new RuntimeException(String.format("Table (or view) %s already exists in Catalog %s.", catalogTable, catalogName));
+            } catch (DatabaseNotExistException e) {
+                throw new RuntimeException(String.format("Database %s does not exist in Catalog %s.", catalogDatabase, catalogName));
+            }
+        }
+
+        Path tablePath = catalog.catalog().getTableLocation(objectPath);
+        context.getCatalogTable().getOptions().put(PATH.key(), tablePath.toString());
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(CATALOG_NAME);
+        return options;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(DEFAULT_DATABASE);
+        options.add(CATALOG_TABLE);
+        return options;
     }
 }


### PR DESCRIPTION
[[FLINK-29252]](https://issues.apache.org/jira/browse/FLINK-29252)Support create table-store table with 'connector'='table-store'
sink to table-store: 
```
SET 'execution.checkpointing.interval' = '10 s';
CREATE TEMPORARY TABLE word_table (
    word STRING
) WITH (
    'connector' = 'datagen',
    'fields.word.length' = '1'
);
CREATE TABLE word_count (
    word STRING PRIMARY KEY NOT ENFORCED,
    cnt BIGINT
) WITH(
  'connector' = 'table-store',
  'catalog-name' = 'test-catalog',
  'default-database' = 'test-db',  //should rename 'catalog-database'？
  'catalog-table' = 'test-tb',
  'warehouse'='file:/tmp/table_store'
);
INSERT INTO word_count SELECT word, COUNT(*) FROM word_table GROUP BY word; 
```

source from table-store: 
```
SET 'execution.checkpointing.interval' = '10 s';
CREATE TABLE word_count (
    word STRING PRIMARY KEY NOT ENFORCED,
    cnt BIGINT
) WITH(
  'connector' = 'table-store',
  'catalog-name' = 'test-catalog',
  'default-database' = 'test-db',
  'catalog-table' = 'test-tb',
  'warehouse'='file:/tmp/table_store'
);
CREATE TEMPORARY TABLE word_table (
    word STRING
) WITH (
    'connector' = 'print'
);
INSERT INTO word_table SELECT word FROM word_count;
```