### PR TITLE
[FLINK-29924] Fix missing a period in the description of kafka.bootstrap.servers.

### DIFF
--- a/docs/layouts/shortcodes/generated/kafka_log_configuration.html
+++ b/docs/layouts/shortcodes/generated/kafka_log_configuration.html
@@ -12,7 +12,7 @@
             <td><h5>kafka.bootstrap.servers</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>Required Kafka server connection string</td>
+            <td>Required Kafka server connection string.</td>
         </tr>
         <tr>
             <td><h5>kafka.topic</h5></td>

--- a/flink-table-store-kafka/src/main/java/org/apache/flink/table/store/kafka/KafkaLogOptions.java
+++ b/flink-table-store-kafka/src/main/java/org/apache/flink/table/store/kafka/KafkaLogOptions.java
@@ -28,7 +28,7 @@ public class KafkaLogOptions {
             ConfigOptions.key("kafka.bootstrap.servers")
                     .stringType()
                     .noDefaultValue()
-                    .withDescription("Required Kafka server connection string");
+                    .withDescription("Required Kafka server connection string.");
 
     public static final ConfigOption<String> TOPIC =
             ConfigOptions.key("kafka.topic")


### PR DESCRIPTION
Just add a missing period about description of "kafka.bootstrap.servers".