### PR TITLE
[hotfix] Fix method name typo in StoreSink class

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/FlinkSinkBuilder.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/FlinkSinkBuilder.java
@@ -111,6 +111,6 @@ public class FlinkSinkBuilder {
                         lockFactory,
                         overwritePartition,
                         logSinkFunction);
-        return sink.sinkTo(new DataStream<>(env, partitioned));
+        return sink.sinkFrom(new DataStream<>(env, partitioned));
     }
 }

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSink.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSink.java
@@ -111,7 +111,7 @@ public class StoreSink implements Serializable {
                         .withLock(lock));
     }
 
-    public DataStreamSink<?> sinkTo(DataStream<RowData> input) {
+    public DataStreamSink<?> sinkFrom(DataStream<RowData> input) {
         // This commitUser is valid only for new jobs.
         // After the job starts, this commitUser will be recorded into the states of write and
         // commit operators.


### PR DESCRIPTION
Change `sinkTo` to `sinkFrom`.