### PR TITLE
[FLINK-29840] Fix bug that old record may overwrite new record in Table Store when snapshot committing is slow

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StateUtils.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StateUtils.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector.sink;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Utility class for sink state manipulation. */
+public class StateUtils {
+
+    public static @Nullable <T> T getSingleValueFromState(
+            StateInitializationContext context,
+            String stateName,
+            Class<T> valueClass,
+            T defaultValue)
+            throws Exception {
+        ListState<T> state =
+                context.getOperatorStateStore()
+                        .getListState(new ListStateDescriptor<>(stateName, valueClass));
+
+        List<T> values = new ArrayList<>();
+        state.get().forEach(values::add);
+
+        if (context.isRestored()) {
+            // Values may contain 0 element or more than 1 element.
+            //
+            // Let's say a vertex has 3 tasks (A, B and C). If A is finished while B and C are still
+            // running, then states of A will be divided between B and C. That is, if the job
+            // restarts, state of vertex A will be empty, and state of vertex B and C may contain
+            // more than 1 element.
+            if (values.isEmpty()) {
+                return null;
+            }
+
+            // As we're storing the same value for each task, we hereby check if all elements are
+            // equal.
+            for (int i = 1; i < values.size(); i++) {
+                Preconditions.checkState(
+                        values.get(i).equals(values.get(i - 1)),
+                        "Values in list state are not the same. This is unexpected.");
+            }
+        } else {
+            Preconditions.checkState(
+                    values.isEmpty(),
+                    "Expecting 0 value for a fresh state but found "
+                            + values.size()
+                            + ". This is unexpected.");
+            state.add(defaultValue);
+            values.add(defaultValue);
+        }
+
+        return values.get(0);
+    }
+}

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreWriteOperator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreWriteOperator.java
@@ -68,7 +68,7 @@ public class StoreWriteOperator extends PrepareCommitOperator {
     /** We listen to this ourselves because we don't have an {@link InternalTimerService}. */
     private long currentWatermark = Long.MIN_VALUE;
 
-    private TableWrite write;
+    @Nullable private TableWrite write;
 
     @Nullable private LogWriteCallback logCallback;
 

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreWriteOperator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreWriteOperator.java
@@ -52,6 +52,13 @@ public class StoreWriteOperator extends PrepareCommitOperator {
 
     private final FileStoreTable table;
 
+    /**
+     * This commitUser is valid only for new jobs. After the job starts, this commitUser will be
+     * recorded into the states of write and commit operators. When the job restarts, commitUser
+     * will be recovered from states and this value is ignored.
+     */
+    private final String initialCommitUser;
+
     @Nullable private final Map<String, String> overwritePartition;
 
     @Nullable private final LogSinkFunction logSinkFunction;
@@ -67,9 +74,11 @@ public class StoreWriteOperator extends PrepareCommitOperator {
 
     public StoreWriteOperator(
             FileStoreTable table,
+            String initialCommitUser,
             @Nullable Map<String, String> overwritePartition,
             @Nullable LogSinkFunction logSinkFunction) {
         this.table = table;
+        this.initialCommitUser = initialCommitUser;
         this.overwritePartition = overwritePartition;
         this.logSinkFunction = logSinkFunction;
     }
@@ -88,18 +97,31 @@ public class StoreWriteOperator extends PrepareCommitOperator {
     @Override
     public void initializeState(StateInitializationContext context) throws Exception {
         super.initializeState(context);
+
         if (logSinkFunction != null) {
             StreamingFunctionUtils.restoreFunctionState(context, logSinkFunction);
+        }
+
+        // each job can only have one user name and this name must be consistent across restarts
+        // we cannot use job id as commit user name here because user may change job id by creating
+        // a savepoint, stop the job and then resume from savepoint
+        String commitUser =
+                StateUtils.getSingleValueFromState(
+                        context, "commit_user_state", String.class, initialCommitUser);
+        // see comments of StateUtils.getSingleValueFromState for why commitUser may be null
+        if (commitUser == null) {
+            this.write = null;
+        } else {
+            this.write =
+                    table.newWrite(commitUser)
+                            .withIOManager(getContainingTask().getEnvironment().getIOManager())
+                            .withOverwrite(overwritePartition != null);
         }
     }
 
     @Override
     public void open() throws Exception {
         super.open();
-        this.write =
-                table.newWrite()
-                        .withIOManager(getContainingTask().getEnvironment().getIOManager())
-                        .withOverwrite(overwritePartition != null);
         this.sinkContext = new SimpleContext(getProcessingTimeService());
         if (logSinkFunction != null) {
             FunctionUtils.openFunction(logSinkFunction, new Configuration());
@@ -187,12 +209,15 @@ public class StoreWriteOperator extends PrepareCommitOperator {
     protected List<Committable> prepareCommit(boolean endOfInput, long checkpointId)
             throws IOException {
         List<Committable> committables = new ArrayList<>();
-        try {
-            for (FileCommittable committable : write.prepareCommit(endOfInput)) {
-                committables.add(new Committable(checkpointId, Committable.Kind.FILE, committable));
+        if (write != null) {
+            try {
+                for (FileCommittable committable : write.prepareCommit(endOfInput, checkpointId)) {
+                    committables.add(
+                            new Committable(checkpointId, Committable.Kind.FILE, committable));
+                }
+            } catch (Exception e) {
+                throw new IOException(e);
             }
-        } catch (Exception e) {
-            throw new IOException(e);
         }
 
         if (logCallback != null) {

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ChangelogWithKeyFileStoreTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ChangelogWithKeyFileStoreTableITCase.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector;
+
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.store.file.utils.FailingAtomicRenameFileSystem;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL;
+
+/** Tests for changelog table with primary keys. */
+public class ChangelogWithKeyFileStoreTableITCase extends AbstractTestBase {
+
+    private String path;
+    private String failingName;
+
+    @Before
+    public void before() throws IOException {
+        path = TEMPORARY_FOLDER.newFolder().toPath().toString();
+        // for failure tests
+        failingName = UUID.randomUUID().toString();
+    }
+
+    @Test
+    public void testBatchRandom() throws Exception {
+        TableEnvironment bEnv =
+                TableEnvironmentTestUtils.create(
+                        EnvironmentSettings.newInstance().inBatchMode().build());
+        testRandom(bEnv, false);
+    }
+
+    @Test
+    public void testStreamingRandom() throws Exception {
+        TableEnvironment sEnv =
+                TableEnvironmentTestUtils.create(
+                        EnvironmentSettings.newInstance().inStreamingMode().build());
+        // set checkpoint interval to a random number to emulate different speed of commit
+        sEnv.getConfig()
+                .getConfiguration()
+                .set(
+                        CHECKPOINTING_INTERVAL,
+                        Duration.ofMillis(ThreadLocalRandom.current().nextInt(900) + 100));
+        testRandom(sEnv, ThreadLocalRandom.current().nextBoolean());
+    }
+
+    /**
+     * Randomly update {@code numParts} partitions and {@code numKeys} keys for about {@code limit}
+     * records. For the final {@code numParts * numKeys} records, keys are updated to some specific
+     * values for result checking.
+     */
+    private void testRandom(TableEnvironment tEnv, boolean enableFailure) throws Exception {
+        int numParts = 4;
+        int numKeys = 64;
+        int numValues = 1024;
+        int limit = 10000;
+
+        String failingPath = FailingAtomicRenameFileSystem.getFailingPath(failingName, path);
+
+        // no failure when creating catalog and table
+        FailingAtomicRenameFileSystem.reset(failingName, 0, 1);
+        tEnv.executeSql(
+                String.format(
+                        "CREATE CATALOG testCatalog WITH ('type'='table-store', 'warehouse'='%s')",
+                        failingPath));
+        tEnv.executeSql("USE CATALOG testCatalog");
+        tEnv.executeSql(
+                "CREATE TABLE T("
+                        + "  pt STRING,"
+                        + "  k INT,"
+                        + "  v1 BIGINT,"
+                        + "  v2 STRING,"
+                        + "  PRIMARY KEY (pt, k) NOT ENFORCED"
+                        + ") PARTITIONED BY (pt) WITH ("
+                        + "  'bucket' = '4'"
+                        + ")");
+
+        // input data must be strictly ordered
+        tEnv.getConfig()
+                .getConfiguration()
+                .set(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 1);
+        tEnv.executeSql(
+                        "CREATE TABLE `default_catalog`.`default_database`.`S` ("
+                                + "  i INT"
+                                + ") WITH ("
+                                + "  'connector' = 'datagen',"
+                                + "  'fields.i.kind' = 'sequence',"
+                                + "  'fields.i.start' = '0',"
+                                + "  'fields.i.end' = '"
+                                + (limit + numParts * numKeys - 1)
+                                + "',"
+                                + "  'number-of-rows' = '"
+                                + (limit + numParts * numKeys)
+                                + "',"
+                                + "  'rows-per-second' = '"
+                                + (limit / 5 + ThreadLocalRandom.current().nextInt(limit / 10))
+                                + "'"
+                                + ")")
+                .await();
+
+        // for the last `numParts * numKeys` records, we update every key to a specific value
+        String ptSql =
+                String.format(
+                        "IF(i >= %d, CAST((i - %d) / %d AS STRING), CAST(CAST(FLOOR(RAND() * %d) AS INT) AS STRING)) AS pt",
+                        limit, limit, numKeys, numParts);
+        String kSql =
+                String.format(
+                        "IF(i >= %d, MOD(i - %d, %d), CAST(FLOOR(RAND() * %d) AS INT)) AS k",
+                        limit, limit, numKeys, numKeys);
+        String v1Sql =
+                String.format(
+                        "IF(i >= %d, i, CAST(FLOOR(RAND() * %d) AS BIGINT)) AS v1",
+                        limit, numValues);
+        String v2Sql = "CAST(i AS STRING) || '.str' AS v2";
+        tEnv.executeSql(
+                String.format(
+                        "CREATE TEMPORARY VIEW myView AS SELECT %s, %s, %s, %s FROM `default_catalog`.`default_database`.`S`",
+                        ptSql, kSql, v1Sql, v2Sql));
+
+        // run test SQL
+        if (enableFailure) {
+            FailingAtomicRenameFileSystem.reset(failingName, 100, 1000);
+        }
+        tEnv.executeSql(
+                        "INSERT INTO T /*+ OPTIONS('sink.parallelism' = '2') */ SELECT * FROM myView")
+                .await();
+
+        // check for result
+        TableEnvironment bEnv =
+                TableEnvironmentTestUtils.create(
+                        EnvironmentSettings.newInstance().inBatchMode().build());
+        bEnv.executeSql(
+                String.format(
+                        "CREATE CATALOG testCatalog WITH ('type'='table-store', 'warehouse'='%s')",
+                        path));
+        bEnv.executeSql("USE CATALOG testCatalog");
+        Map<String, String> actual = new HashMap<>();
+        try (CloseableIterator<Row> it = bEnv.executeSql("SELECT * FROM T").collect()) {
+            while (it.hasNext()) {
+                Row row = it.next();
+                String key = row.getField(0) + "|" + row.getField(1);
+                String value = row.getField(2) + "|" + row.getField(3);
+                actual.put(key, value);
+            }
+        }
+
+        Assert.assertEquals(numParts * numKeys, actual.size());
+        for (int i = 0; i < numParts; i++) {
+            for (int j = 0; j < numKeys; j++) {
+                String key = i + "|" + j;
+                int x = limit + i * numKeys + j;
+                String expectedValue = x + "|" + x + ".str";
+                Assert.assertEquals(expectedValue, actual.get(key));
+            }
+        }
+    }
+}

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ChangelogWithKeyFileStoreTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ChangelogWithKeyFileStoreTableITCase.java
@@ -151,9 +151,11 @@ public class ChangelogWithKeyFileStoreTableITCase extends AbstractTestBase {
         if (enableFailure) {
             FailingAtomicRenameFileSystem.reset(failingName, 100, 1000);
         }
-        tEnv.executeSql(
-                        "INSERT INTO T /*+ OPTIONS('sink.parallelism' = '2') */ SELECT * FROM myView")
-                .await();
+        FailingAtomicRenameFileSystem.retryArtificialException(
+                () ->
+                        tEnv.executeSql(
+                                        "INSERT INTO T /*+ OPTIONS('sink.parallelism' = '2') */ SELECT * FROM myView")
+                                .await());
 
         // check for result
         TableEnvironment bEnv =

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/TestChangelogDataReadWrite.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/TestChangelogDataReadWrite.java
@@ -53,6 +53,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 
@@ -73,6 +74,7 @@ public class TestChangelogDataReadWrite {
     private final FileStorePathFactory pathFactory;
     private final SnapshotManager snapshotManager;
     private final ExecutorService service;
+    private final String commitUser;
 
     public TestChangelogDataReadWrite(String root, ExecutorService service) {
         this.avro = FileFormat.fromIdentifier("avro", new Configuration());
@@ -85,6 +87,7 @@ public class TestChangelogDataReadWrite {
                         CoreOptions.FILE_FORMAT.defaultValue());
         this.snapshotManager = new SnapshotManager(new Path(root));
         this.service = service;
+        this.commitUser = UUID.randomUUID().toString();
     }
 
     public TableRead createReadWithKey() {
@@ -152,6 +155,7 @@ public class TestChangelogDataReadWrite {
                 new KeyValueFileStoreWrite(
                                 new SchemaManager(tablePath),
                                 0,
+                                commitUser,
                                 KEY_TYPE,
                                 VALUE_TYPE,
                                 () -> COMPARATOR,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/AbstractFileStore.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/AbstractFileStore.java
@@ -95,10 +95,10 @@ public abstract class AbstractFileStore<T> implements FileStore<T> {
     }
 
     @Override
-    public FileStoreCommitImpl newCommit(String user) {
+    public FileStoreCommitImpl newCommit(String commitUser) {
         return new FileStoreCommitImpl(
                 schemaId,
-                user,
+                commitUser,
                 partitionType,
                 pathFactory(),
                 snapshotManager(),

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/AppendOnlyFileStore.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/AppendOnlyFileStore.java
@@ -58,10 +58,11 @@ public class AppendOnlyFileStore extends AbstractFileStore<RowData> {
     }
 
     @Override
-    public AppendOnlyFileStoreWrite newWrite() {
+    public AppendOnlyFileStoreWrite newWrite(String commitUser) {
         return new AppendOnlyFileStoreWrite(
                 newRead(),
                 schemaId,
+                commitUser,
                 rowType,
                 pathFactory(),
                 snapshotManager(),

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStore.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/FileStore.java
@@ -46,9 +46,9 @@ public interface FileStore<T> extends Serializable {
 
     FileStoreRead<T> newRead();
 
-    FileStoreWrite<T> newWrite();
+    FileStoreWrite<T> newWrite(String commitUser);
 
-    FileStoreCommit newCommit(String user);
+    FileStoreCommit newCommit(String commitUser);
 
     FileStoreExpire newExpire();
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValueFileStore.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValueFileStore.java
@@ -78,10 +78,11 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
     }
 
     @Override
-    public KeyValueFileStoreWrite newWrite() {
+    public KeyValueFileStoreWrite newWrite(String commitUser) {
         return new KeyValueFileStoreWrite(
                 schemaManager,
                 schemaId,
+                commitUser,
                 keyType,
                 valueType,
                 keyComparatorSupplier,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AppendOnlyFileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AppendOnlyFileStoreWrite.java
@@ -61,12 +61,13 @@ public class AppendOnlyFileStoreWrite extends AbstractFileStoreWrite<RowData> {
     public AppendOnlyFileStoreWrite(
             AppendOnlyFileStoreRead read,
             long schemaId,
+            String commitUser,
             RowType rowType,
             FileStorePathFactory pathFactory,
             SnapshotManager snapshotManager,
             FileStoreScan scan,
             CoreOptions options) {
-        super(snapshotManager, scan);
+        super(commitUser, snapshotManager, scan);
         this.read = read;
         this.schemaId = schemaId;
         this.rowType = rowType;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreWrite.java
@@ -68,10 +68,11 @@ public interface FileStoreWrite<T> {
      * Prepare commit in the write.
      *
      * @param endOfInput if true, the data writing is ended
+     * @param commitIdentifier identifier of the commit being prepared
      * @return the file committable list
      * @throws Exception the thrown exception
      */
-    List<FileCommittable> prepareCommit(boolean endOfInput) throws Exception;
+    List<FileCommittable> prepareCommit(boolean endOfInput, long commitIdentifier) throws Exception;
 
     /**
      * Close the writer.

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreWrite.java
@@ -62,6 +62,7 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
     public KeyValueFileStoreWrite(
             SchemaManager schemaManager,
             long schemaId,
+            String commitUser,
             RowType keyType,
             RowType valueType,
             Supplier<Comparator<RowData>> keyComparatorSupplier,
@@ -70,7 +71,7 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
             SnapshotManager snapshotManager,
             FileStoreScan scan,
             CoreOptions options) {
-        super(snapshotManager, scan, options);
+        super(commitUser, snapshotManager, scan, options);
         this.readerFactoryBuilder =
                 KeyValueFileReaderFactory.builder(
                         schemaManager,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/MemoryFileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/MemoryFileStoreWrite.java
@@ -51,7 +51,7 @@ public abstract class MemoryFileStoreWrite<T> extends AbstractFileStoreWrite<T> 
     }
 
     private Iterator<MemoryOwner> memoryOwners() {
-        Iterator<Map<Integer, WriterAndCommit<T>>> iterator = writers.values().iterator();
+        Iterator<Map<Integer, WriterWithCommit<T>>> iterator = writers.values().iterator();
         return Iterators.concat(
                 new Iterator<Iterator<MemoryOwner>>() {
                     @Override
@@ -63,10 +63,10 @@ public abstract class MemoryFileStoreWrite<T> extends AbstractFileStoreWrite<T> 
                     public Iterator<MemoryOwner> next() {
                         return Iterators.transform(
                                 iterator.next().values().iterator(),
-                                writerAndCommit ->
-                                        writerAndCommit == null
+                                writerWithCommit ->
+                                        writerWithCommit == null
                                                 ? null
-                                                : (MemoryOwner) (writerAndCommit.writer));
+                                                : (MemoryOwner) (writerWithCommit.writer));
                     }
                 });
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/MemoryFileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/MemoryFileStoreWrite.java
@@ -40,15 +40,18 @@ public abstract class MemoryFileStoreWrite<T> extends AbstractFileStoreWrite<T> 
     private final MemoryPoolFactory memoryPoolFactory;
 
     public MemoryFileStoreWrite(
-            SnapshotManager snapshotManager, FileStoreScan scan, CoreOptions options) {
-        super(snapshotManager, scan);
+            String commitUser,
+            SnapshotManager snapshotManager,
+            FileStoreScan scan,
+            CoreOptions options) {
+        super(commitUser, snapshotManager, scan);
         HeapMemorySegmentPool memoryPool =
                 new HeapMemorySegmentPool(options.writeBufferSize(), options.pageSize());
         this.memoryPoolFactory = new MemoryPoolFactory(memoryPool, this::memoryOwners);
     }
 
     private Iterator<MemoryOwner> memoryOwners() {
-        Iterator<Map<Integer, RecordWriter<T>>> iterator = writers.values().iterator();
+        Iterator<Map<Integer, WriterAndCommit<T>>> iterator = writers.values().iterator();
         return Iterators.concat(
                 new Iterator<Iterator<MemoryOwner>>() {
                     @Override
@@ -60,7 +63,10 @@ public abstract class MemoryFileStoreWrite<T> extends AbstractFileStoreWrite<T> 
                     public Iterator<MemoryOwner> next() {
                         return Iterators.transform(
                                 iterator.next().values().iterator(),
-                                writer -> (MemoryOwner) writer);
+                                writerAndCommit ->
+                                        writerAndCommit == null
+                                                ? null
+                                                : (MemoryOwner) (writerAndCommit.writer));
                     }
                 });
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AbstractFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AbstractFileStoreTable.java
@@ -61,7 +61,7 @@ public abstract class AbstractFileStoreTable implements FileStoreTable {
     }
 
     @Override
-    public TableCommit newCommit(String user) {
-        return new TableCommit(store().newCommit(user), store().newExpire());
+    public TableCommit newCommit(String commitUser) {
+        return new TableCommit(store().newCommit(commitUser), store().newExpire());
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTable.java
@@ -104,11 +104,11 @@ public class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
     }
 
     @Override
-    public TableWrite newWrite() {
+    public TableWrite newWrite(String commitUser) {
         SinkRecordConverter recordConverter =
                 new SinkRecordConverter(store.options().bucket(), tableSchema);
         return new TableWriteImpl<>(
-                store.newWrite(),
+                store.newWrite(commitUser),
                 recordConverter,
                 record -> {
                     Preconditions.checkState(

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTable.java
@@ -117,12 +117,12 @@ public class ChangelogValueCountFileStoreTable extends AbstractFileStoreTable {
     }
 
     @Override
-    public TableWrite newWrite() {
+    public TableWrite newWrite(String commitUser) {
         SinkRecordConverter recordConverter =
                 new SinkRecordConverter(store.options().bucket(), tableSchema);
         final KeyValue kv = new KeyValue();
         return new TableWriteImpl<>(
-                store.newWrite(),
+                store.newWrite(commitUser),
                 recordConverter,
                 record -> {
                     switch (record.row().getRowKind()) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
@@ -186,7 +186,7 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
     }
 
     @Override
-    public TableWrite newWrite() {
+    public TableWrite newWrite(String commitUser) {
         SinkRecordConverter recordConverter =
                 new SinkRecordConverter(store.options().bucket(), tableSchema);
         final SequenceGenerator sequenceGenerator =
@@ -196,7 +196,7 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
                         .orElse(null);
         final KeyValue kv = new KeyValue();
         return new TableWriteImpl<>(
-                store.newWrite(),
+                store.newWrite(commitUser),
                 recordConverter,
                 record -> {
                     long sequenceNumber =

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/FileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/FileStoreTable.java
@@ -22,8 +22,6 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.store.CoreOptions;
 import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
-import org.apache.flink.table.store.table.sink.TableCommit;
-import org.apache.flink.table.store.table.sink.TableWrite;
 import org.apache.flink.table.store.table.source.DataTableScan;
 import org.apache.flink.table.types.logical.RowType;
 
@@ -60,8 +58,4 @@ public interface FileStoreTable extends Table, SupportsPartition, SupportsWrite 
 
     @Override
     DataTableScan newScan();
-
-    TableWrite newWrite();
-
-    TableCommit newCommit(String user);
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/SupportsWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/SupportsWrite.java
@@ -24,7 +24,7 @@ import org.apache.flink.table.store.table.sink.TableWrite;
 /** An interface for {@link Table} write support. */
 public interface SupportsWrite {
 
-    TableWrite newWrite();
+    TableWrite newWrite(String commitUser);
 
-    TableCommit newCommit(String user);
+    TableCommit newCommit(String commitUser);
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWrite.java
@@ -40,7 +40,7 @@ public interface TableWrite {
 
     void compact(BinaryRowData partition, int bucket) throws Exception;
 
-    List<FileCommittable> prepareCommit(boolean endOfInput) throws Exception;
+    List<FileCommittable> prepareCommit(boolean endOfInput, long commitIdentifier) throws Exception;
 
     void close() throws Exception;
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWriteImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWriteImpl.java
@@ -75,8 +75,9 @@ public class TableWriteImpl<T> implements TableWrite {
     }
 
     @Override
-    public List<FileCommittable> prepareCommit(boolean endOfInput) throws Exception {
-        return write.prepareCommit(endOfInput);
+    public List<FileCommittable> prepareCommit(boolean endOfInput, long commitIdentifier)
+            throws Exception {
+        return write.prepareCommit(endOfInput, commitIdentifier);
     }
 
     @Override

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -82,7 +82,7 @@ public class TestFileStore extends KeyValueFileStore {
     private final String root;
     private final RowDataSerializer keySerializer;
     private final RowDataSerializer valueSerializer;
-    private final String user;
+    private final String commitUser;
 
     private long commitIdentifier;
 
@@ -105,13 +105,13 @@ public class TestFileStore extends KeyValueFileStore {
         this.root = root;
         this.keySerializer = new RowDataSerializer(keyType);
         this.valueSerializer = new RowDataSerializer(valueType);
-        this.user = UUID.randomUUID().toString();
+        this.commitUser = UUID.randomUUID().toString();
 
         this.commitIdentifier = 0L;
     }
 
     public FileStoreCommitImpl newCommit() {
-        return super.newCommit(user);
+        return super.newCommit(commitUser);
     }
 
     public FileStoreExpireImpl newExpire(
@@ -176,7 +176,7 @@ public class TestFileStore extends KeyValueFileStore {
             Long identifier,
             BiConsumer<FileStoreCommit, ManifestCommittable> commitFunction)
             throws Exception {
-        AbstractFileStoreWrite<KeyValue> write = newWrite();
+        AbstractFileStoreWrite<KeyValue> write = newWrite(commitUser);
         Map<BinaryRowData, Map<Integer, RecordWriter<KeyValue>>> writers = new HashMap<>();
         for (KeyValue kv : kvs) {
             BinaryRowData partition = partitionCalculator.apply(kv);
@@ -206,7 +206,7 @@ public class TestFileStore extends KeyValueFileStore {
                     .write(kv);
         }
 
-        FileStoreCommit commit = newCommit(user);
+        FileStoreCommit commit = newCommit(commitUser);
         ManifestCommittable committable =
                 new ManifestCommittable(identifier == null ? commitIdentifier++ : identifier);
         for (Map.Entry<BinaryRowData, Map<Integer, RecordWriter<KeyValue>>> entryWithPartition :

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
@@ -92,8 +92,9 @@ public class TestCommitThread extends Thread {
                                     .collect(Collectors.joining("\n")));
         }
 
-        this.write = safeStore.newWrite();
-        this.commit = testStore.newCommit(UUID.randomUUID().toString()).withCreateEmptyCommit(true);
+        String commitUser = UUID.randomUUID().toString();
+        this.write = safeStore.newWrite(commitUser);
+        this.commit = testStore.newCommit(commitUser).withCreateEmptyCommit(true);
 
         this.commitIdentifier = 0;
     }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/FailingAtomicRenameFileSystem.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/utils/FailingAtomicRenameFileSystem.java
@@ -30,6 +30,7 @@ import org.apache.flink.core.fs.LocatedFileStatus;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.fs.local.LocalBlockLocation;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.function.RunnableWithException;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -231,6 +232,19 @@ public class FailingAtomicRenameFileSystem extends TestAtomicRenameFileSystem {
         while (true) {
             try {
                 return callable.call();
+            } catch (Throwable t) {
+                if (!ExceptionUtils.findThrowable(t, ArtificialException.class).isPresent()) {
+                    throw t;
+                }
+            }
+        }
+    }
+
+    public static void retryArtificialException(RunnableWithException runnable) throws Exception {
+        while (true) {
+            try {
+                runnable.run();
+                break;
             } catch (Throwable t) {
                 if (!ExceptionUtils.findThrowable(t, ArtificialException.class).isPresent()) {
                     throw t;

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTableTest.java
@@ -162,9 +162,9 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         int numOfBucket = Math.max(random.nextInt(8), 1);
         FileStoreTable table = createFileStoreTable(numOfBucket);
         RowDataSerializer serializer = new RowDataSerializer(table.schema().logicalRowType());
-        TableWrite write = table.newWrite();
+        TableWrite write = table.newWrite(commitUser);
 
-        TableCommit commit = table.newCommit("user");
+        TableCommit commit = table.newCommit(commitUser);
         List<Map<Integer, List<RowData>>> dataset = new ArrayList<>();
         Map<Integer, List<RowData>> dataPerBucket = new HashMap<>(numOfBucket);
         int numOfPartition = Math.max(random.nextInt(10), 1);
@@ -189,7 +189,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
             dataset.add(new HashMap<>(dataPerBucket));
             dataPerBucket.clear();
         }
-        commit.commit(0, write.prepareCommit(true));
+        commit.commit(0, write.prepareCommit(true, 0));
 
         int partition = random.nextInt(numOfPartition);
         List<Integer> availableBucket = new ArrayList<>(dataset.get(partition).keySet());
@@ -214,23 +214,23 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
 
     private void writeData() throws Exception {
         FileStoreTable table = createFileStoreTable();
-        TableWrite write = table.newWrite();
-        TableCommit commit = table.newCommit("user");
+        TableWrite write = table.newWrite(commitUser);
+        TableCommit commit = table.newCommit(commitUser);
 
         write.write(rowData(1, 10, 100L));
         write.write(rowData(2, 20, 200L));
         write.write(rowData(1, 11, 101L));
-        commit.commit(0, write.prepareCommit(true));
+        commit.commit(0, write.prepareCommit(true, 0));
 
         write.write(rowData(1, 12, 102L));
         write.write(rowData(2, 21, 201L));
         write.write(rowData(2, 22, 202L));
-        commit.commit(1, write.prepareCommit(true));
+        commit.commit(1, write.prepareCommit(true, 1));
 
         write.write(rowData(1, 11, 101L));
         write.write(rowData(2, 21, 201L));
         write.write(rowData(1, 12, 102L));
-        commit.commit(2, write.prepareCommit(true));
+        commit.commit(2, write.prepareCommit(true, 2));
 
         write.close();
     }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTableTest.java
@@ -151,26 +151,26 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
 
     private void writeData() throws Exception {
         FileStoreTable table = createFileStoreTable();
-        TableWrite write = table.newWrite();
-        TableCommit commit = table.newCommit("user");
+        TableWrite write = table.newWrite(commitUser);
+        TableCommit commit = table.newCommit(commitUser);
 
         write.write(rowData(1, 10, 100L));
         write.write(rowData(2, 20, 200L));
         write.write(rowData(1, 11, 101L));
-        commit.commit(0, write.prepareCommit(true));
+        commit.commit(0, write.prepareCommit(true, 0));
 
         write.write(rowData(2, 21, 201L));
         write.write(rowData(1, 12, 102L));
         write.write(rowData(2, 21, 201L));
         write.write(rowData(2, 21, 201L));
-        commit.commit(1, write.prepareCommit(true));
+        commit.commit(1, write.prepareCommit(true, 1));
 
         write.write(rowData(1, 11, 101L));
         write.write(rowData(2, 22, 202L));
         write.write(rowDataWithKind(RowKind.DELETE, 2, 21, 201L));
         write.write(rowDataWithKind(RowKind.DELETE, 1, 10, 100L));
         write.write(rowDataWithKind(RowKind.DELETE, 2, 21, 201L));
-        commit.commit(2, write.prepareCommit(true));
+        commit.commit(2, write.prepareCommit(true, 2));
 
         write.close();
     }
@@ -178,13 +178,13 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
     @Test
     public void testChangelogWithoutDataFile() throws Exception {
         FileStoreTable table = createFileStoreTable();
-        TableWrite write = table.newWrite();
-        TableCommit commit = table.newCommit("user");
+        TableWrite write = table.newWrite(commitUser);
+        TableCommit commit = table.newCommit(commitUser);
 
         // no data file should be produced from this commit
         write.write(rowData(1, 10, 100L));
         write.write(rowDataWithKind(RowKind.DELETE, 1, 10, 100L));
-        commit.commit(0, write.prepareCommit(true));
+        commit.commit(0, write.prepareCommit(true, 0));
         write.close();
 
         // check that no data file is produced

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/WritePreemptMemoryTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/WritePreemptMemoryTest.java
@@ -26,7 +26,6 @@ import org.apache.flink.table.store.file.WriteMode;
 import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.schema.UpdateSchema;
-import org.apache.flink.table.store.table.sink.FileCommittable;
 import org.apache.flink.table.store.table.sink.TableCommit;
 import org.apache.flink.table.store.table.sink.TableWrite;
 import org.apache.flink.table.store.table.source.Split;
@@ -63,8 +62,8 @@ public class WritePreemptMemoryTest extends FileStoreTableTestBase {
     private void testWritePreemptMemory(boolean singlePartition) throws Exception {
         // write
         FileStoreTable table = createFileStoreTable();
-        TableWrite write = table.newWrite();
-        TableCommit commit = table.newCommit("user");
+        TableWrite write = table.newWrite(commitUser);
+        TableCommit commit = table.newCommit(commitUser);
         Random random = new Random();
         List<String> expected = new ArrayList<>();
         for (int i = 0; i < 10_000; i++) {
@@ -72,8 +71,7 @@ public class WritePreemptMemoryTest extends FileStoreTableTestBase {
             write.write(row);
             expected.add(BATCH_ROW_TO_STRING.apply(row));
         }
-        List<FileCommittable> committables = write.prepareCommit(true);
-        commit.commit(0, committables);
+        commit.commit(0, write.prepareCommit(true, 0));
         write.close();
 
         // read

--- a/flink-table-store-hive/flink-table-store-hive-connector/src/test/java/org/apache/flink/table/store/mapred/TableStoreRecordReaderTest.java
+++ b/flink-table-store-hive/flink-table-store-hive-connector/src/test/java/org/apache/flink/table/store/mapred/TableStoreRecordReaderTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.RowKind;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -46,6 +47,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -53,6 +55,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TableStoreRecordReaderTest {
 
     @TempDir java.nio.file.Path tempDir;
+    private String commitUser;
+
+    @BeforeEach
+    public void beforeEach() {
+        commitUser = UUID.randomUUID().toString();
+    }
 
     @Test
     public void testPk() throws Exception {
@@ -71,14 +79,14 @@ public class TableStoreRecordReaderTest {
                         Collections.emptyList(),
                         Collections.singletonList("a"));
 
-        TableWrite write = table.newWrite();
-        TableCommit commit = table.newCommit("user");
+        TableWrite write = table.newWrite(commitUser);
+        TableCommit commit = table.newCommit(commitUser);
         write.write(GenericRowData.of(1L, StringData.fromString("Hi")));
         write.write(GenericRowData.of(2L, StringData.fromString("Hello")));
         write.write(GenericRowData.of(3L, StringData.fromString("World")));
         write.write(GenericRowData.of(1L, StringData.fromString("Hi again")));
         write.write(GenericRowData.ofKind(RowKind.DELETE, 2L, StringData.fromString("Hello")));
-        commit.commit(0, write.prepareCommit(true));
+        commit.commit(0, write.prepareCommit(true, 0));
 
         TableStoreRecordReader reader = read(table, BinaryRowDataUtil.EMPTY_ROW, 0);
         RowDataContainer container = reader.createValue();
@@ -112,15 +120,15 @@ public class TableStoreRecordReaderTest {
                         Collections.emptyList(),
                         Collections.emptyList());
 
-        TableWrite write = table.newWrite();
-        TableCommit commit = table.newCommit("user");
+        TableWrite write = table.newWrite(commitUser);
+        TableCommit commit = table.newCommit(commitUser);
         write.write(GenericRowData.of(1, StringData.fromString("Hi")));
         write.write(GenericRowData.of(2, StringData.fromString("Hello")));
         write.write(GenericRowData.of(3, StringData.fromString("World")));
         write.write(GenericRowData.of(1, StringData.fromString("Hi")));
         write.write(GenericRowData.ofKind(RowKind.DELETE, 2, StringData.fromString("Hello")));
         write.write(GenericRowData.of(1, StringData.fromString("Hi")));
-        commit.commit(0, write.prepareCommit(true));
+        commit.commit(0, write.prepareCommit(true, 0));
 
         TableStoreRecordReader reader = read(table, BinaryRowDataUtil.EMPTY_ROW, 0);
         RowDataContainer container = reader.createValue();
@@ -155,12 +163,12 @@ public class TableStoreRecordReaderTest {
                         Collections.emptyList(),
                         Collections.emptyList());
 
-        TableWrite write = table.newWrite();
-        TableCommit commit = table.newCommit("user");
+        TableWrite write = table.newWrite(commitUser);
+        TableCommit commit = table.newCommit(commitUser);
         write.write(GenericRowData.of(1, 10L, StringData.fromString("Hi")));
         write.write(GenericRowData.of(2, 20L, StringData.fromString("Hello")));
         write.write(GenericRowData.of(1, 10L, StringData.fromString("Hi")));
-        commit.commit(0, write.prepareCommit(true));
+        commit.commit(0, write.prepareCommit(true, 0));
 
         TableStoreRecordReader reader =
                 read(table, BinaryRowDataUtil.EMPTY_ROW, 0, Arrays.asList("c", "a"));

--- a/flink-table-store-spark/src/test/java/org/apache/flink/table/store/spark/SimpleTableTestHelper.java
+++ b/flink-table-store-spark/src/test/java/org/apache/flink/table/store/spark/SimpleTableTestHelper.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 /** A simple table test helper to write and commit. */
 public class SimpleTableTestHelper {
@@ -59,8 +60,10 @@ public class SimpleTableTestHelper {
         Configuration conf = Configuration.fromMap(options);
         conf.setString("path", path.toString());
         FileStoreTable table = FileStoreTableFactory.create(conf);
-        this.writer = table.newWrite();
-        this.commit = table.newCommit("user");
+
+        String commitUser = UUID.randomUUID().toString();
+        this.writer = table.newWrite(commitUser);
+        this.commit = table.newCommit(commitUser);
 
         this.commitIdentifier = 0;
     }
@@ -70,6 +73,7 @@ public class SimpleTableTestHelper {
     }
 
     public void commit() throws Exception {
-        commit.commit(commitIdentifier++, writer.prepareCommit(true));
+        commit.commit(commitIdentifier, writer.prepareCommit(true, commitIdentifier));
+        commitIdentifier++;
     }
 }

--- a/flink-table-store-spark/src/test/java/org/apache/flink/table/store/spark/SimpleTableTestHelper.java
+++ b/flink-table-store-spark/src/test/java/org/apache/flink/table/store/spark/SimpleTableTestHelper.java
@@ -34,7 +34,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 /** A simple table test helper to write and commit. */
 public class SimpleTableTestHelper {
@@ -61,7 +60,7 @@ public class SimpleTableTestHelper {
         conf.setString("path", path.toString());
         FileStoreTable table = FileStoreTableFactory.create(conf);
 
-        String commitUser = UUID.randomUUID().toString();
+        String commitUser = "user";
         this.writer = table.newWrite(commitUser);
         this.commit = table.newCommit(commitUser);
 

--- a/flink-table-store-spark2/src/test/java/org/apache/flink/table/store/spark/SimpleTableTestHelper.java
+++ b/flink-table-store-spark2/src/test/java/org/apache/flink/table/store/spark/SimpleTableTestHelper.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.types.logical.RowType;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 /** A simple table test helper to write and commit. */
 public class SimpleTableTestHelper {
@@ -57,8 +58,10 @@ public class SimpleTableTestHelper {
         Configuration conf = Configuration.fromMap(options);
         conf.setString("path", path.toString());
         FileStoreTable table = FileStoreTableFactory.create(conf);
-        this.writer = table.newWrite();
-        this.commit = table.newCommit("user");
+
+        String commitUser = UUID.randomUUID().toString();
+        this.writer = table.newWrite(commitUser);
+        this.commit = table.newCommit(commitUser);
 
         this.commitIdentifier = 0;
     }
@@ -68,6 +71,7 @@ public class SimpleTableTestHelper {
     }
 
     public void commit() throws Exception {
-        commit.commit(commitIdentifier++, writer.prepareCommit(true));
+        commit.commit(commitIdentifier, writer.prepareCommit(true, commitIdentifier));
+        commitIdentifier++;
     }
 }

--- a/flink-table-store-spark2/src/test/java/org/apache/flink/table/store/spark/SimpleTableTestHelper.java
+++ b/flink-table-store-spark2/src/test/java/org/apache/flink/table/store/spark/SimpleTableTestHelper.java
@@ -33,7 +33,6 @@ import org.apache.flink.table.types.logical.RowType;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 /** A simple table test helper to write and commit. */
 public class SimpleTableTestHelper {
@@ -59,7 +58,7 @@ public class SimpleTableTestHelper {
         conf.setString("path", path.toString());
         FileStoreTable table = FileStoreTableFactory.create(conf);
 
-        String commitUser = UUID.randomUUID().toString();
+        String commitUser = "user";
         this.writer = table.newWrite(commitUser);
         this.commit = table.newCommit(commitUser);
 


### PR DESCRIPTION
Consider the following scenario when snapshot committing is slow:
* A writer produces some records at checkpoint T.
* It produces no record at checkpoint T+1 and is closed.
* It produces some records at checkpoint T+2. It will be reopened and read the latest sequence number from disk. However snapshot at checkpoint T may not be committed so the sequence number it reads might be too small.

In this scenario, records from checkpoint T may overwrite records from checkpoint T+2 because they have larger sequence numbers.

This PR fixes this bug by comparing last modified commit identifier and the latest committed identifier before closing a writer. If by comparing we found that the last modification is already committed, we can safely close the writer.