### PR TITLE
[FLINK-29385] Verify duplicate column names for AddColumn

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
@@ -35,6 +35,8 @@ import org.apache.flink.table.store.file.utils.JsonSerdeUtil;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Preconditions;
 
+import org.apache.commons.lang3.StringUtils;
+
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -46,7 +48,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -174,14 +175,15 @@ public class SchemaManager implements Serializable {
                     newOptions.remove(removeOption.key());
                 } else if (change instanceof AddColumn) {
                     AddColumn addColumn = (AddColumn) change;
-                    Set<String> fieldNames =
-                            newFields.stream().map(DataField::name).collect(Collectors.toSet());
-                    if (fieldNames.contains(addColumn.fieldName())) {
+                    if (newFields.stream()
+                            .anyMatch(
+                                    f ->
+                                            StringUtils.equalsIgnoreCase(
+                                                    f.name(), addColumn.fieldName()))) {
                         throw new IllegalArgumentException(
-                                "The column["
-                                        + addColumn.fieldName()
-                                        + "] is exist in "
-                                        + tableRoot);
+                                String.format(
+                                        "The column [%s] exists in the table[%s].",
+                                        addColumn.fieldName(), tableRoot));
                     }
                     int id = highestFieldId.incrementAndGet();
                     DataType dataType =

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
@@ -46,6 +46,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -173,6 +174,15 @@ public class SchemaManager implements Serializable {
                     newOptions.remove(removeOption.key());
                 } else if (change instanceof AddColumn) {
                     AddColumn addColumn = (AddColumn) change;
+                    Set<String> fieldNames =
+                            newFields.stream().map(DataField::name).collect(Collectors.toSet());
+                    if (fieldNames.contains(addColumn.fieldName())) {
+                        throw new IllegalArgumentException(
+                                "The column["
+                                        + addColumn.fieldName()
+                                        + "] is exist in "
+                                        + tableRoot);
+                    }
                     int id = highestFieldId.incrementAndGet();
                     DataType dataType =
                             TableSchema.toDataType(addColumn.logicalType(), highestFieldId);

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/SchemaEvolutionTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/SchemaEvolutionTest.java
@@ -53,6 +53,7 @@ import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.filter;
 
 /** Test for schema evolution. */
 public class SchemaEvolutionTest {
@@ -124,6 +125,7 @@ public class SchemaEvolutionTest {
 
     @Test
     public void testAddDuplicateField() throws Exception {
+        final String columnName = "f3";
         UpdateSchema updateSchema =
                 new UpdateSchema(
                         RowType.of(new IntType(), new BigIntType()),
@@ -133,15 +135,15 @@ public class SchemaEvolutionTest {
                         "");
         schemaManager.commitNewVersion(updateSchema);
         schemaManager.commitChanges(
-                Collections.singletonList(SchemaChange.addColumn("f3", new BigIntType())));
+                Collections.singletonList(SchemaChange.addColumn(columnName, new BigIntType())));
         assertThatThrownBy(
                         () -> {
                             schemaManager.commitChanges(
                                     Collections.singletonList(
-                                            SchemaChange.addColumn("f3", new FloatType())));
+                                            SchemaChange.addColumn(columnName, new FloatType())));
                         })
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith("The column[f3] is exist in");
+                .hasMessage("The column [%s] exists in the table[%s].", columnName, tablePath);
     }
 
     private List<Row> readRecords(FileStoreTable table, Predicate filter) throws IOException {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/SchemaEvolutionTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/SchemaEvolutionTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.table.store.table.source.Split;
 import org.apache.flink.table.store.table.source.TableRead;
 import org.apache.flink.table.store.table.source.TableScan;
 import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.utils.TypeConversions;
@@ -51,6 +52,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for schema evolution. */
 public class SchemaEvolutionTest {
@@ -118,6 +120,28 @@ public class SchemaEvolutionTest {
         // read where f3 = 3 (filter on new field)
         rows = readRecords(table, builder.equal(2, 3L));
         assertThat(rows).containsExactlyInAnyOrder(Row.of(3, 3L, 3L), Row.of(4, 4L, 4L));
+    }
+
+    @Test
+    public void testAddDuplicateField() throws Exception {
+        UpdateSchema updateSchema =
+                new UpdateSchema(
+                        RowType.of(new IntType(), new BigIntType()),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        new HashMap<>(),
+                        "");
+        schemaManager.commitNewVersion(updateSchema);
+        schemaManager.commitChanges(
+                Collections.singletonList(SchemaChange.addColumn("f3", new BigIntType())));
+        assertThatThrownBy(
+                        () -> {
+                            schemaManager.commitChanges(
+                                    Collections.singletonList(
+                                            SchemaChange.addColumn("f3", new FloatType())));
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageStartingWith("The column[f3] is exist in");
     }
 
     private List<Row> readRecords(FileStoreTable table, Predicate filter) throws IOException {


### PR DESCRIPTION
When we execute AddColumn ddl, we should check whether the column name is exist. Otherwise, the ddl will be successful and the job reads this table will create source of flink store table failed.