### PR TITLE
[FLINK-28552] GenerateUtils#generateCompare supports MULTISET and MAP

### DIFF
--- a/flink-table-store-common/src/test/java/org/apache/flink/table/store/format/FileStatsExtractorTestBase.java
+++ b/flink-table-store-common/src/test/java/org/apache/flink/table/store/format/FileStatsExtractorTestBase.java
@@ -25,7 +25,9 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericMapData;
 import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.data.binary.BinaryStringData;
@@ -33,7 +35,10 @@ import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.VarBinaryType;
@@ -46,7 +51,9 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -158,6 +165,10 @@ public abstract class FileStatsExtractorTestBase {
                 return randomTimestampData((TimestampType) type);
             case ARRAY:
                 return randomArray((ArrayType) type);
+            case MAP:
+                return randomMap((MapType) type);
+            case MULTISET:
+                return randomMultiset((MultisetType) type);
             default:
                 throw new UnsupportedOperationException(
                         "Unsupported type " + type.asSummaryString());
@@ -208,6 +219,25 @@ public abstract class FileStatsExtractorTestBase {
             javaArray[i] = createField(type.getElementType());
         }
         return new GenericArrayData(javaArray);
+    }
+
+    private MapData randomMap(MapType type) {
+        int length = ThreadLocalRandom.current().nextInt(10);
+        Map<Object, Object> javaMap = new HashMap<>(length);
+        for (int i = 0; i < length; i++) {
+            javaMap.put(createField(type.getKeyType()), createField(type.getValueType()));
+        }
+        return new GenericMapData(javaMap);
+    }
+
+    private MapData randomMultiset(MultisetType type) {
+        int length = ThreadLocalRandom.current().nextInt(10);
+        Map<Object, Object> javaMap = new HashMap<>(length);
+        IntType intType = new IntType(false);
+        for (int i = 0; i < length; i++) {
+            javaMap.put(createField(type.getElementType()), createField(intType));
+        }
+        return new GenericMapData(javaMap);
     }
 
     protected abstract FileFormat createFormat();

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTableTest.java
@@ -64,18 +64,18 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING))
                 .hasSameElementsAs(
                         Arrays.asList(
-                                "1|10|100|binary|varbinary",
-                                "1|11|101|binary|varbinary",
-                                "1|12|102|binary|varbinary",
-                                "1|11|101|binary|varbinary",
-                                "1|12|102|binary|varbinary"));
+                                "1|10|100|binary|varbinary|mapKey:mapVal|multiset",
+                                "1|11|101|binary|varbinary|mapKey:mapVal|multiset",
+                                "1|12|102|binary|varbinary|mapKey:mapVal|multiset",
+                                "1|11|101|binary|varbinary|mapKey:mapVal|multiset",
+                                "1|12|102|binary|varbinary|mapKey:mapVal|multiset"));
         assertThat(getResult(read, splits, binaryRow(2), 0, BATCH_ROW_TO_STRING))
                 .hasSameElementsAs(
                         Arrays.asList(
-                                "2|20|200|binary|varbinary",
-                                "2|21|201|binary|varbinary",
-                                "2|22|202|binary|varbinary",
-                                "2|21|201|binary|varbinary"));
+                                "2|20|200|binary|varbinary|mapKey:mapVal|multiset",
+                                "2|21|201|binary|varbinary|mapKey:mapVal|multiset",
+                                "2|22|202|binary|varbinary|mapKey:mapVal|multiset",
+                                "2|21|201|binary|varbinary|mapKey:mapVal|multiset"));
     }
 
     @Test
@@ -104,10 +104,10 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         assertThat(getResult(read, splits, binaryRow(2), 0, BATCH_ROW_TO_STRING))
                 .hasSameElementsAs(
                         Arrays.asList(
-                                "2|21|201|binary|varbinary",
+                                "2|21|201|binary|varbinary|mapKey:mapVal|multiset",
                                 // this record is in the same file with the first "2|21|201"
-                                "2|22|202|binary|varbinary",
-                                "2|21|201|binary|varbinary"));
+                                "2|22|202|binary|varbinary|mapKey:mapVal|multiset",
+                                "2|21|201|binary|varbinary|mapKey:mapVal|multiset"));
     }
 
     @Test
