### PR TITLE
[FLINK-29962] Exclude jamon 2.3.1 from dependencies

### DIFF
--- a/flink-table-store-hive/flink-table-store-hive-catalog/pom.xml
+++ b/flink-table-store-hive/flink-table-store-hive-catalog/pom.xml
@@ -359,6 +359,10 @@ under the License.
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.jamon</groupId>
+                    <artifactId>jamon-runtime</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -416,6 +420,10 @@ under the License.
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-databind</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.jamon</groupId>
+                    <artifactId>jamon-runtime</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -444,6 +452,10 @@ under the License.
                 <exclusion>
                     <groupId>org.pentaho</groupId>
                     <artifactId>pentaho-aggdesigner-algorithm</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jamon</groupId>
+                    <artifactId>jamon-runtime</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/flink-table-store-hive/flink-table-store-hive-connector/pom.xml
+++ b/flink-table-store-hive/flink-table-store-hive-connector/pom.xml
@@ -349,6 +349,10 @@ under the License.
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.jamon</groupId>
+                    <artifactId>jamon-runtime</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -406,6 +410,10 @@ under the License.
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-databind</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.jamon</groupId>
+                    <artifactId>jamon-runtime</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -415,6 +423,10 @@ under the License.
             <version>${hive.version}</version>
             <scope>test</scope>
             <exclusions>
+                <exclusion>
+                    <groupId>org.jamon</groupId>
+                    <artifactId>jamon-runtime</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>jdk.tools</groupId>
                     <artifactId>jdk.tools</artifactId>


### PR DESCRIPTION
Flink Table Store has the [same issue](https://issues.apache.org/jira/browse/FLINK-29962) as the main repo - hive dependencies depend on `jamon-runtime-2.3.1` that has malformed [pom](https://repo1.maven.org/maven2/org/jamon/jamon-runtime/2.3.1/jamon-runtime-2.3.1.pom) (nested project tag). My maven mirror complains about this and does not accept the dependency. Here is an error message:

```
Could not resolve dependencies for project org.apache.flink:flink-table-store-hive-catalog:jar:0.3-SNAPSHOT: Failed to collect dependencies at org.apache.hive.hcatalog:hive-webhcat-java-client:jar:2.3.9 -> org.apache.hive.hcatalog:hive-hcatalog-core:jar:2.3.9 -> org.apache.hive:hive-cli:jar:2.3.9 -> org.apache.hive:hive-service:jar:2.3.9 -> org.apache.hive:hive-llap-server:jar:2.3.9 -> org.apache.hbase:hbase-server:jar:1.1.1 -> org.jamon:jamon-runtime:jar:2.3.1: Failed to read artifact descriptor for org.jamon:jamon-runtime:jar:2.3.1: Could not transfer artifact org.jamon:jamon-runtime:pom:2.3.1 from/to confluent-artifactory-central (<mirror url>): transfer failed for <mirror url>/org/jamon/jamon-runtime/2.3.1/jamon-runtime-2.3.1.pom, status: 409 Conflict -> [Help 1]
```

This PR excludes the transitive dependency from the problematic direct dependencies and pins the dependency to 2.4.1.

Kudos to @vvcephei for coming up with the original fix for the main repository.

@JingsongLi Can you please review?


