### PR TITLE
[FLINK-29278] BINARY type is not supported in table store

### DIFF
--- a/flink-table-store-common/src/test/java/org/apache/flink/table/store/format/FileStatsExtractorTestBase.java
+++ b/flink-table-store-common/src/test/java/org/apache/flink/table/store/format/FileStatsExtractorTestBase.java
@@ -30,11 +30,13 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.data.binary.BinaryStringData;
 import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 
 import org.junit.jupiter.api.Test;
@@ -128,6 +130,12 @@ public abstract class FileStatsExtractorTestBase {
                         randomString(random.nextInt(varCharType.getLength()) + 1));
             case BOOLEAN:
                 return random.nextBoolean();
+            case BINARY:
+                BinaryType binaryType = (BinaryType) type;
+                return randomString(binaryType.getLength()).getBytes();
+            case VARBINARY:
+                VarBinaryType varBinaryType = (VarBinaryType) type;
+                return randomString(varBinaryType.getLength()).getBytes();
             case TINYINT:
                 return (byte) random.nextInt(10);
             case SMALLINT:

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/FileStoreTableTestBase.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/FileStoreTableTestBase.java
@@ -71,12 +71,23 @@ public abstract class FileStoreTableTestBase {
                     new LogicalType[] {
                         DataTypes.INT().getLogicalType(),
                         DataTypes.INT().getLogicalType(),
-                        DataTypes.BIGINT().getLogicalType()
+                        DataTypes.BIGINT().getLogicalType(),
+                        DataTypes.BINARY(1).getLogicalType(),
+                        DataTypes.VARBINARY(1).getLogicalType()
                     },
-                    new String[] {"pt", "a", "b"});
+                    new String[] {"pt", "a", "b", "c", "d"});
     protected static final int[] PROJECTION = new int[] {2, 1};
     protected static final Function<RowData, String> BATCH_ROW_TO_STRING =
-            rowData -> rowData.getInt(0) + "|" + rowData.getInt(1) + "|" + rowData.getLong(2);
+            rowData ->
+                    rowData.getInt(0)
+                            + "|"
+                            + rowData.getInt(1)
+                            + "|"
+                            + rowData.getLong(2)
+                            + "|"
+                            + new String(rowData.getBinary(3))
+                            + "|"
+                            + new String(rowData.getBinary(4));
     protected static final Function<RowData, String> BATCH_PROJECTED_ROW_TO_STRING =
             rowData -> rowData.getLong(0) + "|" + rowData.getInt(1);
     protected static final Function<RowData, String> STREAMING_ROW_TO_STRING =
@@ -106,14 +117,14 @@ public abstract class FileStoreTableTestBase {
 
         TableWrite write = table.newWrite();
         TableCommit commit = table.newCommit("user");
-        write.write(GenericRowData.of(1, 10, 100L));
-        write.write(GenericRowData.of(2, 20, 200L));
+        write.write(rowData(1, 10, 100L));
+        write.write(rowData(2, 20, 200L));
         commit.commit("0", write.prepareCommit(true));
         write.close();
 
         write = table.newWrite().withOverwrite(true);
         commit = table.newCommit("user");
-        write.write(GenericRowData.of(2, 21, 201L));
+        write.write(rowData(2, 21, 201L));
         Map<String, String> overwritePartition = new HashMap<>();
         overwritePartition.put("pt", "2");
         commit.withOverwritePartition(overwritePartition).commit("1", write.prepareCommit(true));
@@ -122,9 +133,9 @@ public abstract class FileStoreTableTestBase {
         List<Split> splits = table.newScan().plan().splits;
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING))
-                .hasSameElementsAs(Collections.singletonList("1|10|100"));
+                .hasSameElementsAs(Collections.singletonList("1|10|100|binary|varbinary"));
         assertThat(getResult(read, splits, binaryRow(2), 0, BATCH_ROW_TO_STRING))
-                .hasSameElementsAs(Collections.singletonList("2|21|201"));
+                .hasSameElementsAs(Collections.singletonList("2|21|201|binary|varbinary"));
     }
 
     @Test
@@ -137,11 +148,11 @@ public abstract class FileStoreTableTestBase {
                         });
 
         TableWrite write = table.newWrite();
