### PR TITLE
[FLINK-29149] Migrate E2E tests to catalog-based and enable E2E tests for Flink 1.14

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,12 +13,21 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - name: Build
+      - name: Build Flink 1.15
         run: mvn clean install -DskipTests
-      - name: Test
+      - name: Test Flink 1.15
         run: |
           # run tests with random timezone to find out timezone related bugs
           . .github/workflows/utils.sh
           jvm_timezone=$(random_timezone)
           echo "JVM timezone is set to $jvm_timezone"
           mvn test -pl flink-table-store-e2e-tests -Duser.timezone=$jvm_timezone
+      - name: Build Flink 1.14
+        run: mvn clean install -Dmaven.test.skip=true -Pflink-1.14
+      - name: Test Flink 1.14
+        run: |
+          # run tests with random timezone to find out timezone related bugs
+          . .github/workflows/utils.sh
+          jvm_timezone=$(random_timezone)
+          echo "JVM timezone is set to $jvm_timezone"
+          mvn test -pl flink-table-store-e2e-tests -Duser.timezone=$jvm_timezone -Pflink-1.14

--- a/flink-table-store-e2e-tests/src/test/java/org/apache/flink/table/store/tests/FileStoreStreamE2eTest.java
+++ b/flink-table-store-e2e-tests/src/test/java/org/apache/flink/table/store/tests/FileStoreStreamE2eTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.store.tests;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
@@ -25,59 +26,82 @@ import java.util.UUID;
 /** Tests for reading and writing file store in stream jobs. */
 public class FileStoreStreamE2eTest extends E2eTestBase {
 
+    private String topicName;
+
+    public FileStoreStreamE2eTest() {
+        super(true, false);
+    }
+
+    @Override
+    @BeforeEach
+    public void before() throws Exception {
+        super.before();
+        topicName = "ts-topic-" + UUID.randomUUID();
+        createKafkaTopic(topicName, 1);
+        // prepare first part of test data
+        sendKafkaMessage("1.csv", "A,5\nB,10\nA,4\nB,9", topicName);
+    }
+
     @Test
     public void testWithoutPk() throws Exception {
         String testDataSourceDdl =
-                "CREATE TABLE test_source (\n"
-                        + "    a VARCHAR,\n"
-                        + "    b INT\n"
-                        + ") WITH (\n"
-                        + "    'connector' = 'filesystem',\n"
-                        + "    'format' = 'csv',\n"
-                        + "    'path' = '%s'\n,"
-                        + "    'source.monitor-interval' = '3s'\n"
-                        + ");";
-        String testDataSourceDir = UUID.randomUUID().toString() + ".data";
-        testDataSourceDdl =
-                String.format(testDataSourceDdl, TEST_DATA_DIR + "/" + testDataSourceDir);
+                String.format(
+                        "CREATE TEMPORARY TABLE test_source (\n"
+                                + "    a VARCHAR,\n"
+                                + "    b INT\n"
+                                + ") WITH (\n"
+                                + "    'connector' = 'kafka',\n"
+                                + "    'properties.bootstrap.servers' = 'kafka:9092',\n"
+                                + "    'properties.group.id' = 'testGroup',\n"
+                                + "    'scan.startup.mode' = 'earliest-offset',\n"
+                                + "    'topic' = '%s',\n"
+                                + "    'format' = 'csv'\n"
+                                + ");",
+                        topicName);
 
-        String tableStoreDdl =
-                "CREATE TABLE IF NOT EXISTS table_store (\n"
+        String catalogDdl =
+                String.format(
+                        "CREATE CATALOG ts_catalog WITH (\n"
+                                + "    'type' = 'table-store',\n"
+                                + "    'warehouse' = '%s'\n"
+                                + ");",
+                        TEST_DATA_DIR + "/" + UUID.randomUUID() + ".store");
+
+        String useCatalogCmd = "USE CATALOG ts_catalog;";
+
+        String tableDdl =
+                "CREATE TABLE IF NOT EXISTS ts_table (\n"
                         + "    a VARCHAR,\n"
                         + "    b INT,\n"
                         + "    rn BIGINT\n"
                         + ") WITH (\n"
-                        + "    'bucket' = '3',\n"
-                        + "    'root-path' = '%s'\n"
+                        + "    'bucket' = '3'\n"
                         + ");";
-        tableStoreDdl =
-                String.format(
-                        tableStoreDdl,
-                        TEST_DATA_DIR + "/" + UUID.randomUUID().toString() + ".store");
-
-        // prepare first part of test data
-        writeSharedFile(testDataSourceDir + "/1.csv", "A,5\nB,10\nA,4\nB,9\n");
 
         // insert data into table store
         runSql(
                 "SET 'execution.checkpointing.interval' = '5s';\n"
-                        + "INSERT INTO table_store SELECT a, b, rn FROM (\n"
+                        + "INSERT INTO ts_table SELECT a, b, rn FROM (\n"
                         + "  SELECT a, b, row_number() over (PARTITION BY a ORDER BY b) AS rn FROM test_source\n"
                         + ") WHERE rn <= 3;",
-                testDataSourceDdl,
-                tableStoreDdl);
+                catalogDdl,
+                useCatalogCmd,
+                tableDdl,
+                testDataSourceDdl);
 
         // read all data from table store
         runSql(
-                "INSERT INTO result1 SELECT * FROM table_store;",
-                tableStoreDdl,
+                "INSERT INTO result1 SELECT * FROM ts_table;",
+                catalogDdl,
+                useCatalogCmd,
+                tableDdl,
                 createResultSink("result1", "a VARCHAR, b INT, rn BIGINT"));
 
         // check that we can read the first part of test data
         checkResult("A, 4, 1", "A, 5, 2", "B, 9, 1", "B, 10, 2");
 
         // prepare second part of test data
-        writeSharedFile(testDataSourceDir + "/2.csv", "A,3\nB,8\nA,2\nB,11\n");
+        sendKafkaMessage("2.csv", "A,3\nB,8\nA,2\nB,11", topicName);
 
         // check that we can read the second part of test data
         checkResult("A, 2, 1", "A, 3, 2", "A, 4, 3", "B, 8, 1", "B, 9, 2", "B, 10, 3");
@@ -87,8 +111,10 @@ public class FileStoreStreamE2eTest extends E2eTestBase {
         runSql(
                 "SET 'execution.runtime-mode' = 'batch';\n"
                         + "RESET 'execution.checkpointing.interval';\n"
-                        + "INSERT INTO result2 SELECT * FROM table_store;",
-                tableStoreDdl,
+                        + "INSERT INTO result2 SELECT * FROM ts_table;",
+                catalogDdl,
+                useCatalogCmd,
+                tableDdl,
                 createResultSink("result2", "a VARCHAR, b INT, rn BIGINT"));
         checkResult("A, 2, 1", "A, 3, 2", "A, 4, 3", "B, 8, 1", "B, 9, 2", "B, 10, 3");
     }

--- a/flink-table-store-e2e-tests/src/test/java/org/apache/flink/table/store/tests/HiveE2eTest.java
+++ b/flink-table-store-e2e-tests/src/test/java/org/apache/flink/table/store/tests/HiveE2eTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.store.tests;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.ContainerState;
 
@@ -33,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <p>NOTE: This test runs a complete Hadoop cluster in Docker, which requires a lot of memory. If
  * you're running this test locally, make sure that the memory limit of your Docker is at least 8GB.
  */
+@DisabledIfSystemProperty(named = "flink.version", matches = "1.14.*")
 public class HiveE2eTest extends E2eTestBase {
 
     private static final String TABLE_STORE_HIVE_CONNECTOR_JAR_NAME =

--- a/flink-table-store-e2e-tests/src/test/resources/flink.env
+++ b/flink-table-store-e2e-tests/src/test/resources/flink.env
@@ -16,4 +16,4 @@
 # limitations under the License.
 ################################################################################
 
-FLINK_PROPERTIES="jobmanager.rpc.address: jobmanager\ntaskmanager.numberOfTaskSlots: 9\nparallelism.default: 3\nsql-client.execution.result-mode: TABLEAU\nenv.java.opts.taskmanager: -verbose:gc"
+FLINK_PROPERTIES="jobmanager.rpc.address: jobmanager\ntaskmanager.numberOfTaskSlots: 9\nparallelism.default: 3\nsql-client.execution.result-mode: TABLEAU\nenv.java.opts.taskmanager: -verbose:gc\nexecution.checkpointing.checkpoints-after-tasks-finish.enabled: true"

--- a/pom.xml
+++ b/pom.xml
@@ -430,6 +430,7 @@ under the License.
                         <project.basedir>${project.basedir}</project.basedir>
                         <!--suppress MavenModelInspection -->
                         <test.randomization.seed>${test.randomization.seed}</test.randomization.seed>
+                        <flink.version>${flink.version}</flink.version>
                     </systemPropertyVariables>
                     <argLine>-Xms256m -Xmx2048m -Dmvn.forkNumber=${surefire.forkNumber} -XX:+UseG1GC</argLine>
                 </configuration>


### PR DESCRIPTION
- Get rid of `ManagedTableFactory`
- Use Kafka connector to replace filesystem connector, since for Flink 1.14, [File system sources for streaming is still under development. In the future, the community will add support for common streaming use cases, i.e., partition and directory monitoring](https://nightlies.apache.org/flink/flink-docs-release-1.14/docs/connectors/table/filesystem/)