@@ -119,9 +119,13 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_ROW_TO_STRING))
                 .isEqualTo(
-                        Arrays.asList("+1|11|101|binary|varbinary", "+1|12|102|binary|varbinary"));
+                        Arrays.asList(
+                                "+1|11|101|binary|varbinary|mapKey:mapVal|multiset",
+                                "+1|12|102|binary|varbinary|mapKey:mapVal|multiset"));
         assertThat(getResult(read, splits, binaryRow(2), 0, STREAMING_ROW_TO_STRING))
-                .isEqualTo(Collections.singletonList("+2|21|201|binary|varbinary"));
+                .isEqualTo(
+                        Collections.singletonList(
+                                "+2|21|201|binary|varbinary|mapKey:mapVal|multiset"));
     }
 
     @Test
@@ -150,9 +154,9 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_ROW_TO_STRING))
                 .isEqualTo(
                         Arrays.asList(
-                                "+1|11|101|binary|varbinary",
+                                "+1|11|101|binary|varbinary|mapKey:mapVal|multiset",
                                 // this record is in the same file with "+1|11|101"
-                                "+1|12|102|binary|varbinary"));
+                                "+1|12|102|binary|varbinary|mapKey:mapVal|multiset"));
         assertThat(getResult(read, splits, binaryRow(2), 0, STREAMING_ROW_TO_STRING)).isEmpty();
     }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTableTest.java
@@ -56,15 +56,15 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING))
                 .isEqualTo(
                         Arrays.asList(
-                                "1|11|101|binary|varbinary",
-                                "1|11|101|binary|varbinary",
-                                "1|12|102|binary|varbinary"));
+                                "1|11|101|binary|varbinary|mapKey:mapVal|multiset",
+                                "1|11|101|binary|varbinary|mapKey:mapVal|multiset",
+                                "1|12|102|binary|varbinary|mapKey:mapVal|multiset"));
         assertThat(getResult(read, splits, binaryRow(2), 0, BATCH_ROW_TO_STRING))
                 .isEqualTo(
                         Arrays.asList(
-                                "2|20|200|binary|varbinary",
-                                "2|21|201|binary|varbinary",
-                                "2|22|202|binary|varbinary"));
+                                "2|20|200|binary|varbinary|mapKey:mapVal|multiset",
+                                "2|21|201|binary|varbinary|mapKey:mapVal|multiset",
+                                "2|22|202|binary|varbinary|mapKey:mapVal|multiset"));
     }
 
     @Test
@@ -93,9 +93,9 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
         assertThat(getResult(read, splits, binaryRow(2), 0, BATCH_ROW_TO_STRING))
                 .isEqualTo(
                         Arrays.asList(
-                                "2|21|201|binary|varbinary",
+                                "2|21|201|binary|varbinary|mapKey:mapVal|multiset",
                                 // this record is in the same file with "delete 2|21|201"
-                                "2|22|202|binary|varbinary"));
+                                "2|22|202|binary|varbinary|mapKey:mapVal|multiset"));
     }
 
     @Test
@@ -107,13 +107,15 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_ROW_TO_STRING))
                 .isEqualTo(
-                        Arrays.asList("-1|10|100|binary|varbinary", "+1|11|101|binary|varbinary"));
+                        Arrays.asList(
+                                "-1|10|100|binary|varbinary|mapKey:mapVal|multiset",
+                                "+1|11|101|binary|varbinary|mapKey:mapVal|multiset"));
         assertThat(getResult(read, splits, binaryRow(2), 0, STREAMING_ROW_TO_STRING))
                 .isEqualTo(
                         Arrays.asList(
-                                "-2|21|201|binary|varbinary",
-                                "-2|21|201|binary|varbinary",
-                                "+2|22|202|binary|varbinary"));
+                                "-2|21|201|binary|varbinary|mapKey:mapVal|multiset",
+                                "-2|21|201|binary|varbinary|mapKey:mapVal|multiset",
+                                "+2|22|202|binary|varbinary|mapKey:mapVal|multiset"));
     }
 
     @Test
