### PR TITLE
[FLINK-29876] Explicitly throw exception from Table Store sink when unaligned checkpoint is enabled or at least once checkpoint mode is used

### DIFF
--- a/docs/content/docs/development/write-table.md
+++ b/docs/content/docs/development/write-table.md
@@ -41,7 +41,7 @@ column_list:
 __IMPORTANT:__ 
 - Checkpointing needs to be enabled when writing to the Table Store in STREAMING mode.
 - `execution.checkpointing.unaligned=true` is not supported when writing to the Table Store in STREAMING mode.
-- `execution.checkpointing.mode=AT_LEAST_ONCE` is not supported when writing to the Table Store in STREAMING mode.
+- `execution.checkpointing.mode=at-least-once` is not supported when writing to the Table Store in STREAMING mode.
 {{< /hint >}}
 
 ## Parallelism

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/CatalogITCaseBase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/CatalogITCaseBase.java
@@ -43,7 +43,9 @@ public abstract class CatalogITCaseBase extends AbstractTestBase {
 
     @Before
     public void before() throws IOException {
-        tEnv = TableEnvironment.create(EnvironmentSettings.newInstance().inBatchMode().build());
+        tEnv =
+                TableEnvironmentTestUtils.create(
+                        EnvironmentSettings.newInstance().inBatchMode().build());
         tEnv.executeSql(
                 String.format(
                         "CREATE CATALOG TABLE_STORE WITH ("

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/CompositePkAndMultiPartitionedTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/CompositePkAndMultiPartitionedTableITCase.java
@@ -87,7 +87,7 @@ public class CompositePkAndMultiPartitionedTableITCase extends ReadWriteTableTes
 
         // test streaming read
         final StreamTableEnvironment streamTableEnv =
-                StreamTableEnvironment.create(buildStreamEnv());
+                TableEnvironmentTestUtils.create(buildStreamEnv());
         registerTable(streamTableEnv, managedTable);
         BlockingIterator<Row, Row> streamIter =
                 collectAndCheck(
@@ -273,7 +273,7 @@ public class CompositePkAndMultiPartitionedTableITCase extends ReadWriteTableTes
 
         // test streaming read
         final StreamTableEnvironment streamTableEnv =
-                StreamTableEnvironment.create(buildStreamEnv());
+                TableEnvironmentTestUtils.create(buildStreamEnv());
         registerTable(streamTableEnv, managedTable);
         BlockingIterator<Row, Row> streamIter =
                 collectAndCheck(
@@ -402,7 +402,7 @@ public class CompositePkAndMultiPartitionedTableITCase extends ReadWriteTableTes
 
         // test streaming read
         final StreamTableEnvironment streamTableEnv =
-                StreamTableEnvironment.create(buildStreamEnv());
+                TableEnvironmentTestUtils.create(buildStreamEnv());
         registerTable(streamTableEnv, managedTable);
         BlockingIterator<Row, Row> streamIter =
                 collectAndCheck(
@@ -495,7 +495,7 @@ public class CompositePkAndMultiPartitionedTableITCase extends ReadWriteTableTes
 
         // test streaming read
         final StreamTableEnvironment streamTableEnv =
-                StreamTableEnvironment.create(buildStreamEnv());
+                TableEnvironmentTestUtils.create(buildStreamEnv());
         registerTable(streamTableEnv, managedTable);
         BlockingIterator<Row, Row> streamIter =
                 collectAndCheck(
@@ -598,7 +598,7 @@ public class CompositePkAndMultiPartitionedTableITCase extends ReadWriteTableTes
 
         // test streaming read
         final StreamTableEnvironment streamTableEnv =
-                StreamTableEnvironment.create(buildStreamEnv());
+                TableEnvironmentTestUtils.create(buildStreamEnv());
         registerTable(streamTableEnv, managedTable);
         BlockingIterator<Row, Row> streamIter =
                 collectAndCheck(
@@ -737,7 +737,8 @@ public class CompositePkAndMultiPartitionedTableITCase extends ReadWriteTableTes
 
         // batch read to check data refresh
         final StreamTableEnvironment batchTableEnv =
-                StreamTableEnvironment.create(buildBatchEnv(), EnvironmentSettings.inBatchMode());
+                TableEnvironmentTestUtils.create(
+                        buildBatchEnv(), EnvironmentSettings.inBatchMode());
         registerTable(batchTableEnv, managedTable);
         collectAndCheck(
                 batchTableEnv,
@@ -842,7 +843,8 @@ public class CompositePkAndMultiPartitionedTableITCase extends ReadWriteTableTes
 
         // batch read to check data refresh
         final StreamTableEnvironment batchTableEnv =
-                StreamTableEnvironment.create(buildBatchEnv(), EnvironmentSettings.inBatchMode());
+                TableEnvironmentTestUtils.create(
+                        buildBatchEnv(), EnvironmentSettings.inBatchMode());
         registerTable(batchTableEnv, managedTable);
         collectAndCheck(
                 batchTableEnv,
@@ -923,7 +925,8 @@ public class CompositePkAndMultiPartitionedTableITCase extends ReadWriteTableTes
 
         // batch read to check data refresh
         final StreamTableEnvironment batchTableEnv =
-                StreamTableEnvironment.create(buildBatchEnv(), EnvironmentSettings.inBatchMode());
+                TableEnvironmentTestUtils.create(
+                        buildBatchEnv(), EnvironmentSettings.inBatchMode());
         registerTable(batchTableEnv, managedTable);
         collectAndCheck(
                 batchTableEnv,

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileStoreTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileStoreTableITCase.java
@@ -65,8 +65,12 @@ public abstract class FileStoreTableITCase extends AbstractTestBase {
 
     @Before
     public void before() throws IOException {
-        bEnv = TableEnvironment.create(EnvironmentSettings.newInstance().inBatchMode().build());
-        sEnv = TableEnvironment.create(EnvironmentSettings.newInstance().inStreamingMode().build());
+        bEnv =
+                TableEnvironmentTestUtils.create(
+                        EnvironmentSettings.newInstance().inBatchMode().build());
+        sEnv =
+                TableEnvironmentTestUtils.create(
+                        EnvironmentSettings.newInstance().inStreamingMode().build());
         sEnv.getConfig().getConfiguration().set(CHECKPOINTING_INTERVAL, Duration.ofMillis(100));
         path = TEMPORARY_FOLDER.newFolder().toURI().toString();
         prepareConfiguration(bEnv, path);

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/LookupJoinITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/LookupJoinITCase.java
@@ -42,7 +42,9 @@ public class LookupJoinITCase extends AbstractTestBase {
 
     @Before
     public void before() throws Exception {
-        env = TableEnvironment.create(EnvironmentSettings.newInstance().inStreamingMode().build());
+        env =
+                TableEnvironmentTestUtils.create(
+                        EnvironmentSettings.newInstance().inStreamingMode().build());
         env.getConfig().getConfiguration().set(CHECKPOINTING_INTERVAL, Duration.ofMillis(100));
         env.getConfig()
                 .getConfiguration()

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/MappingTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/MappingTableITCase.java
@@ -44,7 +44,9 @@ public class MappingTableITCase extends AbstractTestBase {
 
     @Before
     public void before() throws IOException {
-        tEnv = TableEnvironment.create(EnvironmentSettings.newInstance().inBatchMode().build());
+        tEnv =
+                TableEnvironmentTestUtils.create(
+                        EnvironmentSettings.newInstance().inBatchMode().build());
         path = TEMPORARY_FOLDER.newFolder().toURI().toString();
     }
 

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ReadWriteTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ReadWriteTableITCase.java
@@ -92,7 +92,7 @@ public class ReadWriteTableITCase extends ReadWriteTableTestBase {
 
         // test streaming read
         final StreamTableEnvironment streamTableEnv =
-                StreamTableEnvironment.create(buildStreamEnv());
+                TableEnvironmentTestUtils.create(buildStreamEnv());
         registerTable(streamTableEnv, managedTable);
         BlockingIterator<Row, Row> streamIter =
                 collectAndCheck(
@@ -211,7 +211,7 @@ public class ReadWriteTableITCase extends ReadWriteTableTestBase {
 
         // test streaming read
         final StreamTableEnvironment streamTableEnv =
-                StreamTableEnvironment.create(buildStreamEnv());
+                TableEnvironmentTestUtils.create(buildStreamEnv());
         registerTable(streamTableEnv, managedTable);
         collectAndCheck(
                         streamTableEnv,
@@ -428,7 +428,8 @@ public class ReadWriteTableITCase extends ReadWriteTableTestBase {
 
         // batch read to check data refresh
         final StreamTableEnvironment batchTableEnv =
-                StreamTableEnvironment.create(buildBatchEnv(), EnvironmentSettings.inBatchMode());
+                TableEnvironmentTestUtils.create(
+                        buildBatchEnv(), EnvironmentSettings.inBatchMode());
         registerTable(batchTableEnv, managedTable);
         collectAndCheck(
                 batchTableEnv,
@@ -1207,7 +1208,7 @@ public class ReadWriteTableITCase extends ReadWriteTableTestBase {
     @Test
     public void testQueryContainsDefaultFieldName() throws Exception {
         rootPath = TEMPORARY_FOLDER.newFolder().getPath();
-        tEnv = StreamTableEnvironment.create(buildBatchEnv(), EnvironmentSettings.inBatchMode());
+        tEnv = TableEnvironmentTestUtils.create(buildBatchEnv(), EnvironmentSettings.inBatchMode());
         String id = registerData(Collections.singletonList(changelogRow("+I", 1, "abc")));
         tEnv.executeSql(
                 String.format(
@@ -1233,7 +1234,7 @@ public class ReadWriteTableITCase extends ReadWriteTableTestBase {
     @Test
     public void testLike() throws Exception {
         rootPath = TEMPORARY_FOLDER.newFolder().getPath();
-        tEnv = StreamTableEnvironment.create(buildBatchEnv(), EnvironmentSettings.inBatchMode());
+        tEnv = TableEnvironmentTestUtils.create(buildBatchEnv(), EnvironmentSettings.inBatchMode());
         List<Row> input =
                 Arrays.asList(
                         changelogRow("+I", 1, "test_1"),
@@ -1334,7 +1335,7 @@ public class ReadWriteTableITCase extends ReadWriteTableTestBase {
     @Test
     public void testIn() throws Exception {
         rootPath = TEMPORARY_FOLDER.newFolder().getPath();
-        tEnv = StreamTableEnvironment.create(buildBatchEnv(), EnvironmentSettings.inBatchMode());
+        tEnv = TableEnvironmentTestUtils.create(buildBatchEnv(), EnvironmentSettings.inBatchMode());
         List<Row> input =
                 Arrays.asList(
                         changelogRow("+I", 1, "aaa"),
@@ -1415,7 +1416,7 @@ public class ReadWriteTableITCase extends ReadWriteTableTestBase {
     @Test
     public void testChangeBucketNumber() throws Exception {
         rootPath = TEMPORARY_FOLDER.newFolder().getPath();
-        tEnv = StreamTableEnvironment.create(buildBatchEnv(), EnvironmentSettings.inBatchMode());
+        tEnv = TableEnvironmentTestUtils.create(buildBatchEnv(), EnvironmentSettings.inBatchMode());
         tEnv.executeSql(
                 String.format(
                         "CREATE TABLE IF NOT EXISTS rates (\n"
@@ -1483,7 +1484,7 @@ public class ReadWriteTableITCase extends ReadWriteTableTestBase {
     public void testStreamingInsertOverwrite() throws Exception {
         rootPath = TEMPORARY_FOLDER.newFolder().getPath();
         tEnv =
-                StreamTableEnvironment.create(
+                TableEnvironmentTestUtils.create(
                         buildStreamEnv(), EnvironmentSettings.inStreamingMode());
         tEnv.executeSql(
                 String.format(

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ReadWriteTableTestBase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ReadWriteTableTestBase.java
@@ -313,7 +313,7 @@ public class ReadWriteTableTestBase extends KafkaTableTestBase {
             env = buildBatchEnv();
             builder.inBatchMode();
         }
-        tEnv = StreamTableEnvironment.create(env, builder.build());
+        tEnv = TableEnvironmentTestUtils.create(env, builder.build());
         tEnv.executeSql(helperTableDdl);
 
         String managedTableDdl;
@@ -406,7 +406,8 @@ public class ReadWriteTableTestBase extends KafkaTableTestBase {
 
     protected void prepareEnvAndOverwrite(String managedTable, String query) throws Exception {
         final StreamTableEnvironment batchEnv =
-                StreamTableEnvironment.create(buildBatchEnv(), EnvironmentSettings.inBatchMode());
+                TableEnvironmentTestUtils.create(
+                        buildBatchEnv(), EnvironmentSettings.inBatchMode());
         registerTable(batchEnv, managedTable);
         batchEnv.executeSql(query).await();
     }

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/StreamingWarehouseITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/StreamingWarehouseITCase.java
@@ -36,9 +36,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class StreamingWarehouseITCase extends ReadWriteTableTestBase {
 
     private final StreamTableEnvironment streamTableEnv =
-            StreamTableEnvironment.create(buildStreamEnv(1));
+            TableEnvironmentTestUtils.create(buildStreamEnv(1));
     private final StreamTableEnvironment batchTableEnv =
-            StreamTableEnvironment.create(buildBatchEnv(1), EnvironmentSettings.inBatchMode());
+            TableEnvironmentTestUtils.create(buildBatchEnv(1), EnvironmentSettings.inBatchMode());
 
     @Test
     public void testUserStory() throws Exception {

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableEnvironmentTestUtils.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableEnvironmentTestUtils.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector;
+
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+
+/** Utility class for creating {@link TableEnvironment} in tests. */
+public class TableEnvironmentTestUtils {
+
+    public static TableEnvironment create(EnvironmentSettings settings) {
+        TableEnvironment tEnv = TableEnvironment.create(settings);
+        disableUnalignedCheckpoint(tEnv);
+        return tEnv;
+    }
+
+    public static StreamTableEnvironment create(StreamExecutionEnvironment env) {
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+        disableUnalignedCheckpoint(tEnv);
+        return tEnv;
+    }
+
+    public static StreamTableEnvironment create(
+            StreamExecutionEnvironment env, EnvironmentSettings settings) {
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, settings);
+        disableUnalignedCheckpoint(tEnv);
+        return tEnv;
+    }
+
+    private static void disableUnalignedCheckpoint(TableEnvironment tEnv) {
+        tEnv.getConfig()
+                .getConfiguration()
+                .set(ExecutionCheckpointingOptions.ENABLE_UNALIGNED, false);
+    }
+}

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreTestBase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/TableStoreTestBase.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Schema;
-import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.internal.TableEnvironmentImpl;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.Column;
@@ -91,7 +90,7 @@ public abstract class TableStoreTestBase extends KafkaTableTestBase {
             env.enableCheckpointing(100);
             builder.inStreamingMode();
         }
-        tEnv = StreamTableEnvironment.create(env, builder.build());
+        tEnv = TableEnvironmentTestUtils.create(env, builder.build());
         ((TableEnvironmentImpl) tEnv)
                 .getCatalogManager()
                 .registerCatalog(

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/SinkSavepointITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/SinkSavepointITCase.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.store.connector.TableEnvironmentTestUtils;
 import org.apache.flink.table.store.file.utils.FailingAtomicRenameFileSystem;
 import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Row;
@@ -133,7 +134,7 @@ public class SinkSavepointITCase extends AbstractTestBase {
 
         EnvironmentSettings settings = EnvironmentSettings.newInstance().inStreamingMode().build();
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(conf);
-        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, settings);
+        StreamTableEnvironment tEnv = TableEnvironmentTestUtils.create(env, settings);
         tEnv.getConfig()
                 .getConfiguration()
                 .set(ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL, Duration.ofMillis(500));
@@ -205,7 +206,7 @@ public class SinkSavepointITCase extends AbstractTestBase {
 
     private void checkRecoverFromSavepointResult(String failingPath) throws Exception {
         EnvironmentSettings settings = EnvironmentSettings.newInstance().inBatchMode().build();
-        TableEnvironment tEnv = TableEnvironment.create(settings);
+        TableEnvironment tEnv = TableEnvironmentTestUtils.create(settings);
         // no failure should occur when checking for answer
         FailingAtomicRenameFileSystem.reset(failingName, 0, 1);
 

--- a/flink-table-store-kafka/src/test/java/org/apache/flink/table/store/kafka/KafkaTableTestBase.java
+++ b/flink-table-store-kafka/src/test/java/org/apache/flink/table/store/kafka/KafkaTableTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.store.kafka;
 
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.test.util.AbstractTestBase;
@@ -95,6 +96,9 @@ public abstract class KafkaTableTestBase extends AbstractTestBase {
         env = StreamExecutionEnvironment.getExecutionEnvironment();
         tEnv = StreamTableEnvironment.create(env);
         env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
+        tEnv.getConfig()
+                .getConfiguration()
+                .set(ExecutionCheckpointingOptions.ENABLE_UNALIGNED, false);
 
         // Probe Kafka broker status per 30 seconds
         scheduleTimeoutLogger(


### PR DESCRIPTION
Currently table store sink does not support unaligned checkpoint or at least once checkpoint mode, but no exception is explicitly thrown. We should throw exception so that users can change their configurations.