### PR TITLE
[hotfix] TableStoreSink requires partition grouping

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/TableStoreSink.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/TableStoreSink.java
@@ -170,4 +170,9 @@ public class TableStoreSink implements DynamicTableSink, SupportsOverwrite, Supp
     public void setLockFactory(@Nullable CatalogLock.Factory lockFactory) {
         this.lockFactory = lockFactory;
     }
+
+    @Override
+    public boolean requiresPartitionGrouping(boolean supportsGrouping) {
+        return supportsGrouping;
+    }
 }


### PR DESCRIPTION
By default, batch sink should sort the input by partition to avoid generating a large number of small files.