### PR TITLE
[FLINK-29916] Fix bug that Levels in Table Store may mistakenly ignore level 0 files when two files have the same sequence number

### DIFF
--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/LevelsTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/LevelsTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.UUID;
 
 import static org.apache.flink.table.store.file.mergetree.compact.MergeTreeCompactManagerTest.row;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,7 +44,6 @@ public class LevelsTest {
 
     @Test
     public void testNonEmptyHighestLevel0() {
-
         Levels levels = new Levels(comparator, Arrays.asList(newFile(0), newFile(0)), 3);
         assertThat(levels.nonEmptyHighestLevel()).isEqualTo(0);
     }
@@ -61,7 +61,14 @@ public class LevelsTest {
         assertThat(levels.nonEmptyHighestLevel()).isEqualTo(2);
     }
 
+    @Test
+    public void testLevel0WithSameSequenceNumbers() {
+        Levels levels = new Levels(comparator, Arrays.asList(newFile(0), newFile(0)), 3);
+        assertThat(levels.allFiles()).hasSize(2);
+    }
+
     public static DataFileMeta newFile(int level) {
-        return new DataFileMeta("", 0, 1, row(0), row(0), null, null, 0, 1, 0, level);
+        return new DataFileMeta(
+                UUID.randomUUID().toString(), 0, 1, row(0), row(0), null, null, 0, 1, 0, level);
     }
 }


### PR DESCRIPTION
Current constructor of `Levels` class contains the following code:

```java
this.level0 = new TreeSet<>(Comparator.comparing(DataFileMeta::maxSequenceNumber).reversed());
```

However when two or more jobs writing the same bucket, they may produce files containing the same sequence number. If two files have the same `maxSequenceNumber`, one of them will be mistakenly ignored by `TreeSet`.