### PR TITLE
[FLINK-29369] Commit delete file failure due to Checkpoint aborted

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/Committable.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/Committable.java
@@ -21,13 +21,20 @@ package org.apache.flink.table.store.connector.sink;
 /** Committable produced by {@link PrepareCommitOperator}. */
 public class Committable {
 
+    private final long checkpointId;
+
     private final Kind kind;
 
     private final Object wrappedCommittable;
 
-    public Committable(Kind kind, Object wrappedCommittable) {
+    public Committable(long checkpointId, Kind kind, Object wrappedCommittable) {
+        this.checkpointId = checkpointId;
         this.kind = kind;
         this.wrappedCommittable = wrappedCommittable;
+    }
+
+    public long checkpointId() {
+        return checkpointId;
     }
 
     public Kind kind() {
@@ -36,6 +43,18 @@ public class Committable {
 
     public Object wrappedCommittable() {
         return wrappedCommittable;
+    }
+
+    @Override
+    public String toString() {
+        return "Committable{"
+                + "checkpointId="
+                + checkpointId
+                + ", kind="
+                + kind
+                + ", wrappedCommittable="
+                + wrappedCommittable
+                + '}';
     }
 
     enum Kind {

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/CommittableSerializer.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/CommittableSerializer.java
@@ -57,7 +57,7 @@ public class CommittableSerializer implements SimpleVersionedSerializer<Committa
                 throw new UnsupportedOperationException("Unsupported kind: " + committable.kind());
         }
 
-        return ByteBuffer.allocate(4 + 1 + wrapped.length + 4)
+        return ByteBuffer.allocate(8 + 1 + wrapped.length + 4)
                 .putLong(committable.checkpointId())
                 .put(committable.kind().toByteValue())
                 .put(wrapped)
@@ -74,7 +74,7 @@ public class CommittableSerializer implements SimpleVersionedSerializer<Committa
         ByteBuffer buffer = ByteBuffer.wrap(bytes);
         long checkpointId = buffer.getLong();
         Committable.Kind kind = Committable.Kind.fromByteValue(buffer.get());
-        byte[] wrapped = new byte[bytes.length - 9];
+        byte[] wrapped = new byte[bytes.length - 13];
         buffer.get(wrapped);
         int version = buffer.getInt();
 

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/CommitterOperator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/CommitterOperator.java
@@ -81,6 +81,8 @@ public class CommitterOperator extends AbstractStreamOperator<Committable>
      */
     private Committer committer;
 
+    private boolean endInput = false;
+
     public CommitterOperator(
             boolean streamingCheckpointEnabled,
             SerializableFunction<String, Committer> committerFactory,
@@ -173,6 +175,7 @@ public class CommitterOperator extends AbstractStreamOperator<Committable>
 
     @Override
     public void endInput() throws Exception {
+        endInput = true;
         if (streamingCheckpointEnabled) {
             return;
         }
@@ -184,7 +187,7 @@ public class CommitterOperator extends AbstractStreamOperator<Committable>
     @Override
     public void notifyCheckpointComplete(long checkpointId) throws Exception {
         super.notifyCheckpointComplete(checkpointId);
-        commitUpToCheckpoint(checkpointId);
+        commitUpToCheckpoint(endInput ? Long.MAX_VALUE : checkpointId);
     }
 
     private void commitUpToCheckpoint(long checkpointId) throws Exception {

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/PrepareCommitOperator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/PrepareCommitOperator.java
@@ -44,7 +44,7 @@ public abstract class PrepareCommitOperator extends AbstractStreamOperator<Commi
     @Override
     public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
         if (!endOfInput) {
-            emitCommittables(false);
+            emitCommittables(false, checkpointId);
         }
         // no records are expected to emit after endOfInput
     }
@@ -52,13 +52,14 @@ public abstract class PrepareCommitOperator extends AbstractStreamOperator<Commi
     @Override
     public void endInput() throws Exception {
         endOfInput = true;
-        emitCommittables(true);
+        emitCommittables(true, Long.MAX_VALUE);
     }
 
-    private void emitCommittables(boolean endOfInput) throws IOException {
-        prepareCommit(endOfInput)
+    private void emitCommittables(boolean endOfInput, long checkpointId) throws IOException {
+        prepareCommit(endOfInput, checkpointId)
                 .forEach(committable -> output.collect(new StreamRecord<>(committable)));
     }
 
-    protected abstract List<Committable> prepareCommit(boolean endOfInput) throws IOException;
+    protected abstract List<Committable> prepareCommit(boolean endOfInput, long checkpointId)
+            throws IOException;
 }

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreCompactOperator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreCompactOperator.java
@@ -58,9 +58,10 @@ public class StoreCompactOperator extends PrepareCommitOperator {
     }
 
     @Override
-    protected List<Committable> prepareCommit(boolean endOfInput) throws IOException {
+    protected List<Committable> prepareCommit(boolean endOfInput, long checkpointId)
+            throws IOException {
         return compact.compact().stream()
-                .map(c -> new Committable(Committable.Kind.FILE, c))
+                .map(c -> new Committable(checkpointId, Committable.Kind.FILE, c))
                 .collect(Collectors.toList());
     }
 }

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreWriteOperator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreWriteOperator.java
@@ -181,11 +181,12 @@ public class StoreWriteOperator extends PrepareCommitOperator {
     }
 
     @Override
-    protected List<Committable> prepareCommit(boolean endOfInput) throws IOException {
+    protected List<Committable> prepareCommit(boolean endOfInput, long checkpointId)
+            throws IOException {
         List<Committable> committables = new ArrayList<>();
         try {
             for (FileCommittable committable : write.prepareCommit(endOfInput)) {
-                committables.add(new Committable(Committable.Kind.FILE, committable));
+                committables.add(new Committable(checkpointId, Committable.Kind.FILE, committable));
             }
         } catch (Exception e) {
             throw new IOException(e);
@@ -203,6 +204,7 @@ public class StoreWriteOperator extends PrepareCommitOperator {
                             (k, v) ->
                                     committables.add(
                                             new Committable(
+                                                    checkpointId,
                                                     Committable.Kind.LOG_OFFSET,
                                                     new LogOffsetCommittable(k, v))));
         }

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/CommittableSerializerTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/CommittableSerializerTest.java
@@ -47,7 +47,7 @@ public class CommittableSerializerTest {
                                         1,
                                         serializer.serialize(
                                                 new Committable(
-                                                        Committable.Kind.FILE, committable)))
+                                                        9, Committable.Kind.FILE, committable)))
                                 .wrappedCommittable();
         assertThat(newCommittable).isEqualTo(committable);
     }
@@ -62,7 +62,9 @@ public class CommittableSerializerTest {
                                         1,
                                         serializer.serialize(
                                                 new Committable(
-                                                        Committable.Kind.LOG_OFFSET, committable)))
+                                                        8,
+                                                        Committable.Kind.LOG_OFFSET,
+                                                        committable)))
                                 .wrappedCommittable();
         assertThat(newCommittable).isEqualTo(committable);
     }

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/CommittableSerializerTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/CommittableSerializerTest.java
@@ -44,7 +44,7 @@ public class CommittableSerializerTest {
                 (FileCommittable)
                         serializer
                                 .deserialize(
-                                        1,
+                                        2,
                                         serializer.serialize(
                                                 new Committable(
                                                         9, Committable.Kind.FILE, committable)))
@@ -59,7 +59,7 @@ public class CommittableSerializerTest {
                 (LogOffsetCommittable)
                         serializer
                                 .deserialize(
-                                        1,
+                                        2,
                                         serializer.serialize(
                                                 new Committable(
                                                         8,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/Increment.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/Increment.java
@@ -97,4 +97,16 @@ public class Increment {
     public int hashCode() {
         return Objects.hash(newFiles, compactBefore, compactAfter);
     }
+
+    @Override
+    public String toString() {
+        return "Increment{"
+                + "newFiles="
+                + newFiles
+                + ", compactBefore="
+                + compactBefore
+                + ", compactAfter="
+                + compactAfter
+                + '}';
+    }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/FileCommittable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/FileCommittable.java
@@ -68,4 +68,16 @@ public class FileCommittable {
     public int hashCode() {
         return Objects.hash(partition, bucket, increment);
     }
+
+    @Override
+    public String toString() {
+        return "FileCommittable{"
+                + "partition="
+                + partition
+                + ", bucket="
+                + bucket
+                + ", increment="
+                + increment
+                + '}';
+    }
 }

--- a/flink-table-store-spark/src/test/java/org/apache/flink/table/store/spark/SparkReadITCase.java
+++ b/flink-table-store-spark/src/test/java/org/apache/flink/table/store/spark/SparkReadITCase.java
@@ -650,8 +650,11 @@ public class SparkReadITCase {
                 .isInstanceOf(NamespaceAlreadyExistsException.class)
                 .hasMessageContaining("Namespace 'bar' already exists");
 
-        assertThat(spark.sql("SHOW NAMESPACES").collectAsList().toString())
-                .isEqualTo("[[bar], [default]]");
+        assertThat(
+                        spark.sql("SHOW NAMESPACES").collectAsList().stream()
+                                .map(row -> row.getString(0))
+                                .collect(Collectors.toList()))
+                .containsExactlyInAnyOrder("bar", "default");
 
         Path nsPath = new Path(warehousePath, "bar.db");
         assertThat(new File(nsPath.toUri())).exists();


### PR DESCRIPTION
After checkpoint abort, the files in cp5 may fall into cp6, because the compaction commit is deleted first and then added, which may lead to:
- Delete a file
- Add the same file again

This causes the deleted file not to be found.

We should reasonably distinguish files of different checkpoints in the committer.