### PR TITLE
[FLINK-29792] Fix unstable test FileStoreCommitTest which may stuck

### DIFF
--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
@@ -86,7 +86,7 @@ public class TestCommitThread extends Thread {
         }
 
         this.write = safeStore.newWrite();
-        this.commit = testStore.newCommit(UUID.randomUUID().toString());
+        this.commit = testStore.newCommit(UUID.randomUUID().toString()).withCreateEmptyCommit(true);
     }
 
     public List<KeyValue> getResult() {


### PR DESCRIPTION
(Cherry-picked from #341)

`FileStoreCommitTest` may stuck because the `FileStoreCommit` in `TestCommitThread` does not commit APPEND snapshot when no new files are produced. In this case, if the following COMPACT snapshot conflicts with the current merge tree, the test will stuck.