### PR TITLE
[FLINK-29805] Fix incorrect snapshot filter when snapshots are committing too slow

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
@@ -52,10 +52,10 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
@@ -151,36 +151,20 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             return committableList;
         }
 
-        // if there is no previous snapshots then nothing should be filtered
-        Long latestSnapshotId = snapshotManager.latestSnapshotId();
-        if (latestSnapshotId == null) {
-            return committableList;
-        }
-
-        // check if a committable is already committed by its identifier
-        Map<Long, ManifestCommittable> identifiers = new LinkedHashMap<>();
-        for (ManifestCommittable committable : committableList) {
-            identifiers.put(committable.identifier(), committable);
-        }
-
-        for (long id = latestSnapshotId; id >= Snapshot.FIRST_SNAPSHOT_ID; id--) {
-            if (!snapshotManager.snapshotExists(id)) {
-                // snapshots before this are expired
-                break;
-            }
-            Snapshot snapshot = snapshotManager.snapshot(id);
-            if (commitUser.equals(snapshot.commitUser())) {
-                if (identifiers.containsKey(snapshot.commitIdentifier())) {
-                    identifiers.remove(snapshot.commitIdentifier());
-                } else {
-                    // early exit, because committableList must be the latest commits by this
-                    // commit user
-                    break;
+        Optional<Snapshot> latestSnapshot = snapshotManager.latestSnapshotOfUser(commitUser);
+        if (latestSnapshot.isPresent()) {
+            List<ManifestCommittable> result = new ArrayList<>();
+            for (ManifestCommittable committable : committableList) {
+                // if committable is newer than latest snapshot, then it hasn't been committed
+                if (committable.identifier() > latestSnapshot.get().commitIdentifier()) {
+                    result.add(committable);
                 }
             }
+            return result;
+        } else {
+            // if there is no previous snapshots then nothing should be filtered
+            return committableList;
         }
-
-        return new ArrayList<>(identifiers.values());
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreExpireImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreExpireImpl.java
@@ -32,7 +32,6 @@ import org.apache.flink.table.store.file.utils.SnapshotManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -100,12 +99,7 @@ public class FileStoreExpireImpl implements FileStoreExpire {
 
         long currentMillis = System.currentTimeMillis();
 
-        Long earliest;
-        try {
-            earliest = snapshotManager.findEarliest();
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to find earliest snapshot id", e);
-        }
+        Long earliest = snapshotManager.earliestSnapshotId();
         if (earliest == null) {
             return;
         }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/SnapshotManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/SnapshotManager.java
@@ -120,7 +120,7 @@ public class SnapshotManager {
         return Optional.empty();
     }
 
-    private Long findLatest() throws IOException {
+    private @Nullable Long findLatest() throws IOException {
         Path snapshotDir = snapshotDirectory();
         FileSystem fs = snapshotDir.getFileSystem();
         if (!fs.exists(snapshotDir)) {
@@ -139,7 +139,7 @@ public class SnapshotManager {
         return findByListFiles(Math::max);
     }
 
-    private Long findEarliest() throws IOException {
+    private @Nullable Long findEarliest() throws IOException {
         Path snapshotDir = snapshotDirectory();
         FileSystem fs = snapshotDir.getFileSystem();
         if (!fs.exists(snapshotDir)) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/SnapshotManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/SnapshotManager.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.store.file.utils;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.store.file.Snapshot;
+import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +30,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.function.BinaryOperator;
 
@@ -80,6 +82,14 @@ public class SnapshotManager {
         }
     }
 
+    public @Nullable Long earliestSnapshotId() {
+        try {
+            return findEarliest();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to find earliest snapshot id", e);
+        }
+    }
+
     public long snapshotCount() throws IOException {
         return listVersionedFiles(snapshotDirectory(), SNAPSHOT_PREFIX).count();
     }
@@ -90,7 +100,27 @@ public class SnapshotManager {
                 .iterator();
     }
 
-    public Long findLatest() throws IOException {
+    public Optional<Snapshot> latestSnapshotOfUser(String user) {
+        Long latestId = latestSnapshotId();
+        if (latestId == null) {
+            return Optional.empty();
+        }
+
+        long earliestId =
+                Preconditions.checkNotNull(
+                        earliestSnapshotId(),
+                        "Latest snapshot id is not null, but earliest snapshot id is null. "
+                                + "This is unexpected.");
+        for (long id = latestId; id >= earliestId; id--) {
+            Snapshot snapshot = snapshot(id);
+            if (user.equals(snapshot.commitUser())) {
+                return Optional.of(snapshot);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Long findLatest() throws IOException {
         Path snapshotDir = snapshotDirectory();
         FileSystem fs = snapshotDir.getFileSystem();
         if (!fs.exists(snapshotDir)) {
@@ -109,7 +139,7 @@ public class SnapshotManager {
         return findByListFiles(Math::max);
     }
 
-    public Long findEarliest() throws IOException {
+    private Long findEarliest() throws IOException {
         Path snapshotDir = snapshotDirectory();
         FileSystem fs = snapshotDir.getFileSystem();
         if (!fs.exists(snapshotDir)) {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -372,7 +372,7 @@ public class TestFileStore extends KeyValueFileStore {
         if (actualFiles.remove(latest)) {
             long latestId = snapshotManager.readHint(SnapshotManager.LATEST);
             latest.getFileSystem().delete(latest, false);
-            assertThat(latestId <= snapshotManager.earliestSnapshotId()).isTrue();
+            assertThat(latestId <= snapshotManager.latestSnapshotId()).isTrue();
         }
         actualFiles.remove(latest);
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -367,12 +367,12 @@ public class TestFileStore extends KeyValueFileStore {
         if (actualFiles.remove(earliest)) {
             long earliestId = snapshotManager.readHint(SnapshotManager.EARLIEST);
             earliest.getFileSystem().delete(earliest, false);
-            assertThat(earliestId <= snapshotManager.findEarliest()).isTrue();
+            assertThat(earliestId <= snapshotManager.earliestSnapshotId()).isTrue();
         }
         if (actualFiles.remove(latest)) {
             long latestId = snapshotManager.readHint(SnapshotManager.LATEST);
             latest.getFileSystem().delete(latest, false);
-            assertThat(latestId <= snapshotManager.findLatest()).isTrue();
+            assertThat(latestId <= snapshotManager.earliestSnapshotId()).isTrue();
         }
         actualFiles.remove(latest);
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreCommitTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreCommitTest.java
@@ -50,6 +50,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -148,12 +149,12 @@ public class FileStoreCommitTest {
 
         assertThat(latest.getFileSystem().exists(latest)).isTrue();
 
-        Long latestId = snapshotManager.findLatest();
+        Long latestId = snapshotManager.latestSnapshotId();
 
         // remove latest hint file
         latest.getFileSystem().delete(latest, false);
 
-        assertThat(snapshotManager.findLatest()).isEqualTo(latestId);
+        assertThat(snapshotManager.latestSnapshotId()).isEqualTo(latestId);
     }
 
     @Test
@@ -167,6 +168,31 @@ public class FileStoreCommitTest {
         // this test succeeds if this call does not fail
         store.newCommit(UUID.randomUUID().toString())
                 .filterCommitted(Collections.singletonList(new ManifestCommittable(999)));
+    }
+
+    @Test
+    public void testFilterAllCommits() throws Exception {
+        testRandomConcurrentNoConflict(1, false, CoreOptions.ChangelogProducer.NONE);
+        TestFileStore store = createStore(false);
+        SnapshotManager snapshotManager = store.snapshotManager();
+        long latestSnapshotId = snapshotManager.latestSnapshotId();
+
+        LinkedHashSet<Long> commitIdentifiers = new LinkedHashSet<>();
+        String user = "";
+        for (long id = Snapshot.FIRST_SNAPSHOT_ID; id <= latestSnapshotId; id++) {
+            Snapshot snapshot = snapshotManager.snapshot(id);
+            commitIdentifiers.add(snapshot.commitIdentifier());
+            user = snapshot.commitUser();
+        }
+
+        // all commit identifiers should be filtered out
+        List<ManifestCommittable> remaining =
+                store.newCommit(user)
+                        .filterCommitted(
+                                commitIdentifiers.stream()
+                                        .map(ManifestCommittable::new)
+                                        .collect(Collectors.toList()));
+        assertThat(remaining).isEmpty();
     }
 
     protected void testRandomConcurrentNoConflict(
@@ -431,7 +457,7 @@ public class FileStoreCommitTest {
                 false,
                 null,
                 (commit, committable) -> commit.commit(committable, Collections.emptyMap()));
-        assertThat(store.snapshotManager().findLatest()).isEqualTo(snapshot.id());
+        assertThat(store.snapshotManager().latestSnapshotId()).isEqualTo(snapshot.id());
 
         // commit empty new files
         store.commitDataImpl(
@@ -444,7 +470,7 @@ public class FileStoreCommitTest {
                     commit.withCreateEmptyCommit(true);
                     commit.commit(committable, Collections.emptyMap());
                 });
-        assertThat(store.snapshotManager().findLatest()).isEqualTo(snapshot.id() + 1);
+        assertThat(store.snapshotManager().latestSnapshotId()).isEqualTo(snapshot.id() + 1);
     }
 
     @Test

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreExpireTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreExpireTest.java
@@ -233,12 +233,12 @@ public class FileStoreExpireTest {
 
         assertThat(earliest.getFileSystem().exists(earliest)).isTrue();
 
-        Long earliestId = snapshotManager.findEarliest();
+        Long earliestId = snapshotManager.earliestSnapshotId();
 
         // remove earliest hint file
         earliest.getFileSystem().delete(earliest, false);
 
-        assertThat(snapshotManager.findEarliest()).isEqualTo(earliestId);
+        assertThat(snapshotManager.earliestSnapshotId()).isEqualTo(earliestId);
     }
 
     @Test


### PR DESCRIPTION
Table Store sink continuously fails with "Trying to add file which is already added" when snapshot committing is slow.

This is due to a bug in `FileStoreCommitImpl#filterCommitted`. When this method finds an identifier, it removes the identifier from a map. However different snapshots may have the same identifier (for example an APPEND commit and the following COMPACT commit will have the same identifier), so we need to use another set to check for identifiers.

When snapshot committing is fast there is at most 1 identifier to check after the job restarts, so nothing happens. However when snapshot committing is slow, there will be multiple identifiers to check and some identifiers will be mistakenly kept.