### PR TITLE
[FLINK-29586] Let write buffer spillable

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -238,9 +238,9 @@
         </tr>
         <tr>
             <td><h5>write-buffer-spillable</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
+            <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
-            <td>Whether the write buffer can be spillable.<ul><li>When `input` changelog-producer is not enabled, it is enabled by default.</li><li>When `input` changelog-producer is started, it is closed by default, because it currently does not support changelog producer input as input.</li></ul></td>
+            <td>Whether the write buffer can be spillable.</td>
         </tr>
         <tr>
             <td><h5>write-mode</h5></td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -75,6 +75,12 @@
             <td>Specify the message format of data files.</td>
         </tr>
         <tr>
+            <td><h5>local-sort.max-num-file-handles</h5></td>
+            <td style="word-wrap: break-word;">128</td>
+            <td>Integer</td>
+            <td>The maximal fan-in for external merge sort. It limits the number of file handles. If it is too small, may cause intermediate merging. But if it is too large, it will cause too many files opened at the same time, consume memory and lead to random reading.</td>
+        </tr>
+        <tr>
             <td><h5>log.changelog-mode</h5></td>
             <td style="word-wrap: break-word;">auto</td>
             <td><p>Enum</p></td>
@@ -229,6 +235,12 @@
             <td style="word-wrap: break-word;">256 mb</td>
             <td>MemorySize</td>
             <td>Amount of data to build up in memory before converting to a sorted on-disk file.</td>
