### PR TITLE
[FLINK-29773] Fix table store unstable tests PreAggregationITCase

### DIFF
--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileStoreTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileStoreTableITCase.java
@@ -76,8 +76,14 @@ public abstract class FileStoreTableITCase extends AbstractTestBase {
 
     private void prepareConfiguration(TableEnvironment env, String path) {
         Configuration config = env.getConfig().getConfiguration();
-        config.set(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 2);
+        config.set(
+                ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM,
+                defaultParallelism());
         config.setString(TABLE_STORE_PREFIX + ROOT_PATH.key(), path);
+    }
+
+    protected int defaultParallelism() {
+        return 2;
     }
 
     private void prepareEnv() {

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/PreAggregationITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/PreAggregationITCase.java
@@ -126,11 +126,18 @@ public class PreAggregationITCase {
 
         @Test
         public void testMergeInMemory() {
+            // VALUES does not guarantee order, but order is important for list aggregations.
+            // So we need to sort the input data.
             batchSql(
-                    "INSERT INTO T6 VALUES "
-                            + "(1, 2, 'first line'),"
-                            + "(1, 2, CAST(NULL AS STRING)), "
-                            + "(1, 2, 'second line')");
+                    "CREATE VIEW myView AS "
+                            + "SELECT b, c, d FROM "
+                            + "(VALUES "
+                            + "  (1, 1, 2, 'first line'),"
+                            + "  (2, 1, 2, CAST(NULL AS STRING)),"
+                            + "  (3, 1, 2, 'second line')"
+                            + ") AS V(a, b, c, d) "
+                            + "ORDER BY a");
+            batchSql("INSERT INTO T6 SELECT * FROM myView");
             List<Row> result = batchSql("SELECT * FROM T6");
             assertThat(result).containsExactlyInAnyOrder(Row.of(1, 2, "first line,second line"));
         }
@@ -197,11 +204,18 @@ public class PreAggregationITCase {
 
         @Test
         public void testMergeInMemory() {
+            // VALUES does not guarantee order, but order is important for last value aggregations.
+            // So we need to sort the input data.
             batchSql(
-                    "INSERT INTO T5 VALUES "
-                            + "(1, 2, CAST(NULL AS INT), CAST('2020-01-01' AS DATE)),"
-                            + "(1, 2, 2, CAST('2020-01-02' AS DATE)), "
-                            + "(1, 2, 3, CAST(NULL AS DATE))");
+                    "CREATE VIEW myView AS "
+                            + "SELECT b, c, d, e FROM "
+                            + "(VALUES "
+                            + "  (1, 1, 2, CAST(NULL AS INT), CAST('2020-01-01' AS DATE)),"
+                            + "  (2, 1, 2, 2, CAST('2020-01-02' AS DATE)),"
+                            + "  (3, 1, 2, 3, CAST(NULL AS DATE))"
+                            + ") AS V(a, b, c, d, e) "
+                            + "ORDER BY a");
+            batchSql("INSERT INTO T5 SELECT * FROM myView");
             List<Row> result = batchSql("SELECT * FROM T5");
             assertThat(result).containsExactlyInAnyOrder(Row.of(1, 2, 3, null));
         }
@@ -268,11 +282,18 @@ public class PreAggregationITCase {
 
         @Test
         public void testMergeInMemory() {
+            // VALUES does not guarantee order, but order is important for last value aggregations.
+            // So we need to sort the input data.
             batchSql(
-                    "INSERT INTO T4 VALUES "
-                            + "(1, 2, CAST(NULL AS INT), CAST('2020-01-01' AS DATE)),"
-                            + "(1, 2, 2, CAST('2020-01-02' AS DATE)), "
-                            + "(1, 2, 3, CAST(NULL AS DATE))");
+                    "CREATE VIEW myView AS "
+                            + "SELECT b, c, d, e FROM "
+                            + "(VALUES "
+                            + "  (1, 1, 2, CAST(NULL AS INT), CAST('2020-01-01' AS DATE)),"
+                            + "  (2, 1, 2, 2, CAST('2020-01-02' AS DATE)),"
+                            + "  (3, 1, 2, 3, CAST(NULL AS DATE))"
+                            + ") AS V(a, b, c, d, e) "
+                            + "ORDER BY a");
+            batchSql("INSERT INTO T4 SELECT * FROM myView");
             List<Row> result = batchSql("SELECT * FROM T4");
             assertThat(result).containsExactlyInAnyOrder(Row.of(1, 2, 3, LocalDate.of(2020, 1, 2)));
         }

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/PreAggregationITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/PreAggregationITCase.java
@@ -107,6 +107,12 @@ public class PreAggregationITCase {
     /** ITCase for listagg aggregate function. */
     public static class ListAggAggregation extends FileStoreTableITCase {
         @Override
+        protected int defaultParallelism() {
+            // set parallelism to 1 so that the order of input data is determined
+            return 1;
+        }
+
+        @Override
         protected List<String> ddl() {
             return Collections.singletonList(
                     "CREATE TABLE IF NOT EXISTS T6 ("
@@ -169,6 +175,12 @@ public class PreAggregationITCase {
 
     /** ITCase for last value aggregate function. */
     public static class LastValueAggregation extends FileStoreTableITCase {
+        @Override
+        protected int defaultParallelism() {
+            // set parallelism to 1 so that the order of input data is determined
+            return 1;
+        }
+
         @Override
         protected List<String> ddl() {
             return Collections.singletonList(
@@ -234,6 +246,12 @@ public class PreAggregationITCase {
 
     /** ITCase for last non-null value aggregate function. */
     public static class LastNonNullValueAggregation extends FileStoreTableITCase {
+        @Override
+        protected int defaultParallelism() {
+            // set parallelism to 1 so that the order of input data is determined
+            return 1;
+        }
+
         @Override
         protected List<String> ddl() {
             return Collections.singletonList(


### PR DESCRIPTION
`PreAggregationITCase.LastValueAggregation` and `PreAggregationITCase.LastNonNullValueAggregation` need to make sure that the order of input data is determined. However the default parallelism of `FileStoreTableITCase` is 2, so the order of input data might change across tests.