### PR TITLE
[FLINK-29805] Fix incorrect snapshot filter when snapshots are committing too slow

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreExpireImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreExpireImpl.java
@@ -32,7 +32,6 @@ import org.apache.flink.table.store.file.utils.SnapshotManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -100,12 +99,7 @@ public class FileStoreExpireImpl implements FileStoreExpire {
 
         long currentMillis = System.currentTimeMillis();
 
-        Long earliest;
-        try {
-            earliest = snapshotManager.findEarliest();
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to find earliest snapshot id", e);
-        }
+        Long earliest = snapshotManager.earliestSnapshotId();
         if (earliest == null) {
             return;
         }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/SnapshotManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/SnapshotManager.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.store.file.utils;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.store.file.Snapshot;
+import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.function.BinaryOperator;
 
@@ -79,7 +81,35 @@ public class SnapshotManager {
         }
     }
 
-    public Long findLatest() throws IOException {
+    public @Nullable Long earliestSnapshotId() {
+        try {
+            return findEarliest();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to find earliest snapshot id", e);
+        }
+    }
+
+    public Optional<Snapshot> latestSnapshotOfUser(String user) {
+        Long latestId = latestSnapshotId();
+        if (latestId == null) {
+            return Optional.empty();
+        }
+
+        long earliestId =
+                Preconditions.checkNotNull(
+                        earliestSnapshotId(),
+                        "Latest snapshot id is not null, but earliest snapshot id is null. "
+                                + "This is unexpected.");
+        for (long id = latestId; id >= earliestId; id--) {
+            Snapshot snapshot = snapshot(id);
+            if (user.equals(snapshot.commitUser())) {
+                return Optional.of(snapshot);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private @Nullable Long findLatest() throws IOException {
         Path snapshotDir = snapshotDirectory();
         FileSystem fs = snapshotDir.getFileSystem();
         if (!fs.exists(snapshotDir)) {
@@ -98,7 +128,7 @@ public class SnapshotManager {
         return findByListFiles(Math::max);
     }
 
-    public Long findEarliest() throws IOException {
+    private @Nullable Long findEarliest() throws IOException {
         Path snapshotDir = snapshotDirectory();
         FileSystem fs = snapshotDir.getFileSystem();
         if (!fs.exists(snapshotDir)) {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -376,12 +376,12 @@ public class TestFileStore extends KeyValueFileStore {
         if (actualFiles.remove(earliest)) {
             long earliestId = snapshotManager.readHint(SnapshotManager.EARLIEST);
             earliest.getFileSystem().delete(earliest, false);
-            assertThat(earliestId <= snapshotManager.findEarliest()).isTrue();
+            assertThat(earliestId <= snapshotManager.earliestSnapshotId()).isTrue();
         }
         if (actualFiles.remove(latest)) {
             long latestId = snapshotManager.readHint(SnapshotManager.LATEST);
             latest.getFileSystem().delete(latest, false);
-            assertThat(latestId <= snapshotManager.findLatest()).isTrue();
+            assertThat(latestId <= snapshotManager.latestSnapshotId()).isTrue();
         }
         actualFiles.remove(latest);
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreExpireTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreExpireTest.java
@@ -206,12 +206,12 @@ public class FileStoreExpireTest {
 
         assertThat(earliest.getFileSystem().exists(earliest)).isTrue();
 
-        Long earliestId = snapshotManager.findEarliest();
+        Long earliestId = snapshotManager.earliestSnapshotId();
 
         // remove earliest hint file
         earliest.getFileSystem().delete(earliest, false);
 
-        assertThat(snapshotManager.findEarliest()).isEqualTo(earliestId);
+        assertThat(snapshotManager.earliestSnapshotId()).isEqualTo(earliestId);
     }
 
     @Test


### PR DESCRIPTION
(Cherry-picked from #350)

Table Store sink continuously fails with "Trying to add file which is already added" when snapshot committing is slow.

This is due to a bug in `FileStoreCommitImpl#filterCommitted`. When this method finds an identifier, it removes the identifier from a map. However different snapshots may have the same identifier (for example an APPEND commit and the following COMPACT commit will have the same identifier), so we need to use another set to check for identifiers.

When snapshot committing is fast there is at most 1 identifier to check after the job restarts, so nothing happens. However when snapshot committing is slow, there will be multiple identifiers to check and some identifiers will be mistakenly kept.