### PR TITLE
[FLINK-29930] Fix FileStatsExtractorTestBase test case

### DIFF
--- a/flink-table-store-common/src/test/java/org/apache/flink/table/store/format/FileStatsExtractorTestBase.java
+++ b/flink-table-store-common/src/test/java/org/apache/flink/table/store/format/FileStatsExtractorTestBase.java
@@ -87,7 +87,7 @@ public abstract class FileStatsExtractorTestBase {
 
     private List<GenericRowData> createData(RowType rowType) {
         ThreadLocalRandom random = ThreadLocalRandom.current();
-        int numRows = random.nextInt(100);
+        int numRows = random.nextInt(1, 100);
         List<List<Object>> columns = new ArrayList<>();
         for (RowType.RowField field : rowType.getFields()) {
             List<Object> column = new ArrayList<>();


### PR DESCRIPTION
Fix `FileStatsExtractorTestBase` when the `numRows` is zero