### PR TITLE
[FLINK-29345] Create reusing reader/writer config in orc format

### DIFF
--- a/flink-table-store-format/src/test/java/org/apache/flink/table/store/format/orc/OrcFileFormatTest.java
+++ b/flink-table-store-format/src/test/java/org/apache/flink/table/store/format/orc/OrcFileFormatTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.Configuration;
 
 import org.junit.jupiter.api.Test;
 
+import static org.apache.flink.table.store.format.orc.OrcFileFormatFactory.IDENTIFIER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link OrcFileFormatFactory}. */
@@ -32,8 +33,8 @@ public class OrcFileFormatTest {
         Configuration options = new Configuration();
         options.setString("haha", "1");
         OrcFileFormat orc = new OrcFileFormatFactory().create(options);
-        assertThat(orc.formatOptions().getString("haha", "")).isEqualTo("1");
-        assertThat(orc.formatOptions().getString("compress", "")).isEqualTo("lz4");
+        assertThat(orc.orcProperties().getProperty(IDENTIFIER + ".haha", "")).isEqualTo("1");
+        assertThat(orc.orcProperties().getProperty(IDENTIFIER + ".compress", "")).isEqualTo("lz4");
     }
 
     @Test
@@ -42,7 +43,7 @@ public class OrcFileFormatTest {
         options.setString("haha", "1");
         options.setString("compress", "zlib");
         OrcFileFormat orc = new OrcFileFormatFactory().create(options);
-        assertThat(orc.formatOptions().getString("haha", "")).isEqualTo("1");
-        assertThat(orc.formatOptions().getString("compress", "")).isEqualTo("zlib");
+        assertThat(orc.orcProperties().getProperty(IDENTIFIER + ".haha", "")).isEqualTo("1");
+        assertThat(orc.orcProperties().getProperty(IDENTIFIER + ".compress", "")).isEqualTo("zlib");
     }
 }


### PR DESCRIPTION
Currently OrcFileFormat will create new org.apache.hadoop.conf.Configuration instance in methods createReaderFactory and createWriterFactory. The initialization of org.apache.hadoop.conf.Configuration tries to load local file core-site.xml.

This PR will initialize the writerConf and readerConf of org.apache.hadoop.conf.Configuration and reuse them in createReaderFactory and createWriterFactory.