### PR TITLE
[FLINK-27958] Compare batch maxKey to reduce comparisons in SortMergeReader

### DIFF
--- a/flink-table-store-benchmark/flink-table-store-micro-benchmarks/src/main/java/org/apache/flink/table/store/benchmark/config/FileBenchmarkOptions.java
+++ b/flink-table-store-benchmark/flink-table-store-micro-benchmarks/src/main/java/org/apache/flink/table/store/benchmark/config/FileBenchmarkOptions.java
@@ -39,12 +39,12 @@ public class FileBenchmarkOptions {
     public static final ConfigOption<Integer> WRITER_BATCH_COUNT =
             key("benchmark.writer.batch-count")
                     .intType()
-                    .defaultValue(50)
+                    .defaultValue(5000)
                     .withDescription("The number of batches to be written by writer.");
 
     public static final ConfigOption<Integer> WRITER_RECORD_COUNT_PER_BATCH =
             key("benchmark.writer.record-count-per-batch")
                     .intType()
-                    .defaultValue(50000)
+                    .defaultValue(500)
                     .withDescription("The number of records to be written in one batch by writer.");
 }

--- a/flink-table-store-benchmark/flink-table-store-micro-benchmarks/src/main/java/org/apache/flink/table/store/benchmark/file/mergetree/MergeTreeReaderBenchmark.java
+++ b/flink-table-store-benchmark/flink-table-store-micro-benchmarks/src/main/java/org/apache/flink/table/store/benchmark/file/mergetree/MergeTreeReaderBenchmark.java
@@ -75,7 +75,7 @@ public class MergeTreeReaderBenchmark extends MergeTreeBenchmark {
                     writer.write(kv);
                 }
 
-                RecordWriter.CommitIncrement increment = writer.prepareCommit(false);
+                RecordWriter.CommitIncrement increment = writer.prepareCommit(true);
                 mergeCompacted(newFileNames, compactedFiles, increment);
             }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/ConcatRecordReader.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/ConcatRecordReader.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.store.file.mergetree.compact;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.table.store.file.utils.RecordReader;
 import org.apache.flink.util.Preconditions;
 