-        write.write(GenericRowData.of(1, 1, 2L));
-        write.write(GenericRowData.of(1, 3, 4L));
-        write.write(GenericRowData.of(1, 5, 6L));
-        write.write(GenericRowData.of(1, 7, 8L));
-        write.write(GenericRowData.of(1, 9, 10L));
+        write.write(rowData(1, 1, 2L));
+        write.write(rowData(1, 3, 4L));
+        write.write(rowData(1, 5, 6L));
+        write.write(rowData(1, 7, 8L));
+        write.write(rowData(1, 9, 10L));
         table.newCommit("user").commit("0", write.prepareCommit(true));
         write.close();
 
@@ -161,16 +172,16 @@ public abstract class FileStoreTableTestBase {
         TableWrite write = table.newWrite();
         TableCommit commit = table.newCommit("user");
 
-        write.write(GenericRowData.of(1, 10, 100L));
-        write.write(GenericRowData.of(1, 20, 200L));
+        write.write(rowData(1, 10, 100L));
+        write.write(rowData(1, 20, 200L));
         commit.commit("0", write.prepareCommit(true));
 
-        write.write(GenericRowData.of(1, 30, 300L));
-        write.write(GenericRowData.of(1, 40, 400L));
+        write.write(rowData(1, 30, 300L));
+        write.write(rowData(1, 40, 400L));
         commit.commit("1", write.prepareCommit(true));
 
-        write.write(GenericRowData.of(1, 50, 500L));
-        write.write(GenericRowData.of(1, 60, 600L));
+        write.write(rowData(1, 50, 500L));
+        write.write(rowData(1, 60, 600L));
         commit.commit("2", write.prepareCommit(true));
 
         write.close();
@@ -179,7 +190,8 @@ public abstract class FileStoreTableTestBase {
         List<Split> splits = table.newScan().plan().splits;
         TableRead read = table.newRead().withFilter(builder.equal(2, 300L));
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING))
-                .hasSameElementsAs(Arrays.asList("1|30|300", "1|40|400"));
+                .hasSameElementsAs(
+                        Arrays.asList("1|30|300|binary|varbinary", "1|40|400|binary|varbinary"));
     }
 
     @Test
