### PR TITLE
[FLINK-29700] Serializer to BinaryInMemorySortBuffer is wrong

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/memory/sort/BinaryInMemorySortBuffer.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/memory/sort/BinaryInMemorySortBuffer.java
@@ -65,7 +65,6 @@ public class BinaryInMemorySortBuffer extends BinaryIndexedSortable {
     public static BinaryInMemorySortBuffer createBuffer(
             NormalizedKeyComputer normalizedKeyComputer,
             AbstractRowDataSerializer<RowData> inputSerializer,
-            BinaryRowDataSerializer serializer,
             RecordComparator comparator,
             MemorySegmentPool memoryPool) {
         checkArgument(memoryPool.freePages() >= MIN_REQUIRED_BUFFERS);
@@ -73,7 +72,6 @@ public class BinaryInMemorySortBuffer extends BinaryIndexedSortable {
         return new BinaryInMemorySortBuffer(
                 normalizedKeyComputer,
                 inputSerializer,
-                serializer,
                 comparator,
                 recordBufferSegments,
                 new SimpleCollectingOutputView(
@@ -84,12 +82,16 @@ public class BinaryInMemorySortBuffer extends BinaryIndexedSortable {
     private BinaryInMemorySortBuffer(
             NormalizedKeyComputer normalizedKeyComputer,
             AbstractRowDataSerializer<RowData> inputSerializer,
-            BinaryRowDataSerializer serializer,
             RecordComparator comparator,
             ArrayList<MemorySegment> recordBufferSegments,
             SimpleCollectingOutputView recordCollector,
             MemorySegmentPool pool) {
-        super(normalizedKeyComputer, serializer, comparator, recordBufferSegments, pool);
+        super(
+                normalizedKeyComputer,
+                new BinaryRowDataSerializer(inputSerializer.getArity()),
+                comparator,
+                recordBufferSegments,
+                pool);
         this.inputSerializer = inputSerializer;
         this.recordBufferSegments = recordBufferSegments;
         this.recordCollector = recordCollector;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/SortBufferMemTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/SortBufferMemTable.java
@@ -24,7 +24,6 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.runtime.generated.NormalizedKeyComputer;
 import org.apache.flink.table.runtime.generated.RecordComparator;
-import org.apache.flink.table.runtime.typeutils.BinaryRowDataSerializer;
 import org.apache.flink.table.runtime.typeutils.InternalSerializers;
 import org.apache.flink.table.runtime.util.MemorySegmentPool;
 import org.apache.flink.table.store.codegen.CodeGenUtils;
@@ -78,7 +77,6 @@ public class SortBufferMemTable implements MemTable {
                 BinaryInMemorySortBuffer.createBuffer(
                         normalizedKeyComputer,
                         InternalSerializers.create(KeyValue.schema(keyType, valueType)),
-                        new BinaryRowDataSerializer(sortKeyTypes.size()),
                         keyComparator,
                         memoryPool);
     }


### PR DESCRIPTION
In SortBufferMemTable, it will use `BinaryInMemorySortBuffer.createBuffer(BinaryRowDataSerializer serializer)`, the serializer is for full row, not just sort key fields.
Problems may occur when there are many fields.

The test does not reproduce the problem because special conditions are required to trigger the problem.
This problem is completely avoided at the code parameter level.