### PR TITLE
[FLINK-29554] Add partial-update.ignore-delete option to avoid exception after join

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -171,6 +171,12 @@
             <td>Memory page size.</td>
         </tr>
         <tr>
+            <td><h5>partial-update.ignore-delete</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to ignore delete/update_before records in partial-update mode.</td>
+        </tr>
+        <tr>
             <td><h5>partition.default-name</h5></td>
             <td style="word-wrap: break-word;">"__DEFAULT_PARTITION__"</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -174,7 +174,7 @@
             <td><h5>partial-update.ignore-delete</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Whether to ignore delete/update_before records in partial-update mode.</td>
+            <td>Whether to ignore delete records in partial-update mode.</td>
         </tr>
         <tr>
             <td><h5>partition.default-name</h5></td>

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
@@ -149,6 +149,13 @@ public class CoreOptions implements Serializable {
                     .defaultValue(MergeEngine.DEDUPLICATE)
                     .withDescription("Specify the merge engine for table with primary key.");
 
+    public static final ConfigOption<Boolean> PARTIAL_UPDATE_IGNORE_DELETE =
+            ConfigOptions.key("partial-update.ignore-delete")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to ignore delete/update_before records in partial-update mode.");
+
     @Immutable
     public static final ConfigOption<WriteMode> WRITE_MODE =
             ConfigOptions.key("write-mode")

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
@@ -153,8 +153,7 @@ public class CoreOptions implements Serializable {
             ConfigOptions.key("partial-update.ignore-delete")
                     .booleanType()
                     .defaultValue(false)
-                    .withDescription(
-                            "Whether to ignore delete/update_before records in partial-update mode.");
+                    .withDescription("Whether to ignore delete records in partial-update mode.");
 
     @Immutable
     public static final ConfigOption<WriteMode> WRITE_MODE =

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/PartialUpdateMergeFunction.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/PartialUpdateMergeFunction.java
@@ -25,9 +25,6 @@ import org.apache.flink.types.RowKind;
 
 import javax.annotation.Nullable;
 
-import static org.apache.flink.util.Preconditions.checkArgument;
-import static org.apache.flink.util.Preconditions.checkNotNull;
-
 /**
  * A {@link MergeFunction} where key is primary key (unique) and value is the partial record, update
  * non-null fields on merge.
@@ -37,13 +34,15 @@ public class PartialUpdateMergeFunction implements MergeFunction<KeyValue> {
     private static final long serialVersionUID = 1L;
 
     private final RowData.FieldGetter[] getters;
+    private final boolean ignoreDelete;
 
     private transient KeyValue latestKv;
     private transient GenericRowData row;
     private transient KeyValue reused;
 
-    public PartialUpdateMergeFunction(RowData.FieldGetter[] getters) {
+    public PartialUpdateMergeFunction(RowData.FieldGetter[] getters, boolean ignoreDelete) {
         this.getters = getters;
+        this.ignoreDelete = ignoreDelete;
     }
 
     @Override
@@ -54,9 +53,15 @@ public class PartialUpdateMergeFunction implements MergeFunction<KeyValue> {
 
     @Override
     public void add(KeyValue kv) {
-        checkArgument(
-                kv.valueKind() == RowKind.INSERT || kv.valueKind() == RowKind.UPDATE_AFTER,
-                "Partial update can not accept delete records. Partial delete is not supported!");
+        if (kv.valueKind() == RowKind.UPDATE_BEFORE || kv.valueKind() == RowKind.DELETE) {
+            if (ignoreDelete) {
+                return;
+            }
+
+            throw new IllegalArgumentException(
+                    "Partial update can not accept delete records. Partial delete is not supported!");
+        }
+
         latestKv = kv;
         for (int i = 0; i < getters.length; i++) {
             Object field = getters[i].getFieldOrNull(kv.value());
@@ -69,9 +74,14 @@ public class PartialUpdateMergeFunction implements MergeFunction<KeyValue> {
     @Override
     @Nullable
     public KeyValue getResult() {
-        checkNotNull(
-                latestKv,
-                "Trying to get result from merge function without any input. This is unexpected.");
+        if (latestKv == null) {
+            if (ignoreDelete) {
+                return null;
+            }
+
+            throw new IllegalArgumentException(
+                    "Trying to get result from merge function without any input. This is unexpected.");
+        }
 
         if (reused == null) {
             reused = new KeyValue();
@@ -82,6 +92,6 @@ public class PartialUpdateMergeFunction implements MergeFunction<KeyValue> {
     @Override
     public MergeFunction<KeyValue> copy() {
         // RowData.FieldGetter is thread safe
-        return new PartialUpdateMergeFunction(getters);
+        return new PartialUpdateMergeFunction(getters, ignoreDelete);
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/PartialUpdateMergeFunction.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/PartialUpdateMergeFunction.java
@@ -58,6 +58,11 @@ public class PartialUpdateMergeFunction implements MergeFunction<KeyValue> {
                 return;
             }
 
+            if (kv.valueKind() == RowKind.UPDATE_BEFORE) {
+                throw new IllegalArgumentException(
+                        "Partial update can not accept update_before records, it is a bug.");
+            }
+
             throw new IllegalArgumentException(
                     "Partial update can not accept delete records. Partial delete is not supported!");
         }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
@@ -86,7 +86,8 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
                 mergeFunction = new DeduplicateMergeFunction();
                 break;
             case PARTIAL_UPDATE:
-                mergeFunction = new PartialUpdateMergeFunction(fieldGetters);
+                boolean ignoreDelete = conf.get(CoreOptions.PARTIAL_UPDATE_IGNORE_DELETE);
+                mergeFunction = new PartialUpdateMergeFunction(fieldGetters, ignoreDelete);
                 break;
             case AGGREGATE:
                 List<String> fieldNames = tableSchema.fieldNames();


### PR DESCRIPTION
When the partial update input is a normal database cdc input, it can work normally as long as there is no delete data.

However, if a join is performed previously, the join node in flink job will generate delete messages, which will cause the partial update insertion to throw an exception.

We can add an option to decide whether to ignore the delete message in this case.