### PR TITLE
[FLINK-29994][Table Store]Fix missing a period in description of Lookup Join.

### DIFF
--- a/docs/layouts/shortcodes/generated/rocksdb_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_configuration.html
@@ -12,7 +12,7 @@
             <td><h5>lookup.cache-rows</h5></td>
             <td style="word-wrap: break-word;">10000</td>
             <td>Long</td>
-            <td>The maximum number of rows to store in the cache</td>
+            <td>The maximum number of rows to store in the cache.</td>
         </tr>
         <tr>
             <td><h5>rocksdb.block.blocksize</h5></td>

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/RocksDBOptions.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/RocksDBOptions.java
@@ -53,7 +53,7 @@ public class RocksDBOptions {
             key("lookup.cache-rows")
                     .longType()
                     .defaultValue(10_000L)
-                    .withDescription("The maximum number of rows to store in the cache");
+                    .withDescription("The maximum number of rows to store in the cache.");
 
     // --------------------------------------------------------------------------
     // Provided configurable DBOptions within Flink


### PR DESCRIPTION
Need to add a period to the description of "lookup.cache-rows".