@@ -191,21 +203,21 @@ public abstract class FileStoreTableTestBase {
         for (int i = 0; i < 4; i++) {
             // write lots of records, let compaction be slower
             for (int j = 0; j < 1000; j++) {
-                write.write(GenericRowData.of(1, 10 * i * j, 100L * i * j));
+                write.write(rowData(1, 10 * i * j, 100L * i * j));
             }
             commit.commit(String.valueOf(i), write.prepareCommit(false));
         }
 
-        write.write(GenericRowData.of(1, 40, 400L));
+        write.write(rowData(1, 40, 400L));
         List<FileCommittable> commit4 = write.prepareCommit(false);
         // trigger compaction, but not wait it.
 
-        write.write(GenericRowData.of(2, 20, 200L));
+        write.write(rowData(2, 20, 200L));
         List<FileCommittable> commit5 = write.prepareCommit(true);
         // wait compaction finish
         // commit5 should be a compaction commit
 
-        write.write(GenericRowData.of(1, 60, 600L));
+        write.write(rowData(1, 60, 600L));
         List<FileCommittable> commit6 = write.prepareCommit(true);
         // if remove writer too fast, will see old files, do another compaction
         // then will be conflicts
@@ -229,7 +241,7 @@ public abstract class FileStoreTableTestBase {
         TableWrite write = table.newWrite();
         TableCommit commit = table.newCommit("user");
         for (int i = 0; i < 10; i++) {
-            write.write(GenericRowData.of(1, 1, 100L));
+            write.write(rowData(1, 1, 100L));
             commit.commit(String.valueOf(i), write.prepareCommit(true));
         }
         write.close();
@@ -289,6 +301,21 @@ public abstract class FileStoreTableTestBase {
         writer.writeInt(0, a);
         writer.complete();
         return b;
+    }
+
+    protected GenericRowData rowData(Object... values) {
+        return GenericRowData.of(
+                values[0], values[1], values[2], "binary".getBytes(), "varbinary".getBytes());
+    }
+
+    protected GenericRowData rowDataWithKind(RowKind rowKind, Object... values) {
+        return GenericRowData.ofKind(
+                rowKind,
+                values[0],
+                values[1],
+                values[2],
+                "binary".getBytes(),
+                "varbinary".getBytes());
     }
 
     protected FileStoreTable createFileStoreTable(int numOfBucket) throws Exception {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/WritePreemptMemoryTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/WritePreemptMemoryTest.java
@@ -68,8 +68,7 @@ public class WritePreemptMemoryTest extends FileStoreTableTestBase {
         Random random = new Random();
         List<String> expected = new ArrayList<>();
         for (int i = 0; i < 10_000; i++) {
-            GenericRowData row =
-                    GenericRowData.of(singlePartition ? 0 : random.nextInt(5), i, i * 10L);
+            GenericRowData row = rowData(singlePartition ? 0 : random.nextInt(5), i, i * 10L);
             write.write(row);
             expected.add(BATCH_ROW_TO_STRING.apply(row));
         }

--- a/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/orc/OrcFileFormat.java
+++ b/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/orc/OrcFileFormat.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.file.src.FileSourceSplit;
 import org.apache.flink.connector.file.src.reader.BulkFormat;
 import org.apache.flink.orc.OrcFilters;
+import org.apache.flink.orc.OrcSplitReaderUtil;
 import org.apache.flink.orc.vector.RowDataVectorizer;
 import org.apache.flink.orc.vector.Vectorizer;
 import org.apache.flink.orc.writer.ThreadLocalClassLoaderConfiguration;
@@ -35,12 +36,9 @@ import org.apache.flink.table.store.format.FileFormat;
 import org.apache.flink.table.store.format.FileStatsExtractor;
 import org.apache.flink.table.store.utils.Projection;
 import org.apache.flink.table.types.logical.ArrayType;
-import org.apache.flink.table.types.logical.CharType;
-import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.types.logical.VarCharType;
 
 import org.apache.orc.OrcFile;
 import org.apache.orc.TypeDescription;
@@ -99,7 +97,7 @@ public class OrcFileFormat extends FileFormat {
 
         return OrcInputFormatFactory.create(
                 readerConf,
-                (RowType) convertLogicalType(type),
+                (RowType) refineLogicalType(type),
                 Projection.of(projection).toTopLevelIndexes(),
                 orcPredicates);
     }
@@ -108,7 +106,8 @@ public class OrcFileFormat extends FileFormat {
     public BulkWriter.Factory<RowData> createWriterFactory(RowType type) {
         LogicalType[] orcTypes = type.getChildren().toArray(new LogicalType[0]);
 
-        TypeDescription typeDescription = logicalTypeToOrcType(type);
+        TypeDescription typeDescription =
+                OrcSplitReaderUtil.logicalTypeToOrcType(refineLogicalType(type));
         Vectorizer<RowData> vectorizer =
                 new RowDataVectorizer(typeDescription.toString(), orcTypes);
         OrcFile.WriterOptions writerOptions = OrcFile.writerOptions(orcProperties, writerConf);
@@ -125,20 +124,22 @@ public class OrcFileFormat extends FileFormat {
         return orcProperties;
     }
 
-    private static LogicalType convertLogicalType(LogicalType type) {
+    private static LogicalType refineLogicalType(LogicalType type) {
         switch (type.getTypeRoot()) {
             case BINARY:
             case VARBINARY:
+                // OrcSplitReaderUtil#logicalTypeToOrcType() only supports the DataTypes.BYTES()
+                // logical type for BINARY and VARBINARY.
                 return DataTypes.BYTES().getLogicalType();
             case ARRAY:
                 ArrayType arrayType = (ArrayType) type;
                 return new ArrayType(
-                        arrayType.isNullable(), convertLogicalType(arrayType.getElementType()));
+                        arrayType.isNullable(), refineLogicalType(arrayType.getElementType()));
             case MAP:
                 MapType mapType = (MapType) type;
                 return new MapType(
-                        convertLogicalType(mapType.getKeyType()),
-                        convertLogicalType(mapType.getValueType()));
+                        refineLogicalType(mapType.getKeyType()),
+                        refineLogicalType(mapType.getValueType()));
             case ROW:
                 RowType rowType = (RowType) type;
                 return new RowType(
@@ -148,72 +149,11 @@ public class OrcFileFormat extends FileFormat {
                                         f ->
                                                 new RowType.RowField(
                                                         f.getName(),
-                                                        convertLogicalType(f.getType()),
+                                                        refineLogicalType(f.getType()),
                                                         f.getDescription().orElse(null)))
                                 .collect(Collectors.toList()));
             default:
                 return type;
-        }
-    }
-
-    /** See {@code org.apache.flink.table.catalog.hive.util.HiveTypeUtil}. */
-    private static TypeDescription logicalTypeToOrcType(LogicalType type) {
-        type = type.copy(true);
-        switch (type.getTypeRoot()) {
-            case CHAR:
-                return TypeDescription.createChar().withMaxLength(((CharType) type).getLength());
-            case VARCHAR:
-                int len = ((VarCharType) type).getLength();
-                if (len == VarCharType.MAX_LENGTH) {
-                    return TypeDescription.createString();
-                } else {
-                    return TypeDescription.createVarchar().withMaxLength(len);
-                }
-            case BOOLEAN:
-                return TypeDescription.createBoolean();
-            case BINARY:
-            case VARBINARY:
-                return TypeDescription.createBinary();
-            case DECIMAL:
-                DecimalType decimalType = (DecimalType) type;
-                return TypeDescription.createDecimal()
-                        .withScale(decimalType.getScale())
-                        .withPrecision(decimalType.getPrecision());
-            case TINYINT:
-                return TypeDescription.createByte();
-            case SMALLINT:
-                return TypeDescription.createShort();
-            case INTEGER:
-                return TypeDescription.createInt();
-            case BIGINT:
-                return TypeDescription.createLong();
-            case FLOAT:
-                return TypeDescription.createFloat();
-            case DOUBLE:
-                return TypeDescription.createDouble();
-            case DATE:
-                return TypeDescription.createDate();
-            case TIMESTAMP_WITHOUT_TIME_ZONE:
-                return TypeDescription.createTimestamp();
-            case ARRAY:
-                ArrayType arrayType = (ArrayType) type;
-                return TypeDescription.createList(logicalTypeToOrcType(arrayType.getElementType()));
-            case MAP:
-                MapType mapType = (MapType) type;
-                return TypeDescription.createMap(
-                        logicalTypeToOrcType(mapType.getKeyType()),
-                        logicalTypeToOrcType(mapType.getValueType()));
-            case ROW:
-                RowType rowType = (RowType) type;
-                TypeDescription struct = TypeDescription.createStruct();
-                for (int i = 0; i < rowType.getFieldCount(); i++) {
-                    struct.addField(
-                            rowType.getFieldNames().get(i),
-                            logicalTypeToOrcType(rowType.getChildren().get(i)));
-                }
-                return struct;
-            default:
-                throw new UnsupportedOperationException("Unsupported type: " + type);
         }
     }
 }

--- a/flink-table-store-format/src/test/java/org/apache/flink/table/store/format/orc/OrcFileStatsExtractorTest.java
+++ b/flink-table-store-format/src/test/java/org/apache/flink/table/store/format/orc/OrcFileStatsExtractorTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.store.format.FileFormat;
 import org.apache.flink.table.store.format.FileStatsExtractorTestBase;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.DateType;
@@ -34,6 +35,7 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 
 /** Tests for {@link OrcFileStatsExtractor}. */
@@ -50,6 +52,8 @@ public class OrcFileStatsExtractorTest extends FileStatsExtractorTestBase {
                 new CharType(8),
                 new VarCharType(8),
                 new BooleanType(),
+                new BinaryType(8),
+                new VarBinaryType(8),
                 new TinyIntType(),
                 new SmallIntType(),
                 new IntType(),


### PR DESCRIPTION
`BINARY` type is not supported in table store for `OrcFileFormat`.

**The brief change log**
- Adds the `BINARY` type support for `OrcFileFormat`.