### PR TITLE
[FLINK-29916] Fix bug that Levels in Table Store may mistakenly ignore level 0 files when two files have the same sequence number

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/Levels.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/Levels.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.store.file.mergetree;
 
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.file.data.DataFileMeta;
+import org.apache.flink.util.Preconditions;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -51,7 +52,19 @@ public class Levels {
                         inputFiles.stream().mapToInt(DataFileMeta::level).max().orElse(-1) + 1);
         checkArgument(restoredMaxLevel > 1, "levels must be at least 2.");
         this.level0 =
-                new TreeSet<>(Comparator.comparing(DataFileMeta::maxSequenceNumber).reversed());
+                new TreeSet<>(
+                        (a, b) -> {
+                            if (a.maxSequenceNumber() != b.maxSequenceNumber()) {
+                                // file with larger sequence number should be in front
+                                return Long.compare(b.maxSequenceNumber(), a.maxSequenceNumber());
+                            } else {
+                                // When two or more jobs are writing the same merge tree, it is
+                                // possible that multiple files have the same maxSequenceNumber. In
+                                // this case we have to compare their file names so that files with
+                                // same maxSequenceNumber won't be "de-duplicated" by the tree set.
+                                return a.fileName().compareTo(b.fileName());
+                            }
+                        });
         this.levels = new ArrayList<>();
         for (int i = 1; i < restoredMaxLevel; i++) {
             levels.add(SortedRun.empty());
@@ -62,6 +75,11 @@ public class Levels {
             levelMap.computeIfAbsent(file.level(), level -> new ArrayList<>()).add(file);
         }
         levelMap.forEach((level, files) -> updateLevel(level, emptyList(), files));
+
+        Preconditions.checkState(
+                level0.size() + levels.stream().mapToInt(r -> r.files().size()).sum()
+                        == inputFiles.size(),
+                "Number of files stored in Levels does not equal to the size of inputFiles. This is unexpected.");
     }
 
     public void addLevel0File(DataFileMeta file) {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/LevelsTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/mergetree/LevelsTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.UUID;
 
 import static org.apache.flink.table.store.file.mergetree.compact.MergeTreeCompactManagerTest.row;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,7 +44,6 @@ public class LevelsTest {
 
     @Test
     public void testNonEmptyHighestLevel0() {
-
         Levels levels = new Levels(comparator, Arrays.asList(newFile(0), newFile(0)), 3);
         assertThat(levels.nonEmptyHighestLevel()).isEqualTo(0);
     }
@@ -61,7 +61,14 @@ public class LevelsTest {
         assertThat(levels.nonEmptyHighestLevel()).isEqualTo(2);
     }
 
+    @Test
+    public void testLevel0WithSameSequenceNumbers() {
+        Levels levels = new Levels(comparator, Arrays.asList(newFile(0), newFile(0)), 3);
+        assertThat(levels.allFiles()).hasSize(2);
+    }
+
     public static DataFileMeta newFile(int level) {
-        return new DataFileMeta("", 0, 1, row(0), row(0), null, null, 0, 1, 0, level);
+        return new DataFileMeta(
+                UUID.randomUUID().toString(), 0, 1, row(0), row(0), null, null, 0, 1, 0, level);
     }
 }


### PR DESCRIPTION
(Cherry-picked from #356)

Current constructor of `Levels` class contains the following code:

```java
this.level0 = new TreeSet<>(Comparator.comparing(DataFileMeta::maxSequenceNumber).reversed());
```

However when two or more jobs writing the same bucket, they may produce files containing the same sequence number. If two files have the same `maxSequenceNumber`, one of them will be mistakenly ignored by `TreeSet`.