### PR TITLE
[FLINK-29792] Fix unstable test FileStoreCommitTest which may stuck

### DIFF
--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreCommitTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreCommitTest.java
@@ -95,9 +95,9 @@ public class FileStoreCommitTest {
     @CsvSource({
         "false,NONE",
         "false,INPUT",
+        "false,FULL_COMPACTION",
         "true,NONE",
         "true,INPUT",
-        "false,FULL_COMPACTION",
         "true,FULL_COMPACTION"
     })
     public void testSingleCommitUser(boolean failing, String changelogProducer) throws Exception {
@@ -109,9 +109,9 @@ public class FileStoreCommitTest {
     @CsvSource({
         "false,NONE",
         "false,INPUT",
+        "false,FULL_COMPACTION",
         "true,NONE",
         "true,INPUT",
-        "false,FULL_COMPACTION",
         "true,FULL_COMPACTION"
     })
     public void testManyCommitUsersNoConflict(boolean failing, String changelogProducer)
@@ -126,9 +126,9 @@ public class FileStoreCommitTest {
     @CsvSource({
         "false,NONE",
         "false,INPUT",
+        "false,FULL_COMPACTION",
         "true,NONE",
         "true,INPUT",
-        "false,FULL_COMPACTION",
         "true,FULL_COMPACTION"
     })
     public void testManyCommitUsersWithConflict(boolean failing, String changelogProducer)

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
@@ -92,7 +92,7 @@ public class TestCommitThread extends Thread {
         }
 
         this.write = safeStore.newWrite();
-        this.commit = testStore.newCommit(UUID.randomUUID().toString());
+        this.commit = testStore.newCommit(UUID.randomUUID().toString()).withCreateEmptyCommit(true);
     }
 
     public List<KeyValue> getResult() {


### PR DESCRIPTION
`FileStoreCommitTest` may stuck because the `FileStoreCommit` in `TestCommitThread` does not commit APPEND snapshot when no new files are produced. In this case, if the following COMPACT snapshot conflicts with the current merge tree, the test will stuck.