### PR TITLE
[FLINK-29273] Page not enough Exception in SortBufferMemTable

### DIFF
--- a/docs/content/docs/development/write-table.md
+++ b/docs/content/docs/development/write-table.md
@@ -191,7 +191,8 @@ The following parameters determine when to stop writing:
 
 There are three main places in the Table Store's sink writer that take up memory:
 - MemTable's write buffer, shared and preempted by all writers of a single task.
-  This memory value can be adjusted by the `write-buffer-size` option.
+  This memory value can be adjusted by the `write-buffer-size` option. You need
+  to ensure that the number of pages is at least greater than the number of writers.
 - The memory consumed by compaction for reading files, can be adjusted by the
   `num-sorted-run.compaction-trigger` option to change the maximum number of files to be merged.
 - The memory consumed by writing columnar (ORC) file, which is not adjustable.

--- a/docs/content/docs/development/write-table.md
+++ b/docs/content/docs/development/write-table.md
@@ -191,8 +191,7 @@ The following parameters determine when to stop writing:
 
 There are three main places in the Table Store's sink writer that take up memory:
 - MemTable's write buffer, shared and preempted by all writers of a single task.
-  This memory value can be adjusted by the `write-buffer-size` option. You need
-  to ensure that the number of pages is at least greater than the number of writers.
+  This memory value can be adjusted by the `write-buffer-size` option.
 - The memory consumed by compaction for reading files, can be adjusted by the
   `num-sorted-run.compaction-trigger` option to change the maximum number of files to be merged.
 - The memory consumed by writing columnar (ORC) file, which is not adjustable.

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/memory/MemoryPoolFactory.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/memory/MemoryPoolFactory.java
@@ -40,8 +40,11 @@ public class MemoryPoolFactory {
     }
 
     public void notifyNewOwner(MemoryOwner owner) {
-        MemorySegmentPool memoryPool = new OwnerMemoryPool(owner);
-        owner.setMemoryPool(memoryPool);
+        owner.setMemoryPool(createSubPool(owner));
+    }
+
+    MemorySegmentPool createSubPool(MemoryOwner owner) {
+        return new OwnerMemoryPool(owner);
     }
 
     private void preemptMemory(MemoryOwner owner) {
@@ -88,6 +91,9 @@ public class MemoryPoolFactory {
 
         @Override
         public int freePages() {
+            // Actually, other owners still keep 1 page
+            // TODO We need to optimize this one page later.
+            // See BinaryInMemorySortBuffer.reset
             return totalPages - allocatedPages;
         }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/memory/MemoryPoolFactoryTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/memory/MemoryPoolFactoryTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.memory;
+
+import org.apache.flink.table.runtime.util.MemorySegmentPool;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link MemoryPoolFactory}. */
+public class MemoryPoolFactoryTest {
+
+    @Test
+    public void testFreePages() {
+        MemoryPoolFactory factory =
+                new MemoryPoolFactory(
+                        new HeapMemorySegmentPool(1024 * 10, 1024), new ArrayList<>());
+        MemorySegmentPool pool1 = factory.createSubPool(new TestMemoryOwner());
+        MemorySegmentPool pool2 = factory.createSubPool(new TestMemoryOwner());
+        assertThat(pool1.nextSegment()).isNotNull();
+        assertThat(pool2.nextSegment()).isNotNull();
+        assertThat(pool2.nextSegment()).isNotNull();
+
+        assertThat(pool1.freePages()).isEqualTo(9);
+        assertThat(pool2.freePages()).isEqualTo(8);
+    }
+
+    private static class TestMemoryOwner implements MemoryOwner {
+        @Override
+        public void setMemoryPool(MemorySegmentPool memoryPool) {}
+
+        @Override
+        public long memoryOccupancy() {
+            return 0;
+        }
+
+        @Override
+        public void flushMemory() {}
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/WritePreemptMemoryTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/WritePreemptMemoryTest.java
@@ -93,7 +93,10 @@ public class WritePreemptMemoryTest extends FileStoreTableTestBase {
         Configuration conf = new Configuration();
         conf.set(CoreOptions.PATH, tablePath.toString());
         conf.set(CoreOptions.WRITE_MODE, WriteMode.CHANGE_LOG);
-        conf.set(CoreOptions.WRITE_BUFFER_SIZE, new MemorySize(30 * 1024));
+        // Run with minimal memory to ensure a more intense preempt
+        // Currently a writer needs at least one page
+        int pages = 10;
+        conf.set(CoreOptions.WRITE_BUFFER_SIZE, new MemorySize(pages * 1024));
         conf.set(CoreOptions.PAGE_SIZE, new MemorySize(1024));
         configure.accept(conf);
         SchemaManager schemaManager = new SchemaManager(tablePath);


### PR DESCRIPTION
When there are many partitions, the partition writer will seize memory and may have the memory not enough exceptions.
We need to make sure that the writer has enough memory before it can start.

Actually, there is enough memory, because it can preempt from other writers. The problem is in `OwnerMemoryPool.freePages`, it should contain preemptable memory.