+        </tr>
+        <tr>
+            <td><h5>write-buffer-spillable</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Boolean</td>
+            <td>Whether the write buffer can be spillable.<ul><li>When `input` changelog-producer is not enabled, it is enabled by default.</li><li>When `input` changelog-producer is started, it is closed by default, because it currently does not support changelog producer input as input.</li></ul></td>
         </tr>
         <tr>
             <td><h5>write-mode</h5></td>

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreWriteOperator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreWriteOperator.java
@@ -96,7 +96,10 @@ public class StoreWriteOperator extends PrepareCommitOperator {
     @Override
     public void open() throws Exception {
         super.open();
-        this.write = table.newWrite().withOverwrite(overwritePartition != null);
+        this.write =
+                table.newWrite()
+                        .withIOManager(getContainingTask().getEnvironment().getIOManager())
+                        .withOverwrite(overwritePartition != null);
         this.sinkContext = new SimpleContext(getProcessingTimeService());
         if (logSinkFunction != null) {
             FunctionUtils.openFunction(logSinkFunction, new Configuration());

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/LargeDataITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/LargeDataITCase.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector;
+
+import org.apache.flink.types.Row;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Large data ITCase. */
+public class LargeDataITCase extends CatalogITCaseBase {
+
+    @Test
+    public void testSpillableWriteBuffer() throws Exception {
+        sql(
+                "CREATE TABLE T1 (a INT PRIMARY KEY NOT ENFORCED, b INT) WITH ("
+                        + "'write-buffer-size'='256 kb', 'write-buffer-spillable'='true')");
+        sql("CREATE TABLE T2 (a INT PRIMARY KEY NOT ENFORCED, b INT)");
+        sql(
+                "CREATE TEMPORARY TABLE datagen (a INT, B INT) WITH ('connector'='datagen', 'number-of-rows'='10000')");
+
+        tEnv.createStatementSet()
+                .addInsertSql("INSERT INTO T1 SELECT * FROM datagen")
+                .addInsertSql("INSERT INTO T2 SELECT * FROM datagen")
+                .execute()
+                .await();
+
+        List<Row> result1 = sql("SELECT * FROM T1");
+        List<Row> result2 = sql("SELECT * FROM T2");
+        assertThat(result1).containsExactlyElementsOf(result2);
+    }
+
+    @Test
+    public void testPartitionedSpillableWriteBuffer() throws Exception {
+        sql(
+                "CREATE TABLE T1 (a INT, b INT, c INT, PRIMARY KEY (a, b) NOT ENFORCED) PARTITIONED BY (b) WITH ("
+                        + "'write-buffer-size'='1 mb', 'write-buffer-spillable'='true')");
+        sql(
+                "CREATE TABLE T2 (a INT, b INT, c INT, PRIMARY KEY (a, b) NOT ENFORCED) PARTITIONED BY (b)");
+        sql(
+                "CREATE TEMPORARY TABLE datagen (a INT, b INT, c INT) WITH ("
+                        + "'connector'='datagen', 'number-of-rows'='10000', 'fields.b.min'='1', 'fields.b.max'='10')");
+
+        tEnv.createStatementSet()
+                .addInsertSql("INSERT INTO T1 SELECT * FROM datagen")
+                .addInsertSql("INSERT INTO T2 SELECT * FROM datagen")
+                .execute()
+                .await();
+
+        List<Row> result1 = sql("SELECT * FROM T1");
+        List<Row> result2 = sql("SELECT * FROM T2");
+        assertThat(result1).containsExactlyInAnyOrderElementsOf(result2);
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
@@ -189,6 +189,30 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Amount of data to build up in memory before converting to a sorted on-disk file.");
 
+    public static final ConfigOption<Boolean> WRITE_BUFFER_SPILLABLE =
+            ConfigOptions.key("write-buffer-spillable")
+                    .booleanType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text("Whether the write buffer can be spillable.")
+                                    .list(
+                                            text(
+                                                    "When `input` changelog-producer is not enabled, it is enabled by default."),
+                                            text(
+                                                    "When `input` changelog-producer is started, it is closed by default,"
+                                                            + " because it currently does not support changelog producer input as input."))
+                                    .build());
+
+    public static final ConfigOption<Integer> LOCAL_SORT_MAX_NUM_FILE_HANDLES =
+            ConfigOptions.key("local-sort.max-num-file-handles")
+                    .intType()
+                    .defaultValue(128)
+                    .withDescription(
+                            "The maximal fan-in for external merge sort. It limits the number of file handles. "
+                                    + "If it is too small, may cause intermediate merging. But if it is too large, "
+                                    + "it will cause too many files opened at the same time, consume memory and lead to random reading.");
+
     public static final ConfigOption<MemorySize> PAGE_SIZE =
             ConfigOptions.key("page-size")
                     .memoryType()
@@ -424,6 +448,15 @@ public class CoreOptions implements Serializable {
 
     public long writeBufferSize() {
         return options.get(WRITE_BUFFER_SIZE).getBytes();
+    }
+
+    public boolean writeBufferSpillable() {
+        Optional<Boolean> optional = options.getOptional(WRITE_BUFFER_SPILLABLE);
+        return optional.orElseGet(() -> changelogProducer() != ChangelogProducer.INPUT);
+    }
+
+    public int localSortMaxNumFileHandles() {
+        return options.get(LOCAL_SORT_MAX_NUM_FILE_HANDLES);
     }
 
     public int pageSize() {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
@@ -192,17 +192,8 @@ public class CoreOptions implements Serializable {
     public static final ConfigOption<Boolean> WRITE_BUFFER_SPILLABLE =
             ConfigOptions.key("write-buffer-spillable")
                     .booleanType()
-                    .noDefaultValue()
-                    .withDescription(
-                            Description.builder()
-                                    .text("Whether the write buffer can be spillable.")
-                                    .list(
-                                            text(
-                                                    "When `input` changelog-producer is not enabled, it is enabled by default."),
-                                            text(
-                                                    "When `input` changelog-producer is started, it is closed by default,"
-                                                            + " because it currently does not support changelog producer input as input."))
-                                    .build());
+                    .defaultValue(true)
+                    .withDescription("Whether the write buffer can be spillable.");
 
     public static final ConfigOption<Integer> LOCAL_SORT_MAX_NUM_FILE_HANDLES =
             ConfigOptions.key("local-sort.max-num-file-handles")
@@ -451,8 +442,7 @@ public class CoreOptions implements Serializable {
     }
 
     public boolean writeBufferSpillable() {
-        Optional<Boolean> optional = options.getOptional(WRITE_BUFFER_SPILLABLE);
-        return optional.orElseGet(() -> changelogProducer() != ChangelogProducer.INPUT);
+        return options.get(WRITE_BUFFER_SPILLABLE);
     }
 
     public int localSortMaxNumFileHandles() {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/io/KeyValueDataFileWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/io/KeyValueDataFileWriter.java
@@ -43,6 +43,9 @@ import java.util.function.Function;
 /**
  * A {@link StatsCollectingSingleFileWriter} to write data files containing {@link KeyValue}s. Also
  * produces {@link DataFileMeta} after writing a file.
+ *
+ * <p>NOTE: records given to the writer must be sorted because it does not compare the min max keys
+ * to produce {@link DataFileMeta}.
  */
 public class KeyValueDataFileWriter
         extends StatsCollectingSingleFileWriter<KeyValue, DataFileMeta> {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/io/KeyValueFileWriterFactory.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/io/KeyValueFileWriterFactory.java
@@ -74,18 +74,15 @@ public class KeyValueFileWriterFactory {
         return pathFactory;
     }
 
-    public KeyValueDataFileWriter createMergeTreeFileWriter(int level) {
-        Path path = pathFactory.newPath();
-        return createDataFileWriter(path, level);
-    }
-
     public RollingFileWriter<KeyValue, DataFileMeta> createRollingMergeTreeFileWriter(int level) {
-        return new RollingFileWriter<>(() -> createMergeTreeFileWriter(level), suggestedFileSize);
+        return new RollingFileWriter<>(
+                () -> createDataFileWriter(pathFactory.newPath(), level), suggestedFileSize);
     }
 
-    public KeyValueDataFileWriter createChangelogFileWriter(int level) {
-        Path path = pathFactory.newChangelogPath();
-        return createDataFileWriter(path, level);
+    public RollingFileWriter<KeyValue, DataFileMeta> createRollingChangelogFileWriter(int level) {
+        return new RollingFileWriter<>(
+                () -> createDataFileWriter(pathFactory.newChangelogPath(), level),
+                suggestedFileSize);
     }
 
     private KeyValueDataFileWriter createDataFileWriter(Path path, int level) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/UniversalCompaction.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/UniversalCompaction.java
@@ -160,6 +160,18 @@ public class UniversalCompaction implements CompactStrategy {
             outputLevel = Math.max(0, runs.get(runCount).level() - 1);
         }
 
+        if (outputLevel == 0) {
+            // do not output level 0
+            for (int i = runCount; i < runs.size(); i++) {
+                LevelSortedRun next = runs.get(i);
+                runCount++;
+                if (next.level() != 0) {
+                    outputLevel = next.level();
+                    break;
+                }
+            }
+        }
+
         return CompactUnit.fromLevelRuns(outputLevel, runs.subList(0, runCount));
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AbstractFileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AbstractFileStoreWrite.java
@@ -18,12 +18,15 @@
 
 package org.apache.flink.table.store.file.operation;
 
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.store.file.io.DataFileMeta;
 import org.apache.flink.table.store.file.manifest.ManifestEntry;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
+
+import javax.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.List;
@@ -38,9 +41,17 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
     private final SnapshotManager snapshotManager;
     private final FileStoreScan scan;
 
+    @Nullable protected IOManager ioManager;
+
     protected AbstractFileStoreWrite(SnapshotManager snapshotManager, FileStoreScan scan) {
         this.snapshotManager = snapshotManager;
         this.scan = scan;
+    }
+
+    @Override
+    public FileStoreWrite<T> withIOManager(IOManager ioManager) {
+        this.ioManager = ioManager;
+        return this;
     }
 
     protected List<DataFileMeta> scanExistingFileMetas(BinaryRowData partition, int bucket) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreWrite.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.store.file.operation;
 
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.store.file.compact.CompactResult;
 import org.apache.flink.table.store.file.io.DataFileMeta;
@@ -35,6 +36,8 @@ import java.util.concurrent.ExecutorService;
  * @param <T> type of record to write.
  */
 public interface FileStoreWrite<T> {
+
+    FileStoreWrite<T> withIOManager(IOManager ioManager);
 
     /** Create a {@link RecordWriter} from partition and bucket. */
     RecordWriter<T> createWriter(

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreWrite.java
@@ -152,6 +152,9 @@ public class KeyValueFileStoreWrite extends AbstractFileStoreWrite<KeyValue> {
                             levels);
         }
         return new MergeTreeWriter(
+                options.writeBufferSpillable(),
+                options.localSortMaxNumFileHandles(),
+                ioManager,
                 compactManager,
                 getMaxSequenceNumber(restoreFiles),
                 keyComparator,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/sort/BinaryExternalSortBuffer.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/sort/BinaryExternalSortBuffer.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.sort;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.runtime.io.compression.BlockCompressionFactory;
+import org.apache.flink.runtime.io.compression.Lz4BlockCompressionFactory;
+import org.apache.flink.runtime.io.disk.iomanager.AbstractChannelWriterOutputView;
+import org.apache.flink.runtime.io.disk.iomanager.FileIOChannel;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.operators.sort.QuickSort;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.runtime.generated.RecordComparator;
+import org.apache.flink.table.runtime.io.ChannelWithMeta;
+import org.apache.flink.table.runtime.operators.sort.BinaryExternalMerger;
+import org.apache.flink.table.runtime.operators.sort.BinaryMergeIterator;
+import org.apache.flink.table.runtime.operators.sort.SpillChannelManager;
+import org.apache.flink.table.runtime.typeutils.BinaryRowDataSerializer;
+import org.apache.flink.table.runtime.util.FileChannelUtil;
+import org.apache.flink.util.MutableObjectIterator;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/** A spillable {@link SortBuffer}. */
+public class BinaryExternalSortBuffer implements SortBuffer {
+
+    private final BinaryRowDataSerializer serializer;
+    private final int pageSize;
+    private final BinaryInMemorySortBuffer inMemorySortBuffer;
+    private final IOManager ioManager;
+    private SpillChannelManager channelManager;
+    private final int maxNumFileHandles;
+    private final boolean compressionEnable;
+    private final BlockCompressionFactory compressionCodecFactory;
+    private final int compressionBlockSize;
+    private final BinaryExternalMerger merger;
+
+    private final FileIOChannel.Enumerator enumerator;
+    private final List<ChannelWithMeta> spillChannelIDs;
+
+    private int numRecords = 0;
+
+    public BinaryExternalSortBuffer(
+            BinaryRowDataSerializer serializer,
+            RecordComparator comparator,
+            int pageSize,
+            BinaryInMemorySortBuffer inMemorySortBuffer,
+            IOManager ioManager,
+            int maxNumFileHandles) {
+        this.serializer = serializer;
+        this.pageSize = pageSize;
+        this.inMemorySortBuffer = inMemorySortBuffer;
+        this.ioManager = ioManager;
+        this.channelManager = new SpillChannelManager();
+        this.maxNumFileHandles = maxNumFileHandles;
+        this.compressionEnable = true;
+        this.compressionCodecFactory = new Lz4BlockCompressionFactory();
+        this.compressionBlockSize = (int) MemorySize.parse("64 kb").getBytes();
+        this.merger =
+                new BinaryExternalMerger(
+                        ioManager,
+                        pageSize,
+                        maxNumFileHandles,
+                        channelManager,
+                        (BinaryRowDataSerializer) serializer.duplicate(),
+                        comparator,
+                        compressionEnable,
+                        compressionCodecFactory,
+                        compressionBlockSize);
+        this.enumerator = ioManager.createChannelEnumerator();
+        this.spillChannelIDs = new ArrayList<>();
+    }
+
+    @Override
+    public int size() {
+        return numRecords;
+    }
+
+    @Override
+    public void clear() {
+        this.numRecords = 0;
+        // release memory
+        inMemorySortBuffer.clear();
+        spillChannelIDs.clear();
+        channelManager.close();
+        // delete files
+        channelManager = new SpillChannelManager();
+    }
+
+    @Override
+    public long getOccupancy() {
+        return inMemorySortBuffer.getOccupancy();
+    }
+
+    @Override
+    public boolean flushMemory() throws IOException {
+        spill();
+        return true;
+    }
+
+    @VisibleForTesting
+    public void write(MutableObjectIterator<BinaryRowData> iterator) throws IOException {
+        BinaryRowData row = serializer.createInstance();
+        while ((row = iterator.next(row)) != null) {
+            write(row);
+        }
+    }
+
+    @Override
+    public boolean write(RowData record) throws IOException {
+        while (true) {
+            boolean success = inMemorySortBuffer.write(record);
+            if (success) {
+                this.numRecords++;
+                return true;
+            }
+            if (inMemorySortBuffer.isEmpty()) {
+                // did not fit in a fresh buffer, must be large...
+                throw new IOException("The record exceeds the maximum size of a sort buffer.");
+            } else {
+                spill();
+
+                if (spillChannelIDs.size() >= maxNumFileHandles) {
+                    List<ChannelWithMeta> merged = merger.mergeChannelList(spillChannelIDs);
+                    spillChannelIDs.clear();
+                    spillChannelIDs.addAll(merged);
+                }
+            }
+        }
+    }
+
+    @Override
+    public final MutableObjectIterator<BinaryRowData> sortedIterator() throws IOException {
+        if (spillChannelIDs.isEmpty()) {
+            return inMemorySortBuffer.sortedIterator();
+        }
+        return spilledIterator();
+    }
+
+    private MutableObjectIterator<BinaryRowData> spilledIterator() throws IOException {
+        spill();
+
+        List<FileIOChannel> openChannels = new ArrayList<>();
+        BinaryMergeIterator<BinaryRowData> iterator =
+                merger.getMergingIterator(spillChannelIDs, openChannels);
+        channelManager.addOpenChannels(openChannels);
+
+        return new MutableObjectIterator<BinaryRowData>() {
+            @Override
+            public BinaryRowData next(BinaryRowData reuse) throws IOException {
+                // BinaryMergeIterator ignore reuse object argument, use its own reusing object
+                return next();
+            }
+
+            @Override
+            public BinaryRowData next() throws IOException {
+                BinaryRowData row = iterator.next();
+                // BinaryMergeIterator reuse object anyway, here we need to copy it to do compaction
+                return row == null ? null : row.copy();
+            }
+        };
+    }
+
+    private void spill() throws IOException {
+        if (inMemorySortBuffer.isEmpty()) {
+            return;
+        }
+
+        // open next channel
+        FileIOChannel.ID channel = enumerator.next();
+        channelManager.addChannel(channel);
+
+        AbstractChannelWriterOutputView output = null;
+        int bytesInLastBuffer;
+        int blockCount;
+
+        try {
+            output =
+                    FileChannelUtil.createOutputView(
+                            ioManager,
+                            channel,
+                            compressionEnable,
+                            compressionCodecFactory,
+                            compressionBlockSize,
+                            pageSize);
+            new QuickSort().sort(inMemorySortBuffer);
+            inMemorySortBuffer.writeToOutput(output);
+            bytesInLastBuffer = output.close();
+            blockCount = output.getBlockCount();
+        } catch (IOException e) {
+            if (output != null) {
+                output.close();
+                output.getChannel().deleteChannel();
+            }
+            throw e;
+        }
+
+        spillChannelIDs.add(new ChannelWithMeta(channel, blockCount, bytesInLastBuffer));
+        inMemorySortBuffer.clear();
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/sort/SortBuffer.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/sort/SortBuffer.java
@@ -16,28 +16,29 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.store.table.sink;
+package org.apache.flink.table.store.file.sort;
 
-import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.util.MutableObjectIterator;
 
-import java.util.List;
+import java.io.IOException;
 
-/**
- * An abstraction layer above {@link org.apache.flink.table.store.file.operation.FileStoreWrite} to
- * provide {@link RowData} writing.
- */
-public interface TableWrite {
+/** Sort buffer to sort records. */
+public interface SortBuffer {
 
-    TableWrite withOverwrite(boolean overwrite);
+    int size();
 
-    TableWrite withIOManager(IOManager ioManager);
+    void clear();
 
-    SinkRecordConverter recordConverter();
+    long getOccupancy();
 
-    SinkRecord write(RowData rowData) throws Exception;
+    /** Flush memory, return false if not supported. */
+    boolean flushMemory() throws IOException;
 
-    List<FileCommittable> prepareCommit(boolean endOfInput) throws Exception;
+    /** @return false if the buffer is full. */
+    boolean write(RowData record) throws IOException;
 
-    void close() throws Exception;
+    /** @return iterator with sorting. */
+    MutableObjectIterator<BinaryRowData> sortedIterator() throws IOException;
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/AbstractTableWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/AbstractTableWrite.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.store.table.sink;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.store.file.operation.FileStoreWrite;
@@ -61,6 +62,12 @@ public abstract class AbstractTableWrite<T> implements TableWrite {
     @Override
     public TableWrite withOverwrite(boolean overwrite) {
         this.overwrite = overwrite;
+        return this;
+    }
+
+    @Override
+    public TableWrite withIOManager(IOManager ioManager) {
+        this.write.withIOManager(ioManager);
         return this;
     }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/io/KeyValueFileReadWriteTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/io/KeyValueFileReadWriteTest.java
@@ -125,12 +125,7 @@ public class KeyValueFileReadWriteTest {
                         "avro");
 
         try {
-            FileWriter<KeyValue, ?> writer;
-            if (ThreadLocalRandom.current().nextBoolean()) {
-                writer = writerFactory.createRollingMergeTreeFileWriter(0);
-            } else {
-                writer = writerFactory.createMergeTreeFileWriter(0);
-            }
+            FileWriter<KeyValue, ?> writer = writerFactory.createRollingMergeTreeFileWriter(0);
             writer.write(CloseableIterator.fromList(data.content, kv -> {}));
         } catch (Throwable e) {
             if (e.getCause() != null) {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/MergeTreeTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/MergeTreeTest.java
@@ -262,6 +262,9 @@ public class MergeTreeTest {
                 files.stream().map(DataFileMeta::maxSequenceNumber).max(Long::compare).orElse(-1L);
         MergeTreeWriter writer =
                 new MergeTreeWriter(
+                        false,
+                        128,
+                        null,
                         createCompactManager(writerFactory, service, files),
                         maxSequenceNumber,
                         comparator,

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/sort/BinaryExternalSortBufferTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/sort/BinaryExternalSortBufferTest.java
@@ -1,0 +1,321 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.sort;
+
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.data.writer.BinaryRowWriter;
+import org.apache.flink.table.runtime.typeutils.AbstractRowDataSerializer;
+import org.apache.flink.table.runtime.typeutils.BinaryRowDataSerializer;
+import org.apache.flink.table.runtime.util.MemorySegmentPool;
+import org.apache.flink.table.store.file.memory.HeapMemorySegmentPool;
+import org.apache.flink.util.MutableObjectIterator;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link BinaryExternalSortBuffer}. */
+public class BinaryExternalSortBufferTest {
+
+    private static final int MEMORY_SIZE = 1024 * 1024 * 32;
+
+    @TempDir Path tempDir;
+
+    private IOManager ioManager;
+    private MemorySegmentPool memorySegmentPool;
+    private int totalPages;
+    private BinaryRowDataSerializer serializer;
+
+    private static String getString(int count) {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < 8; i++) {
+            builder.append(count);
+        }
+        return builder.toString();
+    }
+
+    @BeforeEach
+    public void beforeTest() {
+        ioManager = new IOManagerAsync(tempDir.toString());
+        initMemorySegmentPool(MEMORY_SIZE);
+        this.serializer = new BinaryRowDataSerializer(2);
+    }
+
+    @AfterEach
+    public void afterTest() throws Exception {
+        assertAfterTest();
+        this.ioManager.close();
+    }
+
+    private void initMemorySegmentPool(long maxMemory) {
+        this.memorySegmentPool =
+                new HeapMemorySegmentPool(maxMemory, MemoryManager.DEFAULT_PAGE_SIZE);
+        this.totalPages = memorySegmentPool.freePages();
+    }
+
+    private void assertAfterTest() throws IOException {
+        assertThat(memorySegmentPool.freePages()).isEqualTo(totalPages);
+        List<File> files =
+                Files.walk(tempDir)
+                        .map(Path::toFile)
+                        .filter(f -> !f.isDirectory())
+                        .collect(Collectors.toList());
+        assertThat(files).isEmpty();
+    }
+
+    @Test
+    public void testSortNoSpill() throws Exception {
+        int size = 1_000_000;
+
+        MockBinaryRowReader reader = new MockBinaryRowReader(size);
+
+        // there are two sort buffer if sortMemory > 100 * 1024 * 1024.
+        initMemorySegmentPool(1024 * 1024 * 101);
+        BinaryExternalSortBuffer sorter = createBuffer();
+        sorter.write(reader);
+
+        assertThat(sorter.size()).isEqualTo(size);
+
+        MutableObjectIterator<BinaryRowData> iterator = sorter.sortedIterator();
+
+        BinaryRowData next = serializer.createInstance();
+        for (int i = 0; i < size; i++) {
+            next = iterator.next(next);
+            assertThat(next.getInt(0)).isEqualTo(i);
+            assertThat(next.getString(1).toString()).isEqualTo(getString(i));
+        }
+
+        sorter.clear();
+    }
+
+    @Test
+    public void testSort() throws Exception {
+        int size = 10_000;
+
+        MockBinaryRowReader reader = new MockBinaryRowReader(size);
+
+        BinaryExternalSortBuffer sorter = createBuffer();
+        sorter.write(reader);
+
+        assertThat(sorter.size()).isEqualTo(size);
+
+        assertThat(sorter.getOccupancy()).isGreaterThan(0);
+
+        MutableObjectIterator<BinaryRowData> iterator = sorter.sortedIterator();
+
+        BinaryRowData next = serializer.createInstance();
+        for (int i = 0; i < size; i++) {
+            next = iterator.next(next);
+            assertThat(next.getInt(0)).isEqualTo(i);
+            assertThat(next.getString(1).toString()).isEqualTo(getString(i));
+        }
+
+        sorter.clear();
+        assertThat(sorter.getOccupancy()).isEqualTo(0);
+    }
+
+    @Test
+    public void testSortIntStringWithRepeat() throws Exception {
+        int size = 10_000;
+
+        BinaryExternalSortBuffer sorter = createBuffer();
+        sorter.write(new MockBinaryRowReader(size));
+        assertThat(sorter.size()).isEqualTo(size);
+
+        sorter.write(new MockBinaryRowReader(size));
+        assertThat(sorter.size()).isEqualTo(size * 2);
+
+        sorter.write(new MockBinaryRowReader(size));
+        assertThat(sorter.size()).isEqualTo(size * 3);
+
+        MutableObjectIterator<BinaryRowData> iterator = sorter.sortedIterator();
+
+        BinaryRowData next = serializer.createInstance();
+        for (int i = 0; i < size; i++) {
+            for (int j = 0; j < 3; j++) {
+                next = iterator.next(next);
+                assertThat(next.getInt(0)).isEqualTo(i);
+                assertThat(next.getString(1).toString()).isEqualTo(getString(i));
+            }
+        }
+
+        sorter.clear();
+    }
+
+    @Test
+    public void testRepeatUsingWhenSpill() throws Exception {
+        BinaryExternalSortBuffer sorter = createBuffer();
+        innerTestSpilling(sorter);
+        assertAfterTest();
+        innerTestSpilling(sorter);
+    }
+
+    @Test
+    public void testSpilling() throws Exception {
+        innerTestSpilling(createBuffer());
+    }
+
+    private void innerTestSpilling(BinaryExternalSortBuffer sorter) throws Exception {
+        int size = 1000_000;
+
+        MockBinaryRowReader reader = new MockBinaryRowReader(size);
+        sorter.write(reader);
+        assertThat(sorter.size()).isEqualTo(size);
+
+        MutableObjectIterator<BinaryRowData> iterator = sorter.sortedIterator();
+
+        BinaryRowData next = serializer.createInstance();
+        for (int i = 0; i < size; i++) {
+            next = iterator.next(next);
+            assertThat(next.getInt(0)).isEqualTo(i);
+            assertThat(next.getString(1).toString()).isEqualTo(getString(i));
+        }
+
+        sorter.clear();
+    }
+
+    @Test
+    public void testMergeManyTimes() throws Exception {
+        int size = 1000_000;
+
+        MockBinaryRowReader reader = new MockBinaryRowReader(size);
+
+        BinaryExternalSortBuffer sorter = createBuffer(8);
+        sorter.write(reader);
+        assertThat(sorter.size()).isEqualTo(size);
+
+        MutableObjectIterator<BinaryRowData> iterator = sorter.sortedIterator();
+
+        BinaryRowData next = serializer.createInstance();
+        for (int i = 0; i < size; i++) {
+            next = iterator.next(next);
+            assertThat(next.getInt(0)).isEqualTo(i);
+            assertThat(next.getString(1).toString()).isEqualTo(getString(i));
+        }
+
+        sorter.clear();
+    }
+
+    @Test
+    public void testSpillingRandom() throws Exception {
+        int size = 1000_000;
+
+        MockBinaryRowReader reader = new MockBinaryRowReader(size);
+
+        BinaryExternalSortBuffer sorter = createBuffer(8);
+
+        List<BinaryRowData> data = new ArrayList<>();
+        BinaryRowData row = serializer.createInstance();
+        for (int i = 0; i < size; i++) {
+            row = reader.next(row);
+            data.add(row.copy());
+        }
+
+        Collections.shuffle(data);
+
+        for (int i = 0; i < size; i++) {
+            sorter.write(data.get(i));
+        }
+
+        MutableObjectIterator<BinaryRowData> iterator = sorter.sortedIterator();
+
+        data.sort(Comparator.comparingInt(o -> o.getInt(0)));
+
+        BinaryRowData next = serializer.createInstance();
+        for (int i = 0; i < size; i++) {
+            next = iterator.next(next);
+            assertThat(next.getInt(0)).isEqualTo(data.get(i).getInt(0));
+            assertThat(next.getString(1).toString()).isEqualTo(data.get(i).getString(1).toString());
+        }
+
+        sorter.clear();
+    }
+
+    private BinaryExternalSortBuffer createBuffer() {
+        return createBuffer(128);
+    }
+
+    private BinaryExternalSortBuffer createBuffer(int maxNumFileHandles) {
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        BinaryInMemorySortBuffer inMemorySortBuffer =
+                BinaryInMemorySortBuffer.createBuffer(
+                        IntNormalizedKeyComputer.INSTANCE,
+                        (AbstractRowDataSerializer) serializer,
+                        IntRecordComparator.INSTANCE,
+                        memorySegmentPool);
+        return new BinaryExternalSortBuffer(
+                serializer,
+                IntRecordComparator.INSTANCE,
+                MemoryManager.DEFAULT_PAGE_SIZE,
+                inMemorySortBuffer,
+                ioManager,
+                maxNumFileHandles);
+    }
+
+    /** Mock reader for binary row. */
+    public static class MockBinaryRowReader implements MutableObjectIterator<BinaryRowData> {
+
+        private final int size;
+        private final BinaryRowData row;
+        private final BinaryRowWriter writer;
+
+        private int count;
+
+        public MockBinaryRowReader(int size) {
+            this.size = size;
+            this.row = new BinaryRowData(2);
+            this.writer = new BinaryRowWriter(row);
+        }
+
+        @Override
+        public BinaryRowData next(BinaryRowData reuse) {
+            return next();
+        }
+
+        @Override
+        public BinaryRowData next() {
+            if (count >= size) {
+                return null;
+            }
+            writer.reset();
+            writer.writeInt(0, count);
+            writer.writeString(1, StringData.fromString(getString(count)));
+            writer.complete();
+            count++;
+            return row;
+        }
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/sort/IntNormalizedKeyComputer.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/sort/IntNormalizedKeyComputer.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.sort;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.NormalizedKeyComputer;
+import org.apache.flink.table.runtime.operators.sort.SortUtil;
+
+/** Example for int {@link NormalizedKeyComputer}. */
+public class IntNormalizedKeyComputer implements NormalizedKeyComputer {
+
+    public static final IntNormalizedKeyComputer INSTANCE = new IntNormalizedKeyComputer();
+
+    @Override
+    public void putKey(RowData record, MemorySegment target, int offset) {
+        // write first null byte.
+        if (record.isNullAt(0)) {
+            SortUtil.minNormalizedKey(target, offset, 5);
+        } else {
+            target.put(offset, (byte) 1);
+            SortUtil.putIntNormalizedKey(record.getInt(0), target, offset + 1, 4);
+        }
+
+        // revert 4 bytes to compare easier.
+        target.putInt(offset, Integer.reverseBytes(target.getInt(offset)));
+    }
+
+    @Override
+    public int compareKey(MemorySegment segI, int offsetI, MemorySegment segJ, int offsetJ) {
+        int int1 = segI.getInt(offsetI);
+        int int2 = segJ.getInt(offsetJ);
+        if (int1 != int2) {
+            return (int1 < int2) ^ (int1 < 0) ^ (int2 < 0) ? -1 : 1;
+        }
+
+        byte byte1 = segI.get(offsetI + 4);
+        byte byte2 = segJ.get(offsetJ + 4);
+        if (byte1 != byte2) {
+            return (byte1 < byte2) ^ (byte1 < 0) ^ (byte2 < 0) ? -1 : 1;
+        }
+        return 0;
+    }
+
+    @Override
+    public void swapKey(MemorySegment segI, int offsetI, MemorySegment segJ, int offsetJ) {
+
+        int temp0 = segI.getInt(offsetI);
+        segI.putInt(offsetI, segJ.getInt(offsetJ));
+        segJ.putInt(offsetJ, temp0);
+
+        byte temp1 = segI.get(offsetI + 4);
+        segI.put(offsetI + 4, segJ.get(offsetJ + 4));
+        segJ.put(offsetJ + 4, temp1);
+    }
+
+    @Override
+    public int getNumKeyBytes() {
+        return 5;
+    }
+
+    @Override
+    public boolean isKeyFullyDetermines() {
+        return true;
+    }
+
+    @Override
+    public boolean invertKey() {
+        return false;
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/sort/IntRecordComparator.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/sort/IntRecordComparator.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.sort;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.RecordComparator;
+
+/** Example Int {@link RecordComparator}. */
+public class IntRecordComparator implements RecordComparator {
+
+    public static final IntRecordComparator INSTANCE = new IntRecordComparator();
+
+    @Override
+    public int compare(RowData o1, RowData o2) {
+
+        boolean null0At1 = o1.isNullAt(0);
+        boolean null0At2 = o2.isNullAt(0);
+        int cmp0 =
+                null0At1 && null0At2
+                        ? 0
+                        : (null0At1
+                                ? -1
+                                : (null0At2 ? 1 : Integer.compare(o1.getInt(0), o2.getInt(0))));
+        if (cmp0 != 0) {
+            return cmp0;
+        }
+        return 0;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof IntRecordComparator;
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTableTest.java
@@ -186,16 +186,15 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         List<Split> splits = table.newScan().withIncremental(true).plan().splits;
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, CHANGELOG_ROW_TO_STRING))
-                .isEqualTo(
-                        Arrays.asList(
-                                "+I 1|10|100|binary|varbinary",
-                                "+I 1|20|200|binary|varbinary",
-                                "-D 1|10|100|binary|varbinary",
-                                "+I 1|10|101|binary|varbinary",
-                                "-U 1|20|200|binary|varbinary",
-                                "+U 1|20|201|binary|varbinary",
-                                "-U 1|10|101|binary|varbinary",
-                                "+U 1|10|102|binary|varbinary"));
+                .containsExactlyInAnyOrder(
+                        "+I 1|10|100|binary|varbinary",
+                        "+I 1|20|200|binary|varbinary",
+                        "-D 1|10|100|binary|varbinary",
+                        "+I 1|10|101|binary|varbinary",
+                        "-U 1|20|200|binary|varbinary",
+                        "+U 1|20|201|binary|varbinary",
+                        "-U 1|10|101|binary|varbinary",
+                        "+U 1|10|102|binary|varbinary");
     }
 
     @Test


### PR DESCRIPTION
Column format and remote DFS may greatly affect the performance of compaction. We can change the writeBuffer to spillable to improve the performance. In this way, at least one checkpoint will not result in a remote column file based compression.

This PR:
- `MergeTreeWriter` can output rolling level0 files, because after the writeBuffer can spill, we should avoid too big file in level0. 
- Let `UniversalCompaction` not output level 0 result, because after the writeBuffer can spill, multiple level0 files will be generated, which may lead to useless work done by the compaction. We adjust the outputLevel to at least level1, which can ensure that the compaction must be effective.
- Rename MemTable to WriteBuffer, it can spill now.
- Introduce `BinaryExternalSortBuffer`.
- Adjust `MemoryPoolFactory`, flushMemory can just flush memory, without producing level0 files.
- Introduce `write-buffer-spillable`, about default value: When `input` changelog-producer is not enabled, it is enabled by default. When `input` changelog-producer is started, it is closed by default, because it currently does not support changelog producer input as input. 