### PR TITLE
[FLINK-29983] Fix Table Store with Hive3 lacking hive-standalone-metastore dependency

### DIFF
--- a/docs/content/docs/engines/hive.md
+++ b/docs/content/docs/engines/hive.md
@@ -45,11 +45,12 @@ Table Store currently supports MR and Tez execution engine for Hive.
 {{< stable >}}
 Download the jar file with corresponding version.
 
-| |Jar|
-|---|---|
-|Hive 2.3+|[flink-table-store-hive-catalog-{{< version >}}_2.3.jar](https://www.apache.org/dyn/closer.lua/flink/flink-table-store-{{< version >}}/flink-table-store-hive-catalog-{{< version >}}_2.3.jar)|
-|Hive 2.2|[flink-table-store-hive-catalog-{{< version >}}_2.2.jar](https://www.apache.org/dyn/closer.lua/flink/flink-table-store-{{< version >}}/flink-table-store-hive-catalog-{{< version >}}_2.2.jar)|
-|Hive 2.1|[flink-table-store-hive-catalog-{{< version >}}_2.1.jar](https://www.apache.org/dyn/closer.lua/flink/flink-table-store-{{< version >}}/flink-table-store-hive-catalog-{{< version >}}_2.1.jar)|
+|          | Jar                                                                                                                                                                                            |
+|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Hive 3.1 | [flink-table-store-hive-catalog-{{< version >}}_3.1.jar](https://www.apache.org/dyn/closer.lua/flink/flink-table-store-{{< version >}}/flink-table-store-hive-catalog-{{< version >}}_3.1.jar) |
+| Hive 2.3 | [flink-table-store-hive-catalog-{{< version >}}_2.3.jar](https://www.apache.org/dyn/closer.lua/flink/flink-table-store-{{< version >}}/flink-table-store-hive-catalog-{{< version >}}_2.3.jar) |
+| Hive 2.2 | [flink-table-store-hive-catalog-{{< version >}}_2.2.jar](https://www.apache.org/dyn/closer.lua/flink/flink-table-store-{{< version >}}/flink-table-store-hive-catalog-{{< version >}}_2.2.jar) |
+| Hive 2.1 | [flink-table-store-hive-catalog-{{< version >}}_2.1.jar](https://www.apache.org/dyn/closer.lua/flink/flink-table-store-{{< version >}}/flink-table-store-hive-catalog-{{< version >}}_2.1.jar) |
 
 {{< /stable >}}
 {{< unstable >}}

--- a/flink-table-store-hive/flink-table-store-hive-catalog/pom.xml
+++ b/flink-table-store-hive/flink-table-store-hive-catalog/pom.xml
@@ -33,6 +33,55 @@ under the License.
 
     <packaging>jar</packaging>
 
+    <profiles>
+        <profile>
+            <id>hive-3.1</id>
+            <dependencies>
+                <!-- For Hive 3.1.2, package org.apache.hadoop.hive.metastore.api relies on this dependency-->
+                <dependency>
+                    <groupId>org.apache.hive</groupId>
+                    <artifactId>hive-standalone-metastore</artifactId>
+                    <version>${hive.version}</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>log4j</groupId>
+                            <artifactId>log4j</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.slf4j</groupId>
+                            <artifactId>slf4j-log4j12</artifactId>
+                        </exclusion>
+                </exclusions>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>shade-flink</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                                <configuration>
+                                    <dependencyReducedPomLocation>${project.basedir}/target/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+                                    <artifactSet>
+                                        <includes combine.children="append">
+                                            <include>org.apache.hive:hive-standalone-metastore</include>
+                                        </includes>
+                                    </artifactSet>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>

--- a/flink-table-store-hive/pom.xml
+++ b/flink-table-store-hive/pom.xml
@@ -83,6 +83,49 @@ under the License.
                 <hive.main.version>3</hive.main.version>
                 <hive.version>3.1.2</hive.version>
             </properties>
+            <dependencies>
+                <!-- For Hive 3.1.2, package org.apache.hadoop.hive.metastore.api relies on this dependency-->
+                <dependency>
+                    <groupId>org.apache.hive</groupId>
+                    <artifactId>hive-standalone-metastore</artifactId>
+                    <version>${hive.version}</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>log4j</groupId>
+                            <artifactId>log4j</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.slf4j</groupId>
+                            <artifactId>slf4j-log4j12</artifactId>
+                        </exclusion>
+                </exclusions>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>shade-flink</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                                <configuration>
+                                    <dependencyReducedPomLocation>${project.basedir}/target/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+                                    <artifactSet>
+                                        <includes combine.children="append">
+                                            <include>org.apache.hive:hive-standalone-metastore</include>
+                                        </includes>
+                                    </artifactSet>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 

--- a/flink-table-store-hive/pom.xml
+++ b/flink-table-store-hive/pom.xml
@@ -83,49 +83,6 @@ under the License.
                 <hive.main.version>3</hive.main.version>
                 <hive.version>3.1.2</hive.version>
             </properties>
-            <dependencies>
-                <!-- For Hive 3.1.2, package org.apache.hadoop.hive.metastore.api relies on this dependency-->
-                <dependency>
-                    <groupId>org.apache.hive</groupId>
-                    <artifactId>hive-standalone-metastore</artifactId>
-                    <version>${hive.version}</version>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>log4j</groupId>
-                            <artifactId>log4j</artifactId>
-                        </exclusion>
-                        <exclusion>
-                            <groupId>org.slf4j</groupId>
-                            <artifactId>slf4j-log4j12</artifactId>
-                        </exclusion>
-                </exclusions>
-                </dependency>
-            </dependencies>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-shade-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>shade-flink</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>shade</goal>
-                                </goals>
-                                <configuration>
-                                    <dependencyReducedPomLocation>${project.basedir}/target/dependency-reduced-pom.xml</dependencyReducedPomLocation>
-                                    <artifactSet>
-                                        <includes combine.children="append">
-                                            <include>org.apache.hive:hive-standalone-metastore</include>
-                                        </includes>
-                                    </artifactSet>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 

--- a/tools/releasing/create_binary_release.sh
+++ b/tools/releasing/create_binary_release.sh
@@ -63,6 +63,7 @@ cp flink-table-store-spark/target/flink-table-store-spark-${RELEASE_VERSION}.jar
 cp flink-table-store-spark2/target/flink-table-store-spark2-${RELEASE_VERSION}.jar ${RELEASE_DIR}
 
 mvn clean install -Dcheckstyle.skip=true -Dgpg.skip -DskipTests -Phive-3.1 -f flink-table-store-hive
+cp flink-table-store-hive/flink-table-store-hive-catalog/target/flink-table-store-hive-catalog-${RELEASE_VERSION}.jar ${RELEASE_DIR}/flink-table-store-hive-catalog-${RELEASE_VERSION}_3.1.jar
 cp flink-table-store-hive/flink-table-store-hive-connector/target/flink-table-store-hive-connector-${RELEASE_VERSION}.jar ${RELEASE_DIR}/flink-table-store-hive-connector-${RELEASE_VERSION}_3.1.jar
 
 mvn clean install -Dcheckstyle.skip=true -Dgpg.skip -DskipTests -Phive-2.2 -f flink-table-store-hive
@@ -81,6 +82,7 @@ cp flink-table-store-dist/target/flink-table-store-dist-${RELEASE_VERSION}.jar $
 
 cd ${RELEASE_DIR}
 gpg --armor --detach-sig "flink-table-store-dist-${RELEASE_VERSION}.jar"
+gpg --armor --detach-sig "flink-table-store-hive-catalog-${RELEASE_VERSION}_3.1.jar"
 gpg --armor --detach-sig "flink-table-store-hive-catalog-${RELEASE_VERSION}_2.3.jar"
 gpg --armor --detach-sig "flink-table-store-hive-catalog-${RELEASE_VERSION}_2.2.jar"
 gpg --armor --detach-sig "flink-table-store-hive-catalog-${RELEASE_VERSION}_2.1.jar"
@@ -94,6 +96,7 @@ gpg --armor --detach-sig "flink-table-store-dist-${RELEASE_VERSION}_1.15.jar"
 gpg --armor --detach-sig "flink-table-store-dist-${RELEASE_VERSION}_1.14.jar"
 
 $SHASUM "flink-table-store-dist-${RELEASE_VERSION}.jar" > "flink-table-store-dist-${RELEASE_VERSION}.jar.sha512"
+$SHASUM "flink-table-store-hive-catalog-${RELEASE_VERSION}_3.1.jar" > "flink-table-store-hive-catalog-${RELEASE_VERSION}_3.1.jar.sha512"
 $SHASUM "flink-table-store-hive-catalog-${RELEASE_VERSION}_2.3.jar" > "flink-table-store-hive-catalog-${RELEASE_VERSION}_2.3.jar.sha512"
 $SHASUM "flink-table-store-hive-catalog-${RELEASE_VERSION}_2.2.jar" > "flink-table-store-hive-catalog-${RELEASE_VERSION}_2.2.jar.sha512"
 $SHASUM "flink-table-store-hive-catalog-${RELEASE_VERSION}_2.1.jar" > "flink-table-store-hive-catalog-${RELEASE_VERSION}_2.1.jar.sha512"


### PR DESCRIPTION
For Hive3,  `org.apache.hadoop.hive.metastore.api` is moved to `org.apache.hive:hive-standalone-metastore`. We should shade this package as well to avoid `ClassNotFoundException`