### PR TITLE
[FLINK-29075] Fix table store unstable test RescaleBucketITCase#testSuspendAndRecoverAfterRescaleOverwrite

### DIFF
--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/RescaleBucketITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/RescaleBucketITCase.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.store.connector;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/RescaleBucketITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/RescaleBucketITCase.java
@@ -154,7 +154,7 @@ public class RescaleBucketITCase extends FileStoreTableITCase {
     private void stopJobSafely(ClusterClient<?> client, JobID jobId)
             throws ExecutionException, InterruptedException {
         client.stopWithSavepoint(jobId, true, path, SavepointFormatType.DEFAULT);
-        while (client.getJobStatus(jobId).get() == JobStatus.RUNNING) {
+        while (!client.getJobStatus(jobId).get().isGloballyTerminalState()) {
             Thread.sleep(2000L);
         }
     }


### PR DESCRIPTION
`RescaleBucketITCase#testSuspendAndRecoverAfterRescaleOverwrite` fails due to some expected records in table `T4` does not appear in table `T3`. This is because `stopJobSafely` method does not wait for job to fully shut down.