### PR TITLE
[FLINK-29292] Make result of MergeFunction generic

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValue.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValue.java
@@ -45,11 +45,6 @@ public class KeyValue {
     private RowKind valueKind;
     private RowData value;
 
-    public KeyValue setValue(RowData value) {
-        this.value = value;
-        return this;
-    }
-
     public KeyValue replace(RowData key, RowKind valueKind, RowData value) {
         return replace(key, UNKNOWN_SEQUENCE, valueKind, value);
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValueFileStore.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValueFileStore.java
@@ -40,7 +40,7 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
     private final RowType keyType;
     private final RowType valueType;
     private final Supplier<Comparator<RowData>> keyComparatorSupplier;
-    private final MergeFunction mergeFunction;
+    private final MergeFunction<KeyValue> mergeFunction;
 
     public KeyValueFileStore(
             SchemaManager schemaManager,
@@ -50,7 +50,7 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
             RowType bucketKeyType,
             RowType keyType,
             RowType valueType,
-            MergeFunction mergeFunction) {
+            MergeFunction<KeyValue> mergeFunction) {
         super(schemaManager, schemaId, options, partitionType);
         this.bucketKeyType = bucketKeyType;
         this.keyType = keyType;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MemTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MemTable.java
@@ -56,7 +56,7 @@ public interface MemTable {
      * MergeFunction}.
      */
     Iterator<KeyValue> mergeIterator(
-            Comparator<RowData> keyComparator, MergeFunction mergeFunction);
+            Comparator<RowData> keyComparator, MergeFunction<KeyValue> mergeFunction);
 
     /** Removes all records from this table. The table will be empty after this call returns. */
     void clear();

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeReader.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeReader.java
@@ -48,7 +48,7 @@ public class MergeTreeReader implements RecordReader<KeyValue> {
             boolean dropDelete,
             KeyValueFileReaderFactory readerFactory,
             Comparator<RowData> userKeyComparator,
-            MergeFunction mergeFunction)
+            MergeFunction<KeyValue> mergeFunction)
             throws IOException {
         this.dropDelete = dropDelete;
 
@@ -113,7 +113,7 @@ public class MergeTreeReader implements RecordReader<KeyValue> {
             List<SortedRun> section,
             KeyValueFileReaderFactory readerFactory,
             Comparator<RowData> userKeyComparator,
-            MergeFunction mergeFunction)
+            MergeFunction<KeyValue> mergeFunction)
             throws IOException {
         List<RecordReader<KeyValue>> readers = new ArrayList<>();
         for (SortedRun run : section) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeWriter.java
@@ -55,7 +55,7 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
 
     private final Comparator<RowData> keyComparator;
 
-    private final MergeFunction mergeFunction;
+    private final MergeFunction<KeyValue> mergeFunction;
 
     private final KeyValueFileWriterFactory writerFactory;
 
@@ -77,7 +77,7 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
             CompactManager compactManager,
             long maxSequenceNumber,
             Comparator<RowData> keyComparator,
-            MergeFunction mergeFunction,
+            MergeFunction<KeyValue> mergeFunction,
             KeyValueFileWriterFactory writerFactory,
             boolean commitForceCompact,
             ChangelogProducer changelogProducer) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/DeduplicateMergeFunction.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/DeduplicateMergeFunction.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.store.file.mergetree.compact;
 
-import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.file.KeyValue;
 
 import javax.annotation.Nullable;
@@ -27,30 +26,30 @@ import javax.annotation.Nullable;
  * A {@link MergeFunction} where key is primary key (unique) and value is the full record, only keep
  * the latest one.
  */
-public class DeduplicateMergeFunction implements MergeFunction {
+public class DeduplicateMergeFunction implements MergeFunction<KeyValue> {
 
     private static final long serialVersionUID = 1L;
 
-    private RowData latestValue;
+    private transient KeyValue latestKv;
 
     @Override
     public void reset() {
-        latestValue = null;
+        latestKv = null;
     }
 
     @Override
     public void add(KeyValue kv) {
-        latestValue = kv.value();
+        latestKv = kv;
     }
 
     @Override
     @Nullable
-    public RowData getValue() {
-        return latestValue;
+    public KeyValue getResult() {
+        return latestKv;
     }
 
     @Override
-    public MergeFunction copy() {
+    public MergeFunction<KeyValue> copy() {
         return new DeduplicateMergeFunction();
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/MergeFunction.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/MergeFunction.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.store.file.mergetree.compact;
 
-import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.file.KeyValue;
 
 import javax.annotation.Nullable;
@@ -26,7 +25,7 @@ import javax.annotation.Nullable;
 import java.io.Serializable;
 
 /** Merge function to merge multiple {@link KeyValue}s. */
-public interface MergeFunction extends Serializable {
+public interface MergeFunction<T> extends Serializable {
 
     /** Reset the merge function to its default state. */
     void reset();
@@ -36,8 +35,8 @@ public interface MergeFunction extends Serializable {
 
     /** Get current merged value. Return null if this merged result should be skipped. */
     @Nullable
-    RowData getValue();
+    T getResult();
 
     /** Create a new merge function object with the same functionality as this one. */
-    MergeFunction copy();
+    MergeFunction<T> copy();
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/MergeFunctionHelper.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/MergeFunctionHelper.java
@@ -18,18 +18,17 @@
 
 package org.apache.flink.table.store.file.mergetree.compact;
 
-import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.file.KeyValue;
 
 /** Helper functions for the interaction with {@link MergeFunction}. */
 public class MergeFunctionHelper {
 
-    private final MergeFunction mergeFunction;
+    private final MergeFunction<KeyValue> mergeFunction;
 
     private KeyValue initialKV;
     private boolean isInitialized;
 
-    public MergeFunctionHelper(MergeFunction mergeFunction) {
+    public MergeFunctionHelper(MergeFunction<KeyValue> mergeFunction) {
         this.mergeFunction = mergeFunction;
     }
 
@@ -58,7 +57,7 @@ public class MergeFunctionHelper {
     }
 
     /** Get current value of the {@link MergeFunction} helper. */
-    public RowData getValue() {
-        return isInitialized ? mergeFunction.getValue() : initialKV.value();
+    public KeyValue getResult() {
+        return isInitialized ? mergeFunction.getResult() : initialKV;
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/PartialUpdateMergeFunction.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/PartialUpdateMergeFunction.java
@@ -26,6 +26,7 @@ import org.apache.flink.types.RowKind;
 import javax.annotation.Nullable;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A {@link MergeFunction} where key is primary key (unique) and value is the partial record, update
@@ -68,9 +69,9 @@ public class PartialUpdateMergeFunction implements MergeFunction<KeyValue> {
     @Override
     @Nullable
     public KeyValue getResult() {
-        if (latestKv == null) {
-            return null;
-        }
+        checkNotNull(
+                latestKv,
+                "Trying to get result from merge function without any input. This is unexpected.");
 
         if (reused == null) {
             reused = new KeyValue();

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/SortMergeReader.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/SortMergeReader.java
@@ -50,7 +50,7 @@ public class SortMergeReader implements RecordReader<KeyValue> {
     protected SortMergeReader(
             List<RecordReader<KeyValue>> readers,
             Comparator<RowData> userKeyComparator,
-            MergeFunction mergeFunction) {
+            MergeFunction<KeyValue> mergeFunction) {
         this.nextBatchReaders = new ArrayList<>(readers);
         this.userKeyComparator = userKeyComparator;
         this.mergeFunctionHelper = new MergeFunctionHelper(mergeFunction);
@@ -70,7 +70,7 @@ public class SortMergeReader implements RecordReader<KeyValue> {
     public static RecordReader<KeyValue> create(
             List<RecordReader<KeyValue>> readers,
             Comparator<RowData> userKeyComparator,
-            MergeFunction mergeFunction) {
+            MergeFunction<KeyValue> mergeFunction) {
         return readers.size() == 1
                 ? readers.get(0)
                 : new SortMergeReader(readers, userKeyComparator, mergeFunction);
@@ -130,9 +130,9 @@ public class SortMergeReader implements RecordReader<KeyValue> {
                 if (!hasMore) {
                     return null;
                 }
-                RowData mergedValue = mergeFunctionHelper.getValue();
-                if (mergedValue != null) {
-                    return polled.get(polled.size() - 1).kv.setValue(mergedValue);
+                KeyValue result = mergeFunctionHelper.getResult();
+                if (result != null) {
+                    return result;
                 }
             }
         }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/aggregate/AggregateMergeFunction.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/aggregate/AggregateMergeFunction.java
@@ -33,6 +33,7 @@ import java.util.List;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A {@link MergeFunction} where key is primary key (unique) and value is the partial record,
@@ -78,9 +79,9 @@ public class AggregateMergeFunction implements MergeFunction<KeyValue> {
     @Nullable
     @Override
     public KeyValue getResult() {
-        if (latestKv == null) {
-            return null;
-        }
+        checkNotNull(
+                latestKv,
+                "Trying to get result from merge function without any input. This is unexpected.");
 
         if (reused == null) {
             reused = new KeyValue();

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/aggregate/AggregateMergeFunction.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/aggregate/AggregateMergeFunction.java
@@ -38,15 +38,16 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  * A {@link MergeFunction} where key is primary key (unique) and value is the partial record,
  * pre-aggregate non-null fields on merge.
  */
-public class AggregateMergeFunction implements MergeFunction {
+public class AggregateMergeFunction implements MergeFunction<KeyValue> {
 
     private static final long serialVersionUID = 1L;
 
     private final RowData.FieldGetter[] getters;
-
     private final RowAggregator rowAggregator;
 
+    private transient KeyValue latestKv;
     private transient GenericRowData row;
+    private transient KeyValue reused;
 
     public AggregateMergeFunction(RowData.FieldGetter[] getters, RowAggregator rowAggregator) {
         this.getters = getters;
@@ -55,6 +56,7 @@ public class AggregateMergeFunction implements MergeFunction {
 
     @Override
     public void reset() {
+        this.latestKv = null;
         this.row = new GenericRowData(getters.length);
     }
 
@@ -63,6 +65,7 @@ public class AggregateMergeFunction implements MergeFunction {
         checkArgument(
                 kv.valueKind() == RowKind.INSERT || kv.valueKind() == RowKind.UPDATE_AFTER,
                 "Pre-aggregate can not accept delete records!");
+        latestKv = kv;
         for (int i = 0; i < getters.length; i++) {
             FieldAggregator fieldAggregator = rowAggregator.getFieldAggregatorAtPos(i);
             Object accumulator = getters[i].getFieldOrNull(row);
@@ -74,12 +77,19 @@ public class AggregateMergeFunction implements MergeFunction {
 
     @Nullable
     @Override
-    public RowData getValue() {
-        return row;
+    public KeyValue getResult() {
+        if (latestKv == null) {
+            return null;
+        }
+
+        if (reused == null) {
+            reused = new KeyValue();
+        }
+        return reused.replace(latestKv.key(), latestKv.sequenceNumber(), RowKind.INSERT, row);
     }
 
     @Override
-    public MergeFunction copy() {
+    public MergeFunction<KeyValue> copy() {
         // RowData.FieldGetter is thread safe
         return new AggregateMergeFunction(getters, rowAggregator);
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreRead.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreRead.java
@@ -60,7 +60,7 @@ public class KeyValueFileStoreRead implements FileStoreRead<KeyValue> {
     private final TableSchema tableSchema;
     private final KeyValueFileReaderFactory.Builder readerFactoryBuilder;
     private final Comparator<RowData> keyComparator;
-    private final MergeFunction mergeFunction;
+    private final MergeFunction<KeyValue> mergeFunction;
     private final boolean valueCountMode;
 
     @Nullable private int[][] keyProjectedFields;
@@ -75,7 +75,7 @@ public class KeyValueFileStoreRead implements FileStoreRead<KeyValue> {
             RowType keyType,
             RowType valueType,
             Comparator<RowData> keyComparator,
-            MergeFunction mergeFunction,
+            MergeFunction<KeyValue> mergeFunction,
             FileFormat fileFormat,
             FileStorePathFactory pathFactory) {
         this.tableSchema = schemaManager.schema(schemaId);
@@ -153,7 +153,7 @@ public class KeyValueFileStoreRead implements FileStoreRead<KeyValue> {
 
     private List<ConcatRecordReader.ReaderSupplier<KeyValue>> createSectionReaders(Split split) {
         List<ConcatRecordReader.ReaderSupplier<KeyValue>> sectionReaders = new ArrayList<>();
-        MergeFunction mergeFunc = mergeFunction.copy();
+        MergeFunction<KeyValue> mergeFunc = mergeFunction.copy();
         for (List<SortedRun> section :
                 new IntervalPartition(split.files(), keyComparator).partition()) {
             KeyValueFileReaderFactory readerFactory =

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreWrite.java
@@ -63,7 +63,7 @@ public class KeyValueFileStoreWrite extends AbstractFileStoreWrite<KeyValue> {
     private final KeyValueFileReaderFactory.Builder readerFactoryBuilder;
     private final KeyValueFileWriterFactory.Builder writerFactoryBuilder;
     private final Supplier<Comparator<RowData>> keyComparatorSupplier;
-    private final MergeFunction mergeFunction;
+    private final MergeFunction<KeyValue> mergeFunction;
     private final CoreOptions options;
 
     public KeyValueFileStoreWrite(
@@ -72,7 +72,7 @@ public class KeyValueFileStoreWrite extends AbstractFileStoreWrite<KeyValue> {
             RowType keyType,
             RowType valueType,
             Supplier<Comparator<RowData>> keyComparatorSupplier,
-            MergeFunction mergeFunction,
+            MergeFunction<KeyValue> mergeFunction,
             FileStorePathFactory pathFactory,
             SnapshotManager snapshotManager,
             FileStoreScan scan,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTable.java
@@ -62,7 +62,7 @@ public class ChangelogValueCountFileStoreTable extends AbstractFileStoreTable {
         RowType countType =
                 RowType.of(
                         new LogicalType[] {new BigIntType(false)}, new String[] {"_VALUE_COUNT"});
-        MergeFunction mergeFunction = new ValueCountMergeFunction();
+        MergeFunction<KeyValue> mergeFunction = new ValueCountMergeFunction();
         this.store =
                 new KeyValueFileStore(
                         schemaManager,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
@@ -70,6 +70,7 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
     ChangelogWithKeyFileStoreTable(
             Path path, SchemaManager schemaManager, TableSchema tableSchema) {
         super(path, tableSchema);
+
         RowType rowType = tableSchema.logicalRowType();
         Configuration conf = Configuration.fromMap(tableSchema.options());
         CoreOptions.MergeEngine mergeEngine = conf.get(CoreOptions.MERGE_ENGINE);
@@ -78,7 +79,8 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
         for (int i = 0; i < fieldTypes.size(); i++) {
             fieldGetters[i] = RowDataUtils.createNullCheckingFieldGetter(fieldTypes.get(i), i);
         }
-        MergeFunction mergeFunction;
+
+        MergeFunction<KeyValue> mergeFunction;
         switch (mergeEngine) {
             case DEDUPLICATE:
                 mergeFunction = new DeduplicateMergeFunction();

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -92,7 +92,7 @@ public class TestFileStore extends KeyValueFileStore {
             RowType partitionType,
             RowType keyType,
             RowType valueType,
-            MergeFunction mergeFunction) {
+            MergeFunction<KeyValue> mergeFunction) {
         Configuration conf = new Configuration();
 
         conf.set(CoreOptions.WRITE_BUFFER_SIZE, WRITE_BUFFER_SIZE);
@@ -118,7 +118,7 @@ public class TestFileStore extends KeyValueFileStore {
             RowType partitionType,
             RowType keyType,
             RowType valueType,
-            MergeFunction mergeFunction) {
+            MergeFunction<KeyValue> mergeFunction) {
         super(
                 new SchemaManager(options.path()),
                 0L,

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/SortBufferMemTableTestBase.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/SortBufferMemTableTestBase.java
@@ -61,7 +61,7 @@ public abstract class SortBufferMemTableTestBase {
 
     protected abstract List<ReusingTestData> getExpected(List<ReusingTestData> input);
 
-    protected abstract MergeFunction createMergeFunction();
+    protected abstract MergeFunction<KeyValue> createMergeFunction();
 
     @Test
     public void testAndClear() throws IOException {
@@ -147,7 +147,7 @@ public abstract class SortBufferMemTableTestBase {
         }
 
         @Override
-        protected MergeFunction createMergeFunction() {
+        protected MergeFunction<KeyValue> createMergeFunction() {
             return new DeduplicateMergeFunction();
         }
     }
@@ -166,7 +166,7 @@ public abstract class SortBufferMemTableTestBase {
         }
 
         @Override
-        protected MergeFunction createMergeFunction() {
+        protected MergeFunction<KeyValue> createMergeFunction() {
             return new ValueCountMergeFunction();
         }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/SortMergeReaderTestBase.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/SortMergeReaderTestBase.java
@@ -32,7 +32,7 @@ import java.util.List;
 /** Tests for {@link SortMergeReader}. */
 public abstract class SortMergeReaderTestBase extends CombiningRecordReaderTestBase {
 
-    protected abstract MergeFunction createMergeFunction();
+    protected abstract MergeFunction<KeyValue> createMergeFunction();
 
     @Override
     protected RecordReader<KeyValue> createRecordReader(List<TestReusingRecordReader> readers) {
@@ -85,7 +85,7 @@ public abstract class SortMergeReaderTestBase extends CombiningRecordReaderTestB
         }
 
         @Override
-        protected MergeFunction createMergeFunction() {
+        protected MergeFunction<KeyValue> createMergeFunction() {
             return new DeduplicateMergeFunction();
         }
     }
@@ -104,7 +104,7 @@ public abstract class SortMergeReaderTestBase extends CombiningRecordReaderTestB
         }
 
         @Override
-        protected MergeFunction createMergeFunction() {
+        protected MergeFunction<KeyValue> createMergeFunction() {
             return new ValueCountMergeFunction();
         }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreReadTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreReadTest.java
@@ -227,7 +227,10 @@ public class KeyValueFileStoreReadTest {
     }
 
     private TestFileStore createStore(
-            RowType partitionType, RowType keyType, RowType valueType, MergeFunction mergeFunction)
+            RowType partitionType,
+            RowType keyType,
+            RowType valueType,
+            MergeFunction<KeyValue> mergeFunction)
             throws Exception {
         SchemaManager schemaManager = new SchemaManager(new Path(tempDir.toUri()));
         boolean valueCountMode = mergeFunction instanceof ValueCountMergeFunction;


### PR DESCRIPTION
`MergeFunction` of full compaction need to produce changelogs instead of single `KeyValue`. We need to modify MergeFunction into a generic class.