### PR TITLE
[FLINK-29295] Clear RecordWriter slower to avoid causing frequent compaction conflicts

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/Increment.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/Increment.java
@@ -75,6 +75,10 @@ public class Increment {
         return compactAfter;
     }
 
+    public boolean isEmpty() {
+        return newFiles.isEmpty() && compactBefore.isEmpty() && compactAfter.isEmpty();
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/AbstractTableWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/AbstractTableWrite.java
@@ -99,7 +99,7 @@ public abstract class AbstractTableWrite<T> implements TableWrite {
                 // clear if no update
                 // we need a mechanism to clear writers, otherwise there will be more and more
                 // such as yesterday's partition that no longer needs to be written.
-                if (committable.increment().newFiles().isEmpty()) {
+                if (committable.increment().isEmpty()) {
                     writer.close();
                     bucketIter.remove();
                 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/FileStoreTableTestBase.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/FileStoreTableTestBase.java
@@ -25,8 +25,6 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.data.writer.BinaryRowWriter;
-import org.apache.flink.table.store.CoreOptions;
-import org.apache.flink.table.store.file.WriteMode;
 import org.apache.flink.table.store.file.mergetree.compact.ConcatRecordReader;
 import org.apache.flink.table.store.file.mergetree.compact.ConcatRecordReader.ReaderSupplier;
 import org.apache.flink.table.store.file.predicate.PredicateBuilder;
@@ -58,7 +56,6 @@ import java.util.function.Function;
 import static org.apache.flink.table.store.CoreOptions.BUCKET;
 import static org.apache.flink.table.store.CoreOptions.BUCKET_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
 /** Base test class for {@link FileStoreTable}. */
 public abstract class FileStoreTableTestBase {
@@ -182,8 +179,6 @@ public abstract class FileStoreTableTestBase {
     @Test
     public void testPartitionEmptyWriter() throws Exception {
         FileStoreTable table = createFileStoreTable();
-        assumeThat(writeMode(table)).isEqualTo(WriteMode.CHANGE_LOG);
-
         TableWrite write = table.newWrite();
         TableCommit commit = table.newCommit("user");
 
@@ -211,11 +206,6 @@ public abstract class FileStoreTableTestBase {
         commit.commit("6", commit6);
 
         write.close();
-    }
-
-    private WriteMode writeMode(FileStoreTable table) {
-        Configuration conf = Configuration.fromMap(table.schema().options());
-        return conf.get(CoreOptions.WRITE_MODE);
     }
 
     protected List<String> getResult(

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/FileStoreTableTestBase.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/FileStoreTableTestBase.java
@@ -192,14 +192,17 @@ public abstract class FileStoreTableTestBase {
 
         write.write(GenericRowData.of(1, 40, 400L));
         List<FileCommittable> commit4 = write.prepareCommit(false);
+        // trigger compaction, but not wait it.
 
         write.write(GenericRowData.of(2, 20, 200L));
         List<FileCommittable> commit5 = write.prepareCommit(true);
+        // wait compaction finish
         // commit5 should be a compaction commit
 
         write.write(GenericRowData.of(1, 60, 600L));
         List<FileCommittable> commit6 = write.prepareCommit(true);
-        // commit6 should be a compaction commit
+        // if remove writer too fast, will see old files, do another compaction
+        // then will be conflicts
 
         commit.commit("4", commit4);
         commit.commit("5", commit5);


### PR DESCRIPTION
In AbstractTableWrite, the Writer is cleaned up as soon as no new files are generated, which may lead to the changes generated after the compaction have not been committed, but the new data from the next checkpoint comes to create a new writer, which conflicts with the changes generated in the next round of checkpoint and the previous round, resulting in an exception:
```
Caused by: java.lang.IllegalStateException: Trying to delete file {org.apache.flink.table.data.binary.BinaryRowData@5759f99e, 0, 0, data-7bf2498e-d0a1-42a5-97b7-b3860f10b076-0.orc} which is not previously added. Manifest might be corrupted.
```