@@ -143,10 +145,10 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
         assertThat(getResult(read, splits, binaryRow(2), 0, STREAMING_ROW_TO_STRING))
                 .isEqualTo(
                         Arrays.asList(
-                                "-2|21|201|binary|varbinary",
-                                "-2|21|201|binary|varbinary",
+                                "-2|21|201|binary|varbinary|mapKey:mapVal|multiset",
+                                "-2|21|201|binary|varbinary|mapKey:mapVal|multiset",
                                 // this record is in the same file with "delete 2|21|201"
-                                "+2|22|202|binary|varbinary"));
+                                "+2|22|202|binary|varbinary|mapKey:mapVal|multiset"));
     }
 
     private void writeData() throws Exception {

--- a/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/orc/OrcFileFormat.java
+++ b/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/orc/OrcFileFormat.java
@@ -37,8 +37,10 @@ import org.apache.flink.table.store.format.FileFormat;
 import org.apache.flink.table.store.format.FileStatsExtractor;
 import org.apache.flink.table.store.utils.Projection;
 import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.RowType;
 
 import org.apache.orc.TypeDescription;
@@ -111,7 +113,7 @@ public class OrcFileFormat extends FileFormat {
      */
     @Override
     public BulkWriter.Factory<RowData> createWriterFactory(RowType type) {
-        LogicalType[] orcTypes = type.getChildren().toArray(new LogicalType[0]);
+        LogicalType[] orcTypes = refineLogicalType(type).getChildren().toArray(new LogicalType[0]);
 
         TypeDescription typeDescription =
                 OrcSplitReaderUtil.logicalTypeToOrcType(refineLogicalType(type));
@@ -145,6 +147,11 @@ public class OrcFileFormat extends FileFormat {
                 return new MapType(
                         refineLogicalType(mapType.getKeyType()),
                         refineLogicalType(mapType.getValueType()));
+            case MULTISET:
+                MultisetType multisetType = (MultisetType) type;
+                return new MapType(
+                        refineLogicalType(multisetType.getElementType()),
+                        refineLogicalType(new IntType(false)));
             case ROW:
                 RowType rowType = (RowType) type;
                 return new RowType(

--- a/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/orc/OrcFileFormat.java
+++ b/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/orc/OrcFileFormat.java
@@ -113,10 +113,10 @@ public class OrcFileFormat extends FileFormat {
      */
     @Override
     public BulkWriter.Factory<RowData> createWriterFactory(RowType type) {
-        LogicalType[] orcTypes = refineLogicalType(type).getChildren().toArray(new LogicalType[0]);
+        LogicalType refinedType = refineLogicalType(type);
+        LogicalType[] orcTypes = refinedType.getChildren().toArray(new LogicalType[0]);
 
-        TypeDescription typeDescription =
-                OrcSplitReaderUtil.logicalTypeToOrcType(refineLogicalType(type));
+        TypeDescription typeDescription = OrcSplitReaderUtil.logicalTypeToOrcType(refinedType);
         Vectorizer<RowData> vectorizer =
                 new RowDataVectorizer(typeDescription.toString(), orcTypes);
 

--- a/flink-table-store-format/src/test/java/org/apache/flink/table/store/format/orc/OrcFileStatsExtractorTest.java
+++ b/flink-table-store-format/src/test/java/org/apache/flink/table/store/format/orc/OrcFileStatsExtractorTest.java
@@ -31,6 +31,8 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TimestampType;
@@ -66,6 +68,8 @@ public class OrcFileStatsExtractorTest extends FileStatsExtractorTestBase {
                 new TimestampType(3),
                 // orc reader & writer currently cannot preserve a high precision timestamp
                 // new TimestampType(9),
-                new ArrayType(new IntType()));
+                new ArrayType(new IntType()),
+                new MapType(new VarCharType(8), new VarCharType(8)),
+                new MultisetType(new VarCharType(8)));
     }
 }


### PR DESCRIPTION
Currently, changelog mode cannot support map and multiset as the field type. More specifically,

- `MULTISET` is not supported at all, including append-only mode. (
```
Caused by: java.lang.UnsupportedOperationException: Unsupported type: MULTISET<TINYINT>

at org.apache.flink.table.store.shaded.org.apache.flink.orc.OrcSplitReaderUtil.logicalTypeToOrcType(OrcSplitReaderUtil.java:214)
at org.apache.flink.table.store.shaded.org.apache.flink.orc.OrcSplitReaderUtil.logicalTypeToOrcType(OrcSplitReaderUtil.java:210)
at org.apache.flink.table.store.format.orc.OrcFileFormat.createWriterFactory(OrcFileFormat.java:94)
at org.apache.flink.table.store.file.data.AppendOnlyWriter$RowRollingWriter.lambda$createRollingRowWriter$0(AppendOnlyWriter.java:229)
at org.apache.flink.table.store.file.writer.RollingFileWriter.openCurrentWriter(RollingFileWriter.java:73)
at org.apache.flink.table.store.file.writer.RollingFileWriter.write(RollingFileWriter.java:61)
at org.apache.flink.table.store.file.data.AppendOnlyWriter.write(AppendOnlyWriter.java:108)
at org.apache.flink.table.store.file.data.AppendOnlyWriter.write(AppendOnlyWriter.java:56)
at org.apache.flink.table.store.table.AppendOnlyFileStoreTable$3.writeSinkRecord(AppendOnlyFileStoreTable.java:119)
at org.apache.flink.table.store.table.sink.AbstractTableWrite.write(AbstractTableWrite.java:76)
at org.apache.flink.table.store.connector.sink.StoreWriteOperator.processElement(StoreWriteOperator.java:124)
... 13 more)
``` 

Stacktrace
```
java.lang.UnsupportedOperationException
    at org.apache.flink.table.store.codegen.GenerateUtils$.generateCompare(GenerateUtils.scala:139)
    at org.apache.flink.table.store.codegen.GenerateUtils$.$anonfun$generateRowCompare$1(GenerateUtils.scala:289)
    at scala.collection.IndexedSeqOptimized.foreach(IndexedSeqOptimized.scala:32)
    at scala.collection.IndexedSeqOptimized.foreach$(IndexedSeqOptimized.scala:29)
    at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:194)
    at org.apache.flink.table.store.codegen.GenerateUtils$.generateRowCompare(GenerateUtils.scala:263)
    at org.apache.flink.table.store.codegen.ComparatorCodeGenerator$.gen(ComparatorCodeGenerator.scala:45)
    at org.apache.flink.table.store.codegen.ComparatorCodeGenerator.gen(ComparatorCodeGenerator.scala)
    at org.apache.flink.table.store.codegen.CodeGeneratorImpl.generateRecordComparator(CodeGeneratorImpl.java:53)
    at org.apache.flink.table.store.codegen.CodeGenUtils.generateRecordComparator(CodeGenUtils.java:66)
    at org.apache.flink.table.store.file.utils.KeyComparatorSupplier.<init>(KeyComparatorSupplier.java:40)
    at org.apache.flink.table.store.file.KeyValueFileStore.<init>(KeyValueFileStore.java:59)
    at org.apache.flink.table.store.table.ChangelogValueCountFileStoreTable.<init>(ChangelogValueCountFileStoreTable.java:73)
    at org.apache.flink.table.store.table.FileStoreTableFactory.create(FileStoreTableFactory.java:70)
    at org.apache.flink.table.store.table.FileStoreTableFactory.create(FileStoreTableFactory.java:50)
    at org.apache.flink.table.store.spark.SimpleTableTestHelper.<init>(SimpleTableTestHelper.java:58)
    at org.apache.flink.table.store.spark.SparkReadITCase.startMetastoreAndSpark(SparkReadITCase.java:93)
```
`GenerateUtils#generateCompare` should support `MULTISET` and `MAP`.

**The brief change log**

- `GenerateUtils#generateCompare` supports `MULTISET` and `MAP`.
- `OrcFileFormat` supports to refine the `MULTISET` to `MAP`.