### PR TITLE
[FLINK-29823] Support to show schema of table snapshot

### DIFF
--- a/docs/content/docs/development/query-table.md
+++ b/docs/content/docs/development/query-table.md
@@ -126,3 +126,23 @@ SELECT * FROM MyTable$options;
 +------------------------+--------------------+
 1 rows in set
 ```
+
+## Table Snapshot Schema
+
+You can query table snapshot's schema with given snapshot id through Flink SQL,
+then you can query from the table snapshot according to the schema.
+
+```sql
+SHOW CREATE TABLE MyTable$snapshot$10;
+
+CREATE TABLE `my_catalog`.`default`.`MyTable$snapshot$10` (
+  `word` VARCHAR(1024) NOT NULL,
+  `cnt` BIGINT,
+  `sum_val` BIGINT,
+  CONSTRAINT `***` PRIMARY KEY (`word`) NOT ENFORCED
+) WITH (
+  'path' = 'file:/***/MyTable',
+  'snapshot' = 10
+)
+
+```

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/FlinkCatalog.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/FlinkCatalog.java
@@ -56,6 +56,7 @@ import java.util.Optional;
 
 import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
 import static org.apache.flink.table.store.CoreOptions.PATH;
+import static org.apache.flink.table.store.CoreOptions.SNAPSHOT;
 
 /** Catalog for table store. */
 public class FlinkCatalog extends AbstractCatalog {
@@ -156,12 +157,14 @@ public class FlinkCatalog extends AbstractCatalog {
         }
 
         if (table instanceof FileStoreTable) {
-            CatalogTable catalogTable =
-                    ((FileStoreTable) table).schema().toUpdateSchema().toCatalogTable();
+            FileStoreTable storeTable = (FileStoreTable) table;
+            CatalogTable catalogTable = storeTable.schema().toUpdateSchema().toCatalogTable();
             // add path to source and sink
-            catalogTable
-                    .getOptions()
-                    .put(PATH.key(), catalog.getTableLocation(tablePath).toString());
+            Map<String, String> options = catalogTable.getOptions();
+            options.put(PATH.key(), storeTable.location().toString());
+            if (storeTable.getSnapshotId() != null) {
+                options.put(SNAPSHOT.key(), String.valueOf(storeTable.getSnapshotId()));
+            }
             return catalogTable;
         } else {
             return new MetadataCatalogTable(table);

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
@@ -84,6 +84,12 @@ public class CoreOptions implements Serializable {
                     .noDefaultValue()
                     .withDescription("The file path of this table in the filesystem.");
 
+    public static final ConfigOption<Long> SNAPSHOT =
+            ConfigOptions.key("snapshot")
+                    .longType()
+                    .defaultValue(-1L)
+                    .withDescription("The snapshot id of the table, -1 means the latest snapshot.");
+
     public static final ConfigOption<String> FILE_FORMAT =
             ConfigOptions.key("file.format")
                     .stringType()

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/Catalog.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/Catalog.java
@@ -38,6 +38,8 @@ public interface Catalog extends AutoCloseable {
 
     String METADATA_TABLE_SPLITTER = "$";
 
+    String SNAPSHOT = "snapshot";
+
     /**
      * Get lock factory from catalog. Lock is used to support multiple concurrent writes on the
      * object store.

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AbstractFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AbstractFileStoreTable.java
@@ -25,17 +25,21 @@ import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
 import org.apache.flink.table.store.table.sink.TableCommit;
 
+import javax.annotation.Nullable;
+
 /** Abstract {@link FileStoreTable}. */
 public abstract class AbstractFileStoreTable implements FileStoreTable {
 
     private static final long serialVersionUID = 1L;
 
     private final Path path;
+    @Nullable private final Long snapshotId;
     protected final TableSchema tableSchema;
 
-    public AbstractFileStoreTable(Path path, TableSchema tableSchema) {
+    public AbstractFileStoreTable(Path path, TableSchema tableSchema, @Nullable Long snapshotId) {
         this.path = path;
         this.tableSchema = tableSchema;
+        this.snapshotId = snapshotId;
     }
 
     protected abstract FileStore<?> store();
@@ -63,5 +67,11 @@ public abstract class AbstractFileStoreTable implements FileStoreTable {
     @Override
     public TableCommit newCommit(String user) {
         return new TableCommit(store().newCommit(user), store().newExpire());
+    }
+
+    @Nullable
+    @Override
+    public Long getSnapshotId() {
+        return snapshotId;
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTable.java
@@ -51,8 +51,9 @@ public class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
 
     private final AppendOnlyFileStore store;
 
-    AppendOnlyFileStoreTable(Path path, SchemaManager schemaManager, TableSchema tableSchema) {
-        super(path, tableSchema);
+    AppendOnlyFileStoreTable(
+            Path path, SchemaManager schemaManager, TableSchema tableSchema, Long snapshotId) {
+        super(path, tableSchema, snapshotId);
         this.store =
                 new AppendOnlyFileStore(
                         schemaManager,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTable.java
@@ -55,8 +55,8 @@ public class ChangelogValueCountFileStoreTable extends AbstractFileStoreTable {
     private final KeyValueFileStore store;
 
     ChangelogValueCountFileStoreTable(
-            Path path, SchemaManager schemaManager, TableSchema tableSchema) {
-        super(path, tableSchema);
+            Path path, SchemaManager schemaManager, TableSchema tableSchema, Long snapshotId) {
+        super(path, tableSchema, snapshotId);
         RowType countType =
                 RowType.of(
                         new LogicalType[] {new BigIntType(false)}, new String[] {"_VALUE_COUNT"});

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
@@ -66,8 +66,8 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
     private final KeyValueFileStore store;
 
     ChangelogWithKeyFileStoreTable(
-            Path path, SchemaManager schemaManager, TableSchema tableSchema) {
-        super(path, tableSchema);
+            Path path, SchemaManager schemaManager, TableSchema tableSchema, Long snapshotId) {
+        super(path, tableSchema, snapshotId);
 
         RowType rowType = tableSchema.logicalRowType();
         Configuration conf = Configuration.fromMap(tableSchema.options());

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/FileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/FileStoreTable.java
@@ -27,6 +27,8 @@ import org.apache.flink.table.store.table.sink.TableWrite;
 import org.apache.flink.table.store.table.source.DataTableScan;
 import org.apache.flink.table.types.logical.RowType;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
 
 /**
@@ -64,4 +66,7 @@ public interface FileStoreTable extends Table, SupportsPartition, SupportsWrite 
     TableWrite newWrite();
 
     TableCommit newCommit(String user);
+
+    @Nullable
+    Long getSnapshotId();
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTableTest.java
@@ -251,6 +251,6 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                                 Collections.emptyList(),
                                 conf.toMap(),
                                 ""));
-        return new AppendOnlyFileStoreTable(tablePath, schemaManager, tableSchema);
+        return new AppendOnlyFileStoreTable(tablePath, schemaManager, tableSchema, null);
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTableTest.java
@@ -211,6 +211,6 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
                                 Collections.emptyList(),
                                 conf.toMap(),
                                 ""));
-        return new ChangelogValueCountFileStoreTable(tablePath, schemaManager, tableSchema);
+        return new ChangelogValueCountFileStoreTable(tablePath, schemaManager, tableSchema, null);
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTableTest.java
@@ -486,6 +486,6 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
                                 Arrays.asList("pt", "a"),
                                 conf.toMap(),
                                 ""));
-        return new ChangelogWithKeyFileStoreTable(tablePath, schemaManager, tableSchema);
+        return new ChangelogWithKeyFileStoreTable(tablePath, schemaManager, tableSchema, null);
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/WritePreemptMemoryTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/WritePreemptMemoryTest.java
@@ -107,6 +107,6 @@ public class WritePreemptMemoryTest extends FileStoreTableTestBase {
                                 Arrays.asList("pt", "a"),
                                 conf.toMap(),
                                 ""));
-        return new ChangelogWithKeyFileStoreTable(tablePath, schemaManager, schema);
+        return new ChangelogWithKeyFileStoreTable(tablePath, schemaManager, schema, null);
     }
 }


### PR DESCRIPTION
Currently we can only query the latest snapshot data from table store.  We need to support reading the data of the specified snapshot, in this way, we can read historical versions or compare data across versions as needed. This PR aims to support to get schema for table with given snapshot id as follows and `10` is the snapshot id:
`SHOW CREATE TABLE word_count$snapshot$10`

One can get the columns for table `word_count` with snapshot `10`, and then can build query on the snapshot.