### PR TITLE
[FLINK-29752] Modify Flink Table Store connector to trigger full compaction constantly when full changelog is needed

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -33,7 +33,7 @@
             <td>Whether to double write to a changelog file. This changelog file keeps the details of data changes, it can be read directly during stream reads.<br /><br />Possible values:<ul><li>"none": No changelog file.</li><li>"input": Double write to a changelog file when flushing memory table, the changelog is from input.</li><li>"full-compaction": Generate changelog files with each full compaction.</li></ul></td>
         </tr>
         <tr>
-            <td><h5>changelog-producer.full-compaction.trigger-interval</h5></td>
+            <td><h5>changelog-producer.compaction-interval</h5></td>
             <td style="word-wrap: break-word;">30 min</td>
             <td>Duration</td>
             <td>When changelog-producer is set to FULL_COMPACTION, full compaction will be constantly triggered after this interval.</td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -33,6 +33,12 @@
             <td>Whether to double write to a changelog file. This changelog file keeps the details of data changes, it can be read directly during stream reads.<br /><br />Possible values:<ul><li>"none": No changelog file.</li><li>"input": Double write to a changelog file when flushing memory table, the changelog is from input.</li><li>"full-compaction": Generate changelog files with each full compaction.</li></ul></td>
         </tr>
         <tr>
+            <td><h5>changelog-producer.full-compaction.trigger-interval</h5></td>
+            <td style="word-wrap: break-word;">30 min</td>
+            <td>Duration</td>
+            <td>When changelog-producer is set to FULL_COMPACTION, full compaction will be constantly triggered after this interval.</td>
+        </tr>
+        <tr>
             <td><h5>commit.force-compact</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/FullChangelogStoreWriteOperator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/FullChangelogStoreWriteOperator.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector.sink;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.api.java.typeutils.runtime.TupleSerializer;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.runtime.typeutils.BinaryRowDataSerializer;