@@ -74,6 +75,11 @@ public class ConcatRecordReader<T> implements RecordReader<T> {
         if (current != null) {
             current.close();
         }
+    }
+
+    @VisibleForTesting
+    public int getReaderCount() {
+        return queue.size();
     }
 
     /** Supplier to get {@link RecordReader}. */

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/region/RecordReaderRegion.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/region/RecordReaderRegion.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.mergetree.region;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.file.mergetree.SortedRun;
+import org.apache.flink.table.store.file.utils.RecordReader;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Record reader region manages {@link RecordReaderSubRegion} list, and each subregion is
+ * constructed according to {@link SortedRun}. {@link SortedRegionDataRecordReader}s with
+ * intersected key ranges in subregions must go to the same region, for example, there are two
+ * subregions and each one has two {@link SortedRegionDataRecordReader} as follows
+ *
+ * <ul>
+ *   <li>subregion1: reader11 with key range [1,100], reader12 with key range [200, 300]
+ *   <li>subregion2: reader21 with key range [50, 250], reader 22 with key range [280, 400]
+ * </ul>
+ *
+ * <p>reader11 and reader21, reader21 and reader12, reader12 and reader22 have intersected key
+ * ranges.
+ */
+public class RecordReaderRegion<T> {
+    private final List<RecordReaderSubRegion<T>> readers;
+    private final Comparator<RowData> keyComparator;
+    private RowData minKey;
+    private RowData maxKey;
+
+    public RecordReaderRegion(Comparator<RowData> keyComparator, int count) {
+        this.keyComparator = keyComparator;
+        this.readers = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            this.readers.add(new RecordReaderSubRegion<>(i, new ArrayList<>()));
+        }
+    }
+
+    public RowData getMinKey() {
+        return minKey;
+    }
+
+    public RowData getMaxKey() {
+        return maxKey;
+    }
+
+    public boolean mergeReader(SortedRegionDataRecordReader<T> reader, int index) {
+        checkState(
+                index < readers.size(),
+                "The index[%s] of merged reader must be < the readers count[%s]",
+                index,
+                readers.size());
+        if (minKey == null && maxKey == null) {
+            minKey = reader.getMinKey();
+            maxKey = reader.getMaxKey();
+            readers.get(index).add(reader);
+            return true;
+        }
+
+        checkState(minKey != null, "minKey is null");
+        checkState(maxKey != null, "maxKey is null");
+        // Each SortedDataFileRecordReader in SortedRun will be sorted by key, so the new reader
+        // minKey must >= the one in the region
+        checkState(
+                keyComparator.compare(minKey, reader.getMinKey()) <= 0,
+                "The added minKey in reader must be equal or larger than the minKey in region");
+        if (keyComparator.compare(maxKey, reader.getMinKey()) >= 0) {
+            readers.get(index).add(reader);
+            if (keyComparator.compare(maxKey, reader.getMaxKey()) < 0) {
+                maxKey = reader.getMaxKey();
+            }
+            return true;
+        }
+
+        return false;
+    }
+
+    public boolean isEmpty() {
+        if (readers.isEmpty()) {
+            return true;
+        }
+
+        for (RecordReaderSubRegion<T> reader : readers) {
+            if (!reader.isEmpty()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @VisibleForTesting
+    RecordReaderSubRegion<T> getReader(int index) {
+        return readers.get(index);
+    }
+
+    public List<RecordReader<T>> getReaders() throws IOException {
+        List<RecordReader<T>> readerList = new ArrayList<>();
+        for (RecordReaderSubRegion<T> recordReaderSubRegion : readers) {
+            if (!recordReaderSubRegion.isEmpty()) {
+                readerList.add(recordReaderSubRegion.getReader());
+            }
+        }
+        return readerList;
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/region/RecordReaderRegionManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/region/RecordReaderRegionManager.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.mergetree.region;
+
+import org.apache.flink.table.data.RowData;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Record region manager will divide {@link RecordReaderSubRegion} into multiple {@link
+ * RecordReaderRegion}s, {@link SortedRegionDataRecordReader}s in {@link RecordReaderSubRegion} with
+ * intersected key ranges in subregions must go to the same region.
+ */
+public class RecordReaderRegionManager<T> {
+    private final List<RecordReaderSubRegion<T>> sortedReaders;
+    private final Comparator<RowData> keyComparator;
+
+    public RecordReaderRegionManager(
+            List<RecordReaderSubRegion<T>> sortedReaders, Comparator<RowData> keyComparator) {
+        this.sortedReaders = sortedReaders;
+        this.keyComparator = keyComparator;
+    }
+
+    public List<RecordReaderRegion<T>> getRegionList() {
+        List<RecordReaderRegion<T>> regionList = new ArrayList<>();
+        RecordReaderRegion<T> current =
+                new RecordReaderRegion<>(keyComparator, sortedReaders.size());
+        while (!isEmpty()) {
+            // find the minimum minKey
+            SortedRegionDataRecordReader<T> minKeyReader = null;
+            int index = -1;
+            for (RecordReaderSubRegion<T> reader : sortedReaders) {
+                if (!reader.isEmpty()) {
+                    SortedRegionDataRecordReader<T> minIndexReader = reader.peek();
+                    if (minKeyReader == null
+                            || keyComparator.compare(
+                                            minKeyReader.getMinKey(), minIndexReader.getMinKey())
+                                    > 0) {
+                        minKeyReader = minIndexReader;
+                        index = reader.getIndex();
+                    }
+                }
+            }
+            if (minKeyReader == null) {
+                break;
+            }
+            sortedReaders.get(index).remove();
+            if (!current.mergeReader(minKeyReader, index)) {
+                checkState(!current.isEmpty(), "Current region can't be empty");
+                regionList.add(current);
+                current = new RecordReaderRegion<>(keyComparator, sortedReaders.size());
+                checkState(current.mergeReader(minKeyReader, index));
+            }
+        }
+        if (!current.isEmpty()) {
+            regionList.add(current);
+        }
+
+        return regionList;
+    }
+
+    private boolean isEmpty() {
+        for (RecordReaderSubRegion<T> indexReader : sortedReaders) {
+            if (!indexReader.isEmpty()) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/region/RecordReaderSubRegion.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/region/RecordReaderSubRegion.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.mergetree.region;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.table.store.file.mergetree.SortedRun;
+import org.apache.flink.table.store.file.mergetree.compact.ConcatRecordReader;
+import org.apache.flink.table.store.file.utils.RecordReader;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * {@link RecordReaderSubRegion} will first be created from {@link SortedRun} in which the
+ * sortedReaders are according to the data files in {@link SortedRun}. Then the {@link
+ * RecordReaderRegionManager} will divide {@link RecordReaderSubRegion} list into multiple {@link
+ * RecordReaderRegion}. Each {@link RecordReaderRegion} includes {@link RecordReaderSubRegion} list.
+ *
+ * @param <T> the record type of the reader
+ */
+public class RecordReaderSubRegion<T> {
+    private final int index;
+    // The readers is created from data files in {@code SortedRun}, so it has been sorted by key.
+    private final List<SortedRegionDataRecordReader<T>> sortedReaders;
+
+    public RecordReaderSubRegion(int index, List<SortedRegionDataRecordReader<T>> sortedReaders) {
+        this.index = index;
+        this.sortedReaders = sortedReaders;
+    }
+
+    public boolean isEmpty() {
+        return sortedReaders.isEmpty();
+    }
+
+    public SortedRegionDataRecordReader<T> peek() {
+        return sortedReaders.get(0);
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public void remove() {
+        sortedReaders.remove(0);
+    }
+
+    public void add(SortedRegionDataRecordReader<T> reader) {
+        sortedReaders.add(reader);
+    }
+
+    public RecordReader<T> getReader() throws IOException {
+        if (sortedReaders.size() == 1) {
+            return sortedReaders.get(0).getReader().get();
+        } else {
+            return ConcatRecordReader.create(
+                    sortedReaders.stream()
+                            .map(SortedRegionDataRecordReader::getReader)
+                            .collect(Collectors.toList()));
+        }
+    }
+
+    @VisibleForTesting
+    List<SortedRegionDataRecordReader<T>> getSortedReaders() {
+        return sortedReaders;
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/region/SortedRegionDataRecordReader.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/region/SortedRegionDataRecordReader.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.mergetree.region;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.file.mergetree.compact.ConcatRecordReader;
+
+/**
+ * Sorted data file record reader with key range.
+ *
+ * @param <T> the record type
+ */
+public class SortedRegionDataRecordReader<T> {
+    private final ConcatRecordReader.ReaderSupplier<T> reader;
+
+    private final RowData minKey;
+    private final RowData maxKey;
+
+    public SortedRegionDataRecordReader(
+            ConcatRecordReader.ReaderSupplier<T> reader, RowData minKey, RowData maxKey) {
+        this.reader = reader;
+        this.minKey = minKey;
+        this.maxKey = maxKey;
+    }
+
+    public ConcatRecordReader.ReaderSupplier<T> getReader() {
+        return reader;
+    }
+
+    public RowData getMinKey() {
+        return minKey;
+    }
+
+    public RowData getMaxKey() {
+        return maxKey;
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/region/RecordReaderRegionManagerTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/region/RecordReaderRegionManagerTest.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.mergetree.region;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.file.KeyValue;
+import org.apache.flink.table.store.file.mergetree.compact.ConcatRecordReader;
+import org.apache.flink.table.store.file.utils.RecordReader;
+import org.apache.flink.table.store.file.utils.TestReusingRecordReader;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Test cases for {@link RecordReaderRegionManager}. */
+public class RecordReaderRegionManagerTest {
+    /**
+     * Split two subregion list to multiple regions. In this test case we build two subregion as
+     * follows:
+     *
+     * <ul>
+     *   <li>subregion1 with key ranges: [1, 2] [3, 4] [5, 180] [5, 190] [200, 600] [610, 700]
+     *   <li>subregion2 with key ranges: [4, 10] [20, 30] [20, 190] [195, 500] [200, 605]
+     * </ul>
+     *
+     * <p>All readers in the subregions will be divided into four regions:
+     *
+     * <ul>
+     *   <li>region1: subregion1 with key ranges [1, 2]
+     *   <li>region2: subregion1 with key ranges [3, 4] [5, 180] [5, 190], subregion2 with key
+     *       ranges [4, 10] [20, 30] [20, 190]
+     *   <li>region3: subregion1 with key ranges [200, 600], subregion2 with key ranges [195, 500]
+     *       [200 605]
+     *   <li>region4: subregion1 with key ranges [610, 700]
+     * </ul>
+     */
+    @Test
+    public void testSplitReaderRegions() throws Exception {
+        RecordReaderSubRegion<KeyValue> subRegion1 =
+                new RecordReaderSubRegion<>(
+                        0,
+                        new ArrayList<>(
+                                Arrays.asList(
+                                        new SortedRegionDataRecordReader<>(
+                                                () ->
+                                                        new TestReusingRecordReader(
+                                                                new ArrayList<>()),
+                                                generateKey(1),
+                                                generateKey(2)),
+                                        new SortedRegionDataRecordReader<>(
+                                                () ->
+                                                        new TestReusingRecordReader(
+                                                                new ArrayList<>()),
+                                                generateKey(3),
+                                                generateKey(4)),
+                                        new SortedRegionDataRecordReader<>(
+                                                () ->
+                                                        new TestReusingRecordReader(
+                                                                new ArrayList<>()),
+                                                generateKey(5),
+                                                generateKey(180)),
+                                        new SortedRegionDataRecordReader<>(
+                                                () ->
+                                                        new TestReusingRecordReader(
+                                                                new ArrayList<>()),
+                                                generateKey(5),
+                                                generateKey(190)),
+                                        new SortedRegionDataRecordReader<>(
+                                                () ->
+                                                        new TestReusingRecordReader(
+                                                                new ArrayList<>()),
+                                                generateKey(200),
+                                                generateKey(600)),
+                                        new SortedRegionDataRecordReader<>(
+                                                () ->
+                                                        new TestReusingRecordReader(
+                                                                new ArrayList<>()),
+                                                generateKey(610),
+                                                generateKey(700)))));
+        RecordReaderSubRegion<KeyValue> subRegion2 =
+                new RecordReaderSubRegion<>(
+                        1,
+                        new ArrayList<>(
+                                Arrays.asList(
+                                        new SortedRegionDataRecordReader<>(
+                                                () ->
+                                                        new TestReusingRecordReader(
+                                                                new ArrayList<>()),
+                                                generateKey(4),
+                                                generateKey(10)),
+                                        new SortedRegionDataRecordReader<>(
+                                                () ->
+                                                        new TestReusingRecordReader(
+                                                                new ArrayList<>()),
+                                                generateKey(20),
+                                                generateKey(30)),
+                                        new SortedRegionDataRecordReader<>(
+                                                () ->
+                                                        new TestReusingRecordReader(
+                                                                new ArrayList<>()),
+                                                generateKey(20),
+                                                generateKey(190)),
+                                        new SortedRegionDataRecordReader<>(
+                                                () ->
+                                                        new TestReusingRecordReader(
+                                                                new ArrayList<>()),
+                                                generateKey(195),
+                                                generateKey(500)),
+                                        new SortedRegionDataRecordReader<>(
+                                                () ->
+                                                        new TestReusingRecordReader(
+                                                                new ArrayList<>()),
+                                                generateKey(200),
+                                                generateKey(605)))));
+
+        Comparator<RowData> keyComparator = Comparator.comparingInt(o -> o.getInt(0));
+        RecordReaderRegionManager<KeyValue> regionManager =
+                new RecordReaderRegionManager<>(
+                        Arrays.asList(subRegion1, subRegion2), keyComparator);
+
+        List<RecordReaderRegion<KeyValue>> regionList = regionManager.getRegionList();
+        // Check region count
+        assertEquals(4, regionList.size());
+
+        // Validate key ranges in region1
+        RecordReaderRegion<KeyValue> region1 = regionList.get(0);
+        List<RecordReader<KeyValue>> region1Readers = region1.getReaders();
+        assertEquals(1, region1Readers.size());
+        assertEquals(1, region1.getReader(0).getSortedReaders().size());
+        validateSortedReaderKeyRange(
+                region1.getReader(0).getSortedReaders().get(0), 1, 2, keyComparator);
+
+        // Validate key ranges in region2
+        RecordReaderRegion<KeyValue> region2 = regionList.get(1);
+        List<RecordReader<KeyValue>> region2Readers = region2.getReaders();
+        assertEquals(2, region2Readers.size());
+
+        RecordReaderSubRegion<KeyValue> region2SubRegion0 = region2.getReader(0);
+        assertEquals(3, ((ConcatRecordReader<KeyValue>) region2Readers.get(0)).getReaderCount());
+        validateSortedReaderKeyRange(
+                region2SubRegion0.getSortedReaders().get(0), 3, 4, keyComparator);
+        validateSortedReaderKeyRange(
+                region2SubRegion0.getSortedReaders().get(1), 5, 180, keyComparator);
+        validateSortedReaderKeyRange(
+                region2SubRegion0.getSortedReaders().get(2), 5, 190, keyComparator);
+
+        RecordReaderSubRegion<KeyValue> region2SubRegion1 = region2.getReader(1);
+        assertEquals(3, ((ConcatRecordReader<KeyValue>) region2Readers.get(0)).getReaderCount());
+        validateSortedReaderKeyRange(
+                region2SubRegion1.getSortedReaders().get(0), 4, 10, keyComparator);
+        validateSortedReaderKeyRange(
+                region2SubRegion1.getSortedReaders().get(1), 20, 30, keyComparator);
+        validateSortedReaderKeyRange(
+                region2SubRegion1.getSortedReaders().get(2), 20, 190, keyComparator);
+    }
+
+    private void validateSortedReaderKeyRange(
+            SortedRegionDataRecordReader<KeyValue> sortedReader,
+            int minKey,
+            int maxKey,
+            Comparator<RowData> keyComparator) {
+        assertEquals(0, keyComparator.compare(generateKey(minKey), sortedReader.getMinKey()));
+        assertEquals(0, keyComparator.compare(generateKey(maxKey), sortedReader.getMaxKey()));
+    }
+
+    private RowData generateKey(int value) {
+        GenericRowData data = new GenericRowData(1);
+        data.setField(0, value);
+        return data;
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/region/RecordReaderRegionTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/region/RecordReaderRegionTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.mergetree.region;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.file.KeyValue;
+import org.apache.flink.table.store.file.utils.TestReusingRecordReader;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Test cases for {@link RecordReaderRegion}. */
+public class RecordReaderRegionTest {
+    @Test
+    public void testIndexExceedCount() {
+        final int count = 2;
+
+        RecordReaderRegion<KeyValue> region =
+                new RecordReaderRegion<>(Comparator.comparingInt(o -> o.getInt(0)), count);
+        TestReusingRecordReader reader = new TestReusingRecordReader(new ArrayList<>());
+        assertThatThrownBy(
+                        () ->
+                                region.mergeReader(
+                                        new SortedRegionDataRecordReader<>(
+                                                () -> reader, null, null),
+                                        count))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage(
+                        String.format(
+                                "The index[%s] of merged reader must be < the readers count[%s]",
+                                count, count));
+        assertTrue(region.isEmpty());
+    }
+
+    @Test
+    public void testMergeReaderWithNullKey() throws Exception {
+        final int count = 2;
+        final int index = count - 1;
+        RecordReaderRegion<KeyValue> region =
+                new RecordReaderRegion<>(Comparator.comparingInt(o -> o.getInt(0)), count);
+        assertTrue(region.isEmpty());
+
+        TestReusingRecordReader reader = new TestReusingRecordReader(new ArrayList<>());
+        assertTrue(
+                region.mergeReader(
+                        new SortedRegionDataRecordReader<>(() -> reader, null, null), index));
+
+        assertFalse(region.isEmpty());
+        assertTrue(region.getReader(0).isEmpty());
+        assertEquals(1, region.getReader(index).getSortedReaders().size());
+        assertEquals(1, region.getReaders().size());
+    }
+
+    @Test
+    public void testMergeReaderWithRange() throws Exception {
+        final int count = 2;
+        final Comparator<RowData> keyComparator = Comparator.comparingInt(o -> o.getInt(0));
+        RecordReaderRegion<KeyValue> region = new RecordReaderRegion<>(keyComparator, count);
+
+        TestReusingRecordReader reader = new TestReusingRecordReader(new ArrayList<>());
+
+        // merge key range [0, 100] with index 0 and key range [0, 150] with index 1
+        assertTrue(
+                region.mergeReader(
+                        new SortedRegionDataRecordReader<>(
+                                () -> reader, generateKey(0), generateKey(100)),
+                        0));
+        assertEquals(0, keyComparator.compare(generateKey(0), region.getMinKey()));
+        assertEquals(0, keyComparator.compare(generateKey(100), region.getMaxKey()));
+        assertTrue(
+                region.mergeReader(
+                        new SortedRegionDataRecordReader<>(
+                                () -> reader, generateKey(0), generateKey(150)),
+                        1));
+        assertEquals(0, keyComparator.compare(generateKey(0), region.getMinKey()));
+        assertEquals(0, keyComparator.compare(generateKey(150), region.getMaxKey()));
+
+        // merge key range [60, 100] with index 1
+        assertTrue(
+                region.mergeReader(
+                        new SortedRegionDataRecordReader<>(
+                                () -> reader, generateKey(60), generateKey(100)),
+                        1));
+        assertEquals(0, keyComparator.compare(generateKey(0), region.getMinKey()));
+        assertEquals(0, keyComparator.compare(generateKey(150), region.getMaxKey()));
+
+        // merge key range [200, 300] with index 0
+        assertFalse(
+                region.mergeReader(
+                        new SortedRegionDataRecordReader<>(
+                                () -> reader, generateKey(200), generateKey(300)),
+                        0));
+        assertEquals(0, keyComparator.compare(generateKey(0), region.getMinKey()));
+        assertEquals(0, keyComparator.compare(generateKey(150), region.getMaxKey()));
+
+        assertEquals(2, region.getReaders().size());
+
+        // merge range [0, 50] with index 1
+        assertThatThrownBy(
+                        () ->
+                                region.mergeReader(
+                                        new SortedRegionDataRecordReader<>(
+                                                () -> reader, generateKey(-50), generateKey(500)),
+                                        1))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage(
+                        "The added minKey in reader must be equal or larger than the minKey in region");
+    }
+
+    private RowData generateKey(int value) {
+        GenericRowData data = new GenericRowData(1);
+        data.setField(0, value);
+        return data;
+    }
+}


### PR DESCRIPTION
Currently the `SortMergeReader` will compare and sort the readers after reading one batch from them to ensure that the sequence is correct. The readers are created from `SortedRun` list and the key ranges of them may be disjoint. We can compare batch minKey and maxKey for each read in the files of `SortedRun` list and divide them to multiple regions. When there's only one reader in the region, it can read data directly without compare and sort.

So the main changes are as follows:
1. Add `SortedRegionDataRecordReader` class which can create a reader with minKey and maxKey from each file in `SortedRun`
2. Add `RecordReaderSubRegion` class which includes `SortedRegionDataRecordReader` list, it is created from one `SortedRun`
3. Add `RecordReaderRegionManager` to divide `RecordReaderSubRegion` list into multiple `RecordReaderRegion`, each `RecordReaderRegion` manages its own `RecordReaderSubRegion` list and the key range in different `RecordReaderRegion`s are disjoint
4. Create `SortMergeReader` from each `RecordReaderRegion` to reduce the comparisons in different  `RecordReaderRegion`s. If the `RecordReaderRegion` has only one reader, using the specify reader directly

Test cases `RecordReaderRegionTest` and `RecordReaderRegionManagerTest` are added to test the new classes, the `SortMergeReader` and related classes are tested in `MergeTreeTest`