+import org.apache.flink.table.store.CoreOptions;
+import org.apache.flink.table.store.file.Snapshot;
+import org.apache.flink.table.store.file.utils.SnapshotManager;
+import org.apache.flink.table.store.table.FileStoreTable;
+import org.apache.flink.table.store.table.sink.LogSinkFunction;
+import org.apache.flink.table.store.table.sink.SinkRecord;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * A {@link StoreWriteOperator} for {@link
+ * org.apache.flink.table.store.CoreOptions.ChangelogProducer#FULL_COMPACTION} changelog producer.
+ */
+public class FullChangelogStoreWriteOperator extends StoreWriteOperator {
+
+    private final long checkpointThreshold;
+
+    private transient Set<Tuple2<BinaryRowData, Integer>> currentWrittenBuckets;
+    private transient NavigableMap<Long, Set<Tuple2<BinaryRowData, Integer>>> writtenBuckets;
+    private transient ListState<Tuple3<Long, BinaryRowData, Integer>> writtenBucketState;
+    private transient Long snapshotIdentifierToCheck;
+
+    public FullChangelogStoreWriteOperator(
+            FileStoreTable table,
+            String initialCommitUser,
+            @Nullable Map<String, String> overwritePartition,
+            @Nullable LogSinkFunction logSinkFunction,
+            long checkpointThreshold) {
+        super(table, initialCommitUser, overwritePartition, logSinkFunction);
+        this.checkpointThreshold = checkpointThreshold;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void initializeState(StateInitializationContext context) throws Exception {
+        super.initializeState(context);
+
+        TupleSerializer<Tuple3<Long, BinaryRowData, Integer>> writtenBucketStateSerializer =
+                new TupleSerializer<>(
+                        (Class<Tuple3<Long, BinaryRowData, Integer>>) (Class<?>) Tuple3.class,
+                        new TypeSerializer[] {
+                            LongSerializer.INSTANCE,
+                            new BinaryRowDataSerializer(
+                                    table.schema().logicalPartitionType().getFieldCount()),
+                            IntSerializer.INSTANCE
+                        });
+        writtenBucketState =
+                context.getOperatorStateStore()
+                        .getListState(
+                                new ListStateDescriptor<>(
+                                        "table_store_written_buckets",
+                                        writtenBucketStateSerializer));
+        writtenBuckets = new TreeMap<>();
+        writtenBucketState
+                .get()
+                .forEach(
+                        t ->
+                                writtenBuckets
+                                        .computeIfAbsent(t.f0, k -> new HashSet<>())
+                                        .add(Tuple2.of(t.f1, t.f2)));
+
+        snapshotIdentifierToCheck = null;
+    }
+
+    @Override
+    public void open() throws Exception {
+        super.open();
+        currentWrittenBuckets = new HashSet<>();
+    }
+
+    @Override
+    public void processElement(StreamRecord<RowData> element) throws Exception {
+        SinkRecord record = writeRecord(element);
+
+        BinaryRowData partition = record.partition();
+        int bucket = record.bucket();
+        // partition is a reused BinaryRowData
+        // we first check if the tuple exists to minimize copying
+        if (!currentWrittenBuckets.contains(Tuple2.of(partition, bucket))) {
+            currentWrittenBuckets.add(Tuple2.of(partition.copy(), bucket));
+        }
+    }
+
+    @Override
+    public void snapshotState(StateSnapshotContext context) throws Exception {
+        super.snapshotState(context);
+
+        List<Tuple3<Long, BinaryRowData, Integer>> writtenBucketList = new ArrayList<>();
+        for (Map.Entry<Long, Set<Tuple2<BinaryRowData, Integer>>> entry :
+                writtenBuckets.entrySet()) {
+            for (Tuple2<BinaryRowData, Integer> bucket : entry.getValue()) {
+                writtenBucketList.add(Tuple3.of(entry.getKey(), bucket.f0, bucket.f1));
+            }
+        }
+        writtenBucketState.update(writtenBucketList);
+    }
+
+    @Override
+    protected List<Committable> prepareCommit(boolean blocking, long checkpointId)
+            throws IOException {
+        if (snapshotIdentifierToCheck != null) {
+            Optional<Snapshot> snapshot = findSnapshot(snapshotIdentifierToCheck);
+            if (snapshot.map(s -> s.commitKind() == Snapshot.CommitKind.COMPACT).orElse(false)) {
+                writtenBuckets.headMap(snapshotIdentifierToCheck, true).clear();
+                snapshotIdentifierToCheck = null;
+            }
+        }
+
+        if (!currentWrittenBuckets.isEmpty()) {
+            writtenBuckets
+                    .computeIfAbsent(checkpointId, k -> new HashSet<>())
+                    .addAll(currentWrittenBuckets);
+            currentWrittenBuckets.clear();
+        }
+
+        if (snapshotIdentifierToCheck == null // wait for last forced full compaction to complete
+                && !writtenBuckets.isEmpty() // there should be something to compact
+                && checkpointId - writtenBuckets.navigableKeySet().first() + 1
+                        >= checkpointThreshold // checkpoints without full compaction exceeds
+        ) {
+            blocking = true;
+        }
+
+        if (blocking) {
+            snapshotIdentifierToCheck = checkpointId;
+            Set<Tuple2<BinaryRowData, Integer>> compactedBuckets = new HashSet<>();
+            for (Set<Tuple2<BinaryRowData, Integer>> buckets : writtenBuckets.values()) {
+                for (Tuple2<BinaryRowData, Integer> bucket : buckets) {
+                    if (compactedBuckets.contains(bucket)) {
+                        continue;
+                    }
+                    compactedBuckets.add(bucket);
+                    try {
+                        write.compact(bucket.f0, bucket.f1);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        }
+
+        return super.prepareCommit(blocking, checkpointId);
+    }
+
+    private Optional<Snapshot> findSnapshot(long identifierToCheck) {
+        SnapshotManager snapshotManager = table.snapshotManager();
+        Long latestId = snapshotManager.latestSnapshotId();
+        if (latestId == null) {
+            return Optional.empty();
+        }
+
+        Long earliestId = snapshotManager.earliestSnapshotId();
+        if (earliestId == null) {
+            return Optional.empty();
+        }
+
+        for (long id = latestId; id >= earliestId; id--) {
+            Snapshot snapshot = snapshotManager.snapshot(id);
+            if (!snapshot.commitUser().equals(commitUser)) {
+                continue;
+            }
+            if (snapshot.commitIdentifier() == identifierToCheck) {
+                return Optional.of(snapshot);
+            } else if (snapshot.commitIdentifier() < identifierToCheck) {
+                return Optional.empty();
+            }
+        }
+
+        throw new RuntimeException(
+                String.format(
+                        "All snapshot from user %s has identifier larger than %d. "
+                                + "This is rare but it might be that snapshots are expiring too fast.\n"
+                                + "If this exception happens continuously, please consider increasing "
+                                + CoreOptions.SNAPSHOT_TIME_RETAINED.key()
+                                + " or "
+                                + CoreOptions.SNAPSHOT_NUM_RETAINED_MIN,
+                        commitUser,
+                        identifierToCheck));
+    }
+}

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/PrepareCommitOperator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/PrepareCommitOperator.java
@@ -55,11 +55,11 @@ public abstract class PrepareCommitOperator extends AbstractStreamOperator<Commi
         emitCommittables(true, Long.MAX_VALUE);
     }
 
-    private void emitCommittables(boolean endOfInput, long checkpointId) throws IOException {
-        prepareCommit(endOfInput, checkpointId)
+    private void emitCommittables(boolean blocking, long checkpointId) throws IOException {
+        prepareCommit(blocking, checkpointId)
                 .forEach(committable -> output.collect(new StreamRecord<>(committable)));
     }
 
-    protected abstract List<Committable> prepareCommit(boolean endOfInput, long checkpointId)
+    protected abstract List<Committable> prepareCommit(boolean blocking, long checkpointId)
             throws IOException;
 }

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/PrepareCommitOperator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/PrepareCommitOperator.java
@@ -55,11 +55,11 @@ public abstract class PrepareCommitOperator extends AbstractStreamOperator<Commi
         emitCommittables(true, Long.MAX_VALUE);
     }
 
-    private void emitCommittables(boolean blocking, long checkpointId) throws IOException {
-        prepareCommit(blocking, checkpointId)
+    private void emitCommittables(boolean doCompaction, long checkpointId) throws IOException {
+        prepareCommit(doCompaction, checkpointId)
                 .forEach(committable -> output.collect(new StreamRecord<>(committable)));
     }
 
-    protected abstract List<Committable> prepareCommit(boolean blocking, long checkpointId)
+    protected abstract List<Committable> prepareCommit(boolean doCompaction, long checkpointId)
             throws IOException;
 }

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreCompactOperator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreCompactOperator.java
@@ -75,7 +75,7 @@ public class StoreCompactOperator extends PrepareCommitOperator {
     }
 
     @Override
-    protected List<Committable> prepareCommit(boolean blocking, long checkpointId)
+    protected List<Committable> prepareCommit(boolean doCompaction, long checkpointId)
             throws IOException {
         int task = getRuntimeContext().getIndexOfThisSubtask();
         int numTask = getRuntimeContext().getNumberOfParallelSubtasks();

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreCompactOperator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreCompactOperator.java
@@ -75,7 +75,7 @@ public class StoreCompactOperator extends PrepareCommitOperator {
     }
 
     @Override
-    protected List<Committable> prepareCommit(boolean endOfInput, long checkpointId)
+    protected List<Committable> prepareCommit(boolean blocking, long checkpointId)
             throws IOException {
         int task = getRuntimeContext().getIndexOfThisSubtask();
         int numTask = getRuntimeContext().getNumberOfParallelSubtasks();

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSink.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSink.java
@@ -20,16 +20,19 @@ package org.apache.flink.table.store.connector.sink;
 
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.CoreOptions;
 import org.apache.flink.table.store.connector.utils.StreamExecutionEnvironmentUtils;
 import org.apache.flink.table.store.file.catalog.CatalogLock;
 import org.apache.flink.table.store.file.manifest.ManifestCommittableSerializer;
@@ -54,17 +57,12 @@ public class StoreSink implements Serializable {
     private static final String GLOBAL_COMMITTER_NAME = "Global Committer";
 
     private final ObjectIdentifier tableIdentifier;
-
     private final FileStoreTable table;
 
     private final boolean compactionTask;
-
     @Nullable private final Map<String, String> compactPartitionSpec;
-
     @Nullable private final CatalogLock.Factory lockFactory;
-
     @Nullable private final Map<String, String> overwritePartition;
-
     @Nullable private final LogSinkFunction logSinkFunction;
 
     public StoreSink(
@@ -77,6 +75,7 @@ public class StoreSink implements Serializable {
             @Nullable LogSinkFunction logSinkFunction) {
         this.tableIdentifier = tableIdentifier;
         this.table = table;
+
         this.compactionTask = compactionTask;
         this.compactPartitionSpec = compactPartitionSpec;
         this.lockFactory = lockFactory;
@@ -85,10 +84,25 @@ public class StoreSink implements Serializable {
     }
 
     private OneInputStreamOperator<RowData, Committable> createWriteOperator(
-            String initialCommitUser) {
+            CheckpointConfig checkpointConfig, String initialCommitUser) {
         if (compactionTask) {
             return new StoreCompactOperator(table, initialCommitUser, compactPartitionSpec);
         }
+
+        if (table.options().changelogProducer() == CoreOptions.ChangelogProducer.FULL_COMPACTION) {
+            long checkpointInterval = checkpointConfig.getCheckpointInterval();
+            long checkpointThreshold =
+                    table.options().changelogProducerFullCompactionTriggerInterval().toMillis()
+                            / checkpointInterval;
+            checkpointThreshold = Math.max(1L, checkpointThreshold);
+            return new FullChangelogStoreWriteOperator(
+                    table,
+                    initialCommitUser,
+                    overwritePartition,
+                    logSinkFunction,
+                    checkpointThreshold);
+        }
+
         return new StoreWriteOperator(
                 table, initialCommitUser, overwritePartition, logSinkFunction);
     }
@@ -110,17 +124,21 @@ public class StoreSink implements Serializable {
         // ignored.
         String initialCommitUser = UUID.randomUUID().toString();
 
+        StreamExecutionEnvironment env = input.getExecutionEnvironment();
+        ReadableConfig conf = StreamExecutionEnvironmentUtils.getConfiguration(env);
+        CheckpointConfig checkpointConfig = env.getCheckpointConfig();
+
         CommittableTypeInfo typeInfo = new CommittableTypeInfo();
         SingleOutputStreamOperator<Committable> written =
-                input.transform(WRITER_NAME, typeInfo, createWriteOperator(initialCommitUser))
+                input.transform(
+                                WRITER_NAME,
+                                typeInfo,
+                                createWriteOperator(checkpointConfig, initialCommitUser))
                         .setParallelism(input.getParallelism());
 
-        StreamExecutionEnvironment env = input.getExecutionEnvironment();
         boolean streamingCheckpointEnabled =
-                StreamExecutionEnvironmentUtils.getConfiguration(env)
-                                        .get(ExecutionOptions.RUNTIME_MODE)
-                                == RuntimeExecutionMode.STREAMING
-                        && env.getCheckpointConfig().isCheckpointingEnabled();
+                conf.get(ExecutionOptions.RUNTIME_MODE) == RuntimeExecutionMode.STREAMING
+                        && checkpointConfig.isCheckpointingEnabled();
         if (streamingCheckpointEnabled) {
             assertCheckpointConfiguration(env);
         }

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreWriteOperator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreWriteOperator.java
@@ -50,7 +50,7 @@ import java.util.Map;
 /** A {@link PrepareCommitOperator} to write records. */
 public class StoreWriteOperator extends PrepareCommitOperator {
 
-    private final FileStoreTable table;
+    protected final FileStoreTable table;
 
     /**
      * This commitUser is valid only for new jobs. After the job starts, this commitUser will be
@@ -68,9 +68,12 @@ public class StoreWriteOperator extends PrepareCommitOperator {
     /** We listen to this ourselves because we don't have an {@link InternalTimerService}. */
     private long currentWatermark = Long.MIN_VALUE;
 
-    @Nullable private TableWrite write;
+    @Nullable protected transient TableWrite write;
 
-    @Nullable private LogWriteCallback logCallback;
+    /** This is the real commit user read from state. */
+    @Nullable protected transient String commitUser;
+
+    @Nullable private transient LogWriteCallback logCallback;
 
     public StoreWriteOperator(
             FileStoreTable table,
@@ -105,14 +108,14 @@ public class StoreWriteOperator extends PrepareCommitOperator {
         // each job can only have one user name and this name must be consistent across restarts
         // we cannot use job id as commit user name here because user may change job id by creating
         // a savepoint, stop the job and then resume from savepoint
-        String commitUser =
+        commitUser =
                 StateUtils.getSingleValueFromState(
                         context, "commit_user_state", String.class, initialCommitUser);
         // see comments of StateUtils.getSingleValueFromState for why commitUser may be null
         if (commitUser == null) {
-            this.write = null;
+            write = null;
         } else {
-            this.write =
+            write =
                     table.newWrite(commitUser)
                             .withIOManager(getContainingTask().getEnvironment().getIOManager())
                             .withOverwrite(overwritePartition != null);
@@ -142,6 +145,10 @@ public class StoreWriteOperator extends PrepareCommitOperator {
 
     @Override
     public void processElement(StreamRecord<RowData> element) throws Exception {
+        writeRecord(element);
+    }
+
+    protected SinkRecord writeRecord(StreamRecord<RowData> element) throws Exception {
         sinkContext.timestamp = element.hasTimestamp() ? element.getTimestamp() : null;
 
         SinkRecord record;
@@ -156,6 +163,8 @@ public class StoreWriteOperator extends PrepareCommitOperator {
             SinkRecord logRecord = write.recordConverter().convertToLogSinkRecord(record);
             logSinkFunction.invoke(logRecord, sinkContext);
         }
+
+        return record;
     }
 
     @Override
@@ -206,12 +215,12 @@ public class StoreWriteOperator extends PrepareCommitOperator {
     }
 
     @Override
-    protected List<Committable> prepareCommit(boolean endOfInput, long checkpointId)
+    protected List<Committable> prepareCommit(boolean blocking, long checkpointId)
             throws IOException {
         List<Committable> committables = new ArrayList<>();
         if (write != null) {
             try {
-                for (FileCommittable committable : write.prepareCommit(endOfInput, checkpointId)) {
+                for (FileCommittable committable : write.prepareCommit(blocking, checkpointId)) {
                     committables.add(
                             new Committable(checkpointId, Committable.Kind.FILE, committable));
                 }

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreWriteOperator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreWriteOperator.java
@@ -50,6 +50,8 @@ import java.util.Map;
 /** A {@link PrepareCommitOperator} to write records. */
 public class StoreWriteOperator extends PrepareCommitOperator {
 
+    private static final long serialVersionUID = 1L;
+
     protected final FileStoreTable table;
 
     /**
@@ -215,12 +217,13 @@ public class StoreWriteOperator extends PrepareCommitOperator {
     }
 
     @Override
-    protected List<Committable> prepareCommit(boolean blocking, long checkpointId)
+    protected List<Committable> prepareCommit(boolean doCompaction, long checkpointId)
             throws IOException {
         List<Committable> committables = new ArrayList<>();
         if (write != null) {
             try {
-                for (FileCommittable committable : write.prepareCommit(blocking, checkpointId)) {
+                for (FileCommittable committable :
+                        write.prepareCommit(doCompaction, checkpointId)) {
                     committables.add(
                             new Committable(checkpointId, Committable.Kind.FILE, committable));
                 }

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSource.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSource.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.table.store.CoreOptions;
 import org.apache.flink.table.store.file.Snapshot;
 import org.apache.flink.table.store.file.predicate.Predicate;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
@@ -82,6 +83,7 @@ public class FileStoreSource extends FlinkSource {
         Long snapshotId;
         Collection<FileStoreSourceSplit> splits;
         if (checkpoint == null) {
+            // TODO refactor split initialization logic into split enumerator or snapshot enumerator
             // first, create new enumerator, plan splits
             if (latestContinuous) {
                 checkArgument(
@@ -90,7 +92,14 @@ public class FileStoreSource extends FlinkSource {
                 snapshotId = snapshotManager.latestSnapshotId();
                 splits = new ArrayList<>();
             } else {
-                DataTableScan.DataFilePlan plan = scan.plan();
+                DataTableScan.DataFilePlan plan;
+                if (table.options().changelogProducer()
+                                == CoreOptions.ChangelogProducer.FULL_COMPACTION
+                        && isContinuous) {
+                    plan = scan.withLevel(table.options().numLevels() - 1).plan();
+                } else {
+                    plan = scan.plan();
+                }
                 snapshotId = plan.snapshotId;
                 splits = new FileStoreSourceSplitGenerator().createSplits(plan);
             }

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSource.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSource.java
@@ -96,6 +96,8 @@ public class FileStoreSource extends FlinkSource {
                 if (table.options().changelogProducer()
                                 == CoreOptions.ChangelogProducer.FULL_COMPACTION
                         && isContinuous) {
+                    // Read the results of the last full compaction.
+                    // Only full compaction results will appear on the max level.
                     plan = scan.withLevel(table.options().numLevels() - 1).plan();
                 } else {
                     plan = scan.plan();

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ChangelogWithKeyFileStoreTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ChangelogWithKeyFileStoreTableITCase.java
@@ -18,21 +18,34 @@
 
 package org.apache.flink.table.store.connector;
 
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.client.JobStatusMessage;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.store.file.utils.FailingAtomicRenameFileSystem;
 import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
 import org.apache.flink.util.CloseableIterator;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
@@ -40,28 +53,57 @@ import java.util.concurrent.ThreadLocalRandom;
 import static org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL;
 
 /** Tests for changelog table with primary keys. */
-public class ChangelogWithKeyFileStoreTableITCase extends AbstractTestBase {
+public class ChangelogWithKeyFileStoreTableITCase extends TestBaseUtils {
+
+    // ------------------------------------------------------------------------
+    //  Test Utilities
+    // ------------------------------------------------------------------------
+
+    @ClassRule
+    public static final MiniClusterWithClientResource MINI_CLUSTER_RESOURCE =
+            new MiniClusterWithClientResource(
+                    (new MiniClusterResourceConfiguration.Builder())
+                            .setNumberTaskManagers(2)
+                            .setNumberSlotsPerTaskManager(4)
+                            .build());
+
+    @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
 
     private String path;
-    private String failingName;
 
     @Before
     public void before() throws IOException {
         path = TEMPORARY_FOLDER.newFolder().toPath().toString();
-        // for failure tests
-        failingName = UUID.randomUUID().toString();
     }
 
-    @Test
-    public void testBatchRandom() throws Exception {
-        TableEnvironment bEnv =
-                TableEnvironmentTestUtils.create(
-                        EnvironmentSettings.newInstance().inBatchMode().build());
-        testRandom(bEnv, false);
+    /**
+     * Copied from {@link AbstractTestBase}. This test class does not directly extend from {@link
+     * AbstractTestBase} because we need more task managers to run multiple jobs.
+     */
+    @After
+    public final void cleanupRunningJobs() throws Exception {
+        if (!MINI_CLUSTER_RESOURCE.getMiniCluster().isRunning()) {
+            // do nothing if the MiniCluster is not running
+            return;
+        }
+
+        for (JobStatusMessage path : MINI_CLUSTER_RESOURCE.getClusterClient().listJobs().get()) {
+            if (!path.getJobState().isTerminalState()) {
+                try {
+                    MINI_CLUSTER_RESOURCE.getClusterClient().cancel(path.getJobId()).get();
+                } catch (Exception ignored) {
+                    // ignore exceptions when cancelling dangling jobs
+                }
+            }
+        }
     }
 
-    @Test
-    public void testStreamingRandom() throws Exception {
+    private TableEnvironment createBatchTableEnvironment() {
+        return TableEnvironmentTestUtils.create(
+                EnvironmentSettings.newInstance().inBatchMode().build());
+    }
+
+    private TableEnvironment createStreamingTableEnvironment() {
         TableEnvironment sEnv =
                 TableEnvironmentTestUtils.create(
                         EnvironmentSettings.newInstance().inStreamingMode().build());
@@ -71,20 +113,190 @@ public class ChangelogWithKeyFileStoreTableITCase extends AbstractTestBase {
                 .set(
                         CHECKPOINTING_INTERVAL,
                         Duration.ofMillis(ThreadLocalRandom.current().nextInt(900) + 100));
-        testRandom(sEnv, ThreadLocalRandom.current().nextBoolean());
+        return sEnv;
+    }
+
+    // ------------------------------------------------------------------------
+    //  Constructed Tests
+    // ------------------------------------------------------------------------
+
+    @Test
+    public void testFullCompactionTriggerInterval() throws Exception {
+        TableEnvironment sEnv = createStreamingTableEnvironment();
+        sEnv.getConfig()
+                .getConfiguration()
+                .set(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 1);
+
+        sEnv.executeSql(
+                String.format(
+                        "CREATE CATALOG testCatalog WITH ('type'='table-store', 'warehouse'='%s/warehouse')",
+                        path));
+        sEnv.executeSql("USE CATALOG testCatalog");
+        sEnv.executeSql(
+                "CREATE TABLE T ( k INT, v STRING, PRIMARY KEY (k) NOT ENFORCED ) "
+                        + "WITH ( "
+                        + "'bucket' = '2', "
+                        + "'changelog-producer' = 'full-compaction', "
+                        + "'changelog-producer.full-compaction.trigger-interval' = '1s' )");
+
+        Path inputPath = new Path(path, "input");
+        sEnv.executeSql(
+                "CREATE TABLE `default_catalog`.`default_database`.`S` ( i INT, g STRING ) "
+                        + "WITH ( 'connector' = 'filesystem', 'format' = 'testcsv', 'path' = '"
+                        + inputPath
+                        + "', 'source.monitor-interval' = '500ms' )");
+
+        sEnv.executeSql(
+                "INSERT INTO T SELECT SUM(i) AS k, g AS v FROM `default_catalog`.`default_database`.`S` GROUP BY g");
+        CloseableIterator<Row> it = sEnv.executeSql("SELECT * FROM T").collect();
+
+        // write initial data
+        sEnv.executeSql(
+                        "INSERT INTO `default_catalog`.`default_database`.`S` "
+                                + "VALUES (1, 'A'), (2, 'B'), (3, 'C'), (4, 'D')")
+                .await();
+
+        // read initial data
+        List<String> actual = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            actual.add(it.next().toString());
+        }
+        actual.sort(String::compareTo);
+
+        List<String> expected =
+                new ArrayList<>(Arrays.asList("+I[1, A]", "+I[2, B]", "+I[3, C]", "+I[4, D]"));
+        expected.sort(String::compareTo);
+        Assert.assertEquals(expected, actual);
+
+        // write update data
+        sEnv.executeSql(
+                        "INSERT INTO `default_catalog`.`default_database`.`S` "
+                                + "VALUES (1, 'A'), (1, 'B'), (1, 'C'), (1, 'D')")
+                .await();
+
+        // read update data
+        actual.clear();
+        for (int i = 0; i < 8; i++) {
+            actual.add(it.next().toString());
+        }
+        actual.sort(String::compareTo);
+
+        expected =
+                new ArrayList<>(
+                        Arrays.asList(
+                                "-D[1, A]",
+                                "-U[2, B]",
+                                "+U[2, A]",
+                                "-U[3, C]",
+                                "+U[3, B]",
+                                "-U[4, D]",
+                                "+U[4, C]",
+                                "+I[5, D]"));
+        expected.sort(String::compareTo);
+        Assert.assertEquals(expected, actual);
+    }
+
+    // ------------------------------------------------------------------------
+    //  Random Tests
+    // ------------------------------------------------------------------------
+
+    @Test
+    public void testNoChangelogProducerBatchRandom() throws Exception {
+        TableEnvironment bEnv = createBatchTableEnvironment();
+        testNoChangelogProducerRandom(bEnv, 1, false);
+    }
+
+    @Test
+    public void testNoChangelogProducerStreamingRandom() throws Exception {
+        TableEnvironment sEnv = createStreamingTableEnvironment();
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        testNoChangelogProducerRandom(sEnv, random.nextInt(1, 3), random.nextBoolean());
+    }
+
+    @Test
+    public void testFullCompactionChangelogProducerBatchRandom() throws Exception {
+        TableEnvironment bEnv = createBatchTableEnvironment();
+        testFullCompactionChangelogProducerRandom(bEnv, 1, false);
+    }
+
+    @Test
+    public void testFullCompactionChangelogProducerStreamingRandom() throws Exception {
+        TableEnvironment sEnv = createStreamingTableEnvironment();
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        testFullCompactionChangelogProducerRandom(sEnv, random.nextInt(1, 3), random.nextBoolean());
+    }
+
+    private static final int NUM_PARTS = 4;
+    private static final int NUM_KEYS = 64;
+    private static final int NUM_VALUES = 1024;
+    private static final int LIMIT = 10000;
+
+    private void testNoChangelogProducerRandom(
+            TableEnvironment tEnv, int numProducers, boolean enableFailure) throws Exception {
+        List<TableResult> results = testRandom(tEnv, numProducers, enableFailure, "'bucket' = '4'");
+        for (TableResult result : results) {
+            result.await();
+        }
+        checkBatchResult(numProducers);
+    }
+
+    private void testFullCompactionChangelogProducerRandom(
+            TableEnvironment tEnv, int numProducers, boolean enableFailure) throws Exception {
+        testRandom(
+                tEnv,
+                numProducers,
+                enableFailure,
+                "'bucket' = '4',"
+                        + "'changelog-producer' = 'full-compaction',"
+                        + "'changelog-producer.full-compaction.trigger-interval' = '1s'");
+
+        // sleep for a random amount of time to check
+        // if we can first read complete records then read incremental records correctly
+        Thread.sleep(ThreadLocalRandom.current().nextInt(5000));
+
+        TableEnvironment sEnv = createStreamingTableEnvironment();
+        sEnv.getConfig()
+                .getConfiguration()
+                .set(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 1);
+        sEnv.executeSql(
+                String.format(
+                        "CREATE CATALOG testCatalog WITH ('type'='table-store', 'warehouse'='%s')",
+                        path));
+        sEnv.executeSql("USE CATALOG testCatalog");
+
+        ResultChecker checker = new ResultChecker();
+        int endCnt = 0;
+        try (CloseableIterator<Row> it = sEnv.executeSql("SELECT * FROM T").collect()) {
+            while (it.hasNext()) {
+                Row row = it.next();
+                checker.addChangelog(row);
+                if (((long) row.getField(2)) >= LIMIT) {
+                    endCnt++;
+                    if (endCnt == numProducers * NUM_PARTS * NUM_KEYS) {
+                        break;
+                    }
+                }
+            }
+        }
+        checker.assertResult(numProducers);
+
+        checkBatchResult(numProducers);
     }
 
     /**
-     * Randomly update {@code numParts} partitions and {@code numKeys} keys for about {@code limit}
-     * records. For the final {@code numParts * numKeys} records, keys are updated to some specific
-     * values for result checking.
+     * Run {@code numProducers} jobs at the same time. Each job randomly update {@code NUM_PARTS}
+     * partitions and {@code NUM_KEYS} keys for about {@code LIMIT} records. For the final {@code
+     * NUM_PARTS * NUM_KEYS} records, keys are updated to some specific values for result checking.
+     *
+     * <p>All jobs will modify the same set of partitions to emulate conflicting writes. Each job
+     * will write its own set of keys for easy result checking.
      */
-    private void testRandom(TableEnvironment tEnv, boolean enableFailure) throws Exception {
-        int numParts = 4;
-        int numKeys = 64;
-        int numValues = 1024;
-        int limit = 10000;
+    private List<TableResult> testRandom(
+            TableEnvironment tEnv, int numProducers, boolean enableFailure, String tableProperties)
+            throws Exception {
+        assert LIMIT > NUM_VALUES;
 
+        String failingName = UUID.randomUUID().toString();
         String failingPath = FailingAtomicRenameFileSystem.getFailingPath(failingName, path);
 
         // no failure when creating catalog and table
@@ -102,7 +314,7 @@ public class ChangelogWithKeyFileStoreTableITCase extends AbstractTestBase {
                         + "  v2 STRING,"
                         + "  PRIMARY KEY (pt, k) NOT ENFORCED"
                         + ") PARTITIONED BY (pt) WITH ("
-                        + "  'bucket' = '4'"
+                        + tableProperties
                         + ")");
 
         // input data must be strictly ordered
@@ -117,72 +329,121 @@ public class ChangelogWithKeyFileStoreTableITCase extends AbstractTestBase {
                                 + "  'fields.i.kind' = 'sequence',"
                                 + "  'fields.i.start' = '0',"
                                 + "  'fields.i.end' = '"
-                                + (limit + numParts * numKeys - 1)
+                                + (LIMIT + NUM_PARTS * NUM_KEYS - 1)
                                 + "',"
                                 + "  'number-of-rows' = '"
-                                + (limit + numParts * numKeys)
+                                + (LIMIT + NUM_PARTS * NUM_KEYS)
                                 + "',"
                                 + "  'rows-per-second' = '"
-                                + (limit / 5 + ThreadLocalRandom.current().nextInt(limit / 10))
+                                + (LIMIT / 5 + ThreadLocalRandom.current().nextInt(LIMIT / 10))
                                 + "'"
                                 + ")")
                 .await();
 
-        // for the last `numParts * numKeys` records, we update every key to a specific value
-        String ptSql =
-                String.format(
-                        "IF(i >= %d, CAST((i - %d) / %d AS STRING), CAST(CAST(FLOOR(RAND() * %d) AS INT) AS STRING)) AS pt",
-                        limit, limit, numKeys, numParts);
-        String kSql =
-                String.format(
-                        "IF(i >= %d, MOD(i - %d, %d), CAST(FLOOR(RAND() * %d) AS INT)) AS k",
-                        limit, limit, numKeys, numKeys);
-        String v1Sql =
-                String.format(
-                        "IF(i >= %d, i, CAST(FLOOR(RAND() * %d) AS BIGINT)) AS v1",
-                        limit, numValues);
-        String v2Sql = "CAST(i AS STRING) || '.str' AS v2";
-        tEnv.executeSql(
-                String.format(
-                        "CREATE TEMPORARY VIEW myView AS SELECT %s, %s, %s, %s FROM `default_catalog`.`default_database`.`S`",
-                        ptSql, kSql, v1Sql, v2Sql));
+        List<TableResult> results = new ArrayList<>();
 
-        // run test SQL
         if (enableFailure) {
             FailingAtomicRenameFileSystem.reset(failingName, 100, 1000);
         }
-        FailingAtomicRenameFileSystem.retryArtificialException(
-                () ->
-                        tEnv.executeSql(
-                                        "INSERT INTO T /*+ OPTIONS('sink.parallelism' = '2') */ SELECT * FROM myView")
-                                .await());
+        for (int i = 0; i < numProducers; i++) {
+            // for the last `NUM_PARTS * NUM_KEYS` records, we update every key to a specific value
+            String ptSql =
+                    String.format(
+                            "IF(i >= %d, CAST((i - %d) / %d AS STRING), CAST(CAST(FLOOR(RAND() * %d) AS INT) AS STRING)) AS pt",
+                            LIMIT, LIMIT, NUM_KEYS, NUM_PARTS);
+            String kSql =
+                    String.format(
+                            "IF(i >= %d, MOD(i - %d, %d), CAST(FLOOR(RAND() * %d) AS INT)) + %d AS k",
+                            LIMIT, LIMIT, NUM_KEYS, NUM_KEYS, i * NUM_KEYS);
+            String v1Sql =
+                    String.format(
+                            "IF(i >= %d, i, CAST(FLOOR(RAND() * %d) AS BIGINT)) AS v1",
+                            LIMIT, NUM_VALUES);
+            String v2Sql = "CAST(i AS STRING) || '.str' AS v2";
+            tEnv.executeSql(
+                    String.format(
+                            "CREATE TEMPORARY VIEW myView%d AS SELECT %s, %s, %s, %s FROM `default_catalog`.`default_database`.`S`",
+                            i, ptSql, kSql, v1Sql, v2Sql));
 
-        // check for result
-        TableEnvironment bEnv =
-                TableEnvironmentTestUtils.create(
-                        EnvironmentSettings.newInstance().inBatchMode().build());
+            // run test SQL
+            int idx = i;
+            TableResult result =
+                    FailingAtomicRenameFileSystem.retryArtificialException(
+                            () ->
+                                    tEnv.executeSql(
+                                            "INSERT INTO T /*+ OPTIONS('sink.parallelism' = '2') */ SELECT * FROM myView"
+                                                    + idx));
+            results.add(result);
+        }
+
+        return results;
+    }
+
+    private void checkBatchResult(int numProducers) throws Exception {
+        TableEnvironment bEnv = createBatchTableEnvironment();
         bEnv.executeSql(
                 String.format(
                         "CREATE CATALOG testCatalog WITH ('type'='table-store', 'warehouse'='%s')",
                         path));
         bEnv.executeSql("USE CATALOG testCatalog");
-        Map<String, String> actual = new HashMap<>();
+
+        ResultChecker checker = new ResultChecker();
         try (CloseableIterator<Row> it = bEnv.executeSql("SELECT * FROM T").collect()) {
             while (it.hasNext()) {
-                Row row = it.next();
-                String key = row.getField(0) + "|" + row.getField(1);
-                String value = row.getField(2) + "|" + row.getField(3);
-                actual.put(key, value);
+                checker.addChangelog(it.next());
             }
         }
+        checker.assertResult(numProducers);
+    }
 
-        Assert.assertEquals(numParts * numKeys, actual.size());
-        for (int i = 0; i < numParts; i++) {
-            for (int j = 0; j < numKeys; j++) {
-                String key = i + "|" + j;
-                int x = limit + i * numKeys + j;
-                String expectedValue = x + "|" + x + ".str";
-                Assert.assertEquals(expectedValue, actual.get(key));
+    private static class ResultChecker {
+
+        private final Map<String, String> valueMap;
+        private final Map<String, RowKind> kindMap;
+
+        private ResultChecker() {
+            this.valueMap = new HashMap<>();
+            this.kindMap = new HashMap<>();
+        }
+
+        private void addChangelog(Row row) {
+            String key = row.getField(0) + "|" + row.getField(1);
+            String value = row.getField(2) + "|" + row.getField(3);
+            switch (row.getKind()) {
+                case INSERT:
+                    Assert.assertFalse(valueMap.containsKey(key));
+                    Assert.assertTrue(
+                            !kindMap.containsKey(key) || kindMap.get(key) == RowKind.DELETE);
+                    valueMap.put(key, value);
+                    break;
+                case UPDATE_AFTER:
+                    Assert.assertFalse(valueMap.containsKey(key));
+                    Assert.assertEquals(RowKind.UPDATE_BEFORE, kindMap.get(key));
+                    valueMap.put(key, value);
+                    break;
+                case UPDATE_BEFORE:
+                case DELETE:
+                    Assert.assertEquals(value, valueMap.get(key));
+                    Assert.assertTrue(
+                            kindMap.get(key) == RowKind.INSERT
+                                    || kindMap.get(key) == RowKind.UPDATE_AFTER);
+                    valueMap.remove(key);
+                    break;
+                default:
+                    throw new UnsupportedOperationException("Unknown row kind " + row.getKind());
+            }
+            kindMap.put(key, row.getKind());
+        }
+
+        private void assertResult(int numProducers) {
+            Assert.assertEquals(NUM_PARTS * NUM_KEYS * numProducers, valueMap.size());
+            for (int i = 0; i < NUM_PARTS; i++) {
+                for (int j = 0; j < NUM_KEYS * numProducers; j++) {
+                    String key = i + "|" + j;
+                    int x = LIMIT + i * NUM_KEYS + j % NUM_KEYS;
+                    String expectedValue = x + "|" + x + ".str";
+                    Assert.assertEquals(expectedValue, valueMap.get(key));
+                }
             }
         }
     }

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ChangelogWithKeyFileStoreTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ChangelogWithKeyFileStoreTableITCase.java
@@ -137,7 +137,7 @@ public class ChangelogWithKeyFileStoreTableITCase extends TestBaseUtils {
                         + "WITH ( "
                         + "'bucket' = '2', "
                         + "'changelog-producer' = 'full-compaction', "
-                        + "'changelog-producer.full-compaction.trigger-interval' = '1s' )");
+                        + "'changelog-producer.compaction-interval' = '1s' )");
 
         Path inputPath = new Path(path, "input");
         sEnv.executeSql(
@@ -248,7 +248,7 @@ public class ChangelogWithKeyFileStoreTableITCase extends TestBaseUtils {
                 enableFailure,
                 "'bucket' = '4',"
                         + "'changelog-producer' = 'full-compaction',"
-                        + "'changelog-producer.full-compaction.trigger-interval' = '1s'");
+                        + "'changelog-producer.compaction-interval' = '1s'");
 
         // sleep for a random amount of time to check
         // if we can first read complete records then read incremental records correctly

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
@@ -300,7 +300,7 @@ public class CoreOptions implements Serializable {
                                     + "it can be read directly during stream reads.");
 
     public static final ConfigOption<Duration> CHANGELOG_PRODUCER_FULL_COMPACTION_TRIGGER_INTERVAL =
-            ConfigOptions.key("changelog-producer.full-compaction.trigger-interval")
+            ConfigOptions.key("changelog-producer.compaction-interval")
                     .durationType()
                     .defaultValue(Duration.ofMinutes(30))
                     .withDescription(

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
@@ -299,6 +299,17 @@ public class CoreOptions implements Serializable {
                                     + "This changelog file keeps the details of data changes, "
                                     + "it can be read directly during stream reads.");
 
+    public static final ConfigOption<Duration> CHANGELOG_PRODUCER_FULL_COMPACTION_TRIGGER_INTERVAL =
+            ConfigOptions.key("changelog-producer.full-compaction.trigger-interval")
+                    .durationType()
+                    .defaultValue(Duration.ofMinutes(30))
+                    .withDescription(
+                            "When "
+                                    + CHANGELOG_PRODUCER.key()
+                                    + " is set to "
+                                    + ChangelogProducer.FULL_COMPACTION.name()
+                                    + ", full compaction will be constantly triggered after this interval.");
+
     @Immutable
     public static final ConfigOption<String> SEQUENCE_FIELD =
             ConfigOptions.key("sequence.field")
@@ -514,6 +525,10 @@ public class CoreOptions implements Serializable {
 
     public ChangelogProducer changelogProducer() {
         return options.get(CHANGELOG_PRODUCER);
+    }
+
+    public Duration changelogProducerFullCompactionTriggerInterval() {
+        return options.get(CHANGELOG_PRODUCER_FULL_COMPACTION_TRIGGER_INTERVAL);
     }
 
     public Optional<String> sequenceField() {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/append/AppendOnlyWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/append/AppendOnlyWriter.java
@@ -99,10 +99,9 @@ public class AppendOnlyWriter implements RecordWriter<RowData> {
     }
 
     @Override
-    public CommitIncrement prepareCommit(boolean endOnfInput) throws Exception {
+    public CommitIncrement prepareCommit(boolean blocking) throws Exception {
         flushWriter(false);
-        boolean blocking = endOnfInput || forceCompact;
-        trySyncLatestCompaction(blocking);
+        trySyncLatestCompaction(blocking || forceCompact);
         return drainIncrement();
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeWriter.java
@@ -198,10 +198,9 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
     }
 
     @Override
-    public CommitIncrement prepareCommit(boolean endOfInput) throws Exception {
+    public CommitIncrement prepareCommit(boolean blocking) throws Exception {
         flushWriteBuffer(false);
-        boolean blocking = endOfInput || commitForceCompact;
-        trySyncLatestCompaction(blocking);
+        trySyncLatestCompaction(blocking || commitForceCompact);
         return drainIncrement();
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreScan.java
@@ -49,6 +49,8 @@ public interface FileStoreScan {
 
     FileStoreScan withIncremental(boolean isIncremental);
 
+    FileStoreScan withLevel(int level);
+
     /** Produce a {@link Plan}. */
     Plan plan();
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreWrite.java
@@ -67,12 +67,12 @@ public interface FileStoreWrite<T> {
     /**
      * Prepare commit in the write.
      *
-     * @param endOfInput if true, the data writing is ended
+     * @param blocking if this method need to wait for current compaction to complete
      * @param commitIdentifier identifier of the commit being prepared
      * @return the file committable list
      * @throws Exception the thrown exception
      */
-    List<FileCommittable> prepareCommit(boolean endOfInput, long commitIdentifier) throws Exception;
+    List<FileCommittable> prepareCommit(boolean blocking, long commitIdentifier) throws Exception;
 
     /**
      * Close the writer.

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreWrite.java
@@ -42,6 +42,9 @@ import org.apache.flink.table.store.file.utils.RecordWriter;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
 import org.apache.flink.table.types.logical.RowType;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -52,6 +55,8 @@ import static org.apache.flink.table.store.file.io.DataFileMeta.getMaxSequenceNu
 
 /** {@link FileStoreWrite} for {@link org.apache.flink.table.store.file.KeyValueFileStore}. */
 public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KeyValueFileStoreWrite.class);
 
     private final KeyValueFileReaderFactory.Builder readerFactoryBuilder;
     private final KeyValueFileWriterFactory.Builder writerFactoryBuilder;
@@ -111,6 +116,15 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
             int bucket,
             List<DataFileMeta> restoreFiles,
             ExecutorService compactExecutor) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(
+                    "Creating merge tree writer for partition {} bucket {} from restored files {}",
+                    partition,
+                    bucket,
+                    restoreFiles);
+            new RuntimeException().printStackTrace();
+        }
+
         KeyValueFileWriterFactory writerFactory = writerFactoryBuilder.build(partition, bucket);
         Comparator<RowData> keyComparator = keyComparatorSupplier.get();
         Levels levels = new Levels(keyComparator, restoreFiles, options.numLevels());

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RecordWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RecordWriter.java
@@ -42,10 +42,10 @@ public interface RecordWriter<T> {
     /**
      * Prepare for a commit.
      *
-     * @param endOfInput Signal that there is no committable anymore.
+     * @param blocking if this method need to wait for current compaction to complete
      * @return Incremental files in this snapshot cycle
      */
-    CommitIncrement prepareCommit(boolean endOfInput) throws Exception;
+    CommitIncrement prepareCommit(boolean blocking) throws Exception;
 
     /**
      * Sync the writer. The structure related to file reading and writing is thread unsafe, there

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWrite.java
@@ -40,7 +40,7 @@ public interface TableWrite {
 
     void compact(BinaryRowData partition, int bucket) throws Exception;
 
-    List<FileCommittable> prepareCommit(boolean endOfInput, long commitIdentifier) throws Exception;
+    List<FileCommittable> prepareCommit(boolean blocking, long commitIdentifier) throws Exception;
 
     void close() throws Exception;
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWriteImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWriteImpl.java
@@ -75,9 +75,9 @@ public class TableWriteImpl<T> implements TableWrite {
     }
 
     @Override
-    public List<FileCommittable> prepareCommit(boolean endOfInput, long commitIdentifier)
+    public List<FileCommittable> prepareCommit(boolean blocking, long commitIdentifier)
             throws Exception {
-        return write.prepareCommit(endOfInput, commitIdentifier);
+        return write.prepareCommit(blocking, commitIdentifier);
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/DataTableScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/DataTableScan.java
@@ -91,6 +91,11 @@ public abstract class DataTableScan implements TableScan {
         return this;
     }
 
+    public DataTableScan withLevel(int level) {
+        scan.withLevel(level);
+        return this;
+    }
+
     @VisibleForTesting
     public DataTableScan withBucket(int bucket) {
         scan.withBucket(bucket);

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/UniversalCompactionTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/compact/UniversalCompactionTest.java
@@ -104,7 +104,6 @@ public class UniversalCompactionTest {
         assertThat(pick.isPresent()).isTrue();
         results = pick.get().files().stream().mapToLong(DataFileMeta::fileSize).toArray();
         // 3 should be in the candidate, by size ratio after picking by file num
-        System.out.println(pick.get().outputLevel());
         assertThat(results).isEqualTo(new long[] {1, 2});
     }
 
@@ -125,7 +124,6 @@ public class UniversalCompactionTest {
         assertThat(pick.isPresent()).isTrue();
         results = pick.get().files().stream().mapToLong(DataFileMeta::fileSize).toArray();
         // 3 should be in the candidate, by size ratio after picking by file num
-        System.out.println(pick.get().outputLevel());
         assertThat(results).isEqualTo(new long[] {1, 2, 3});
     }
 


### PR DESCRIPTION
The last step to produce full compaction changelog is to modify Flink Table Store connector, so that full compaction will be triggered once in a while. If not, changelog files are not guaranteed to be produced, and the last few records for a partition may not appear in changelog.