### PR TITLE
[FLINK-27843] Schema evolution for data file meta

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/AppendOnlyFileStore.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/AppendOnlyFileStore.java
@@ -76,6 +76,8 @@ public class AppendOnlyFileStore extends AbstractFileStore<RowData> {
                 bucketKeyType.getFieldCount() == 0 ? rowType : bucketKeyType,
                 rowType,
                 snapshotManager(),
+                schemaManager,
+                schemaManager.schema(schemaId),
                 manifestFileFactory(),
                 manifestListFactory(),
                 options.bucket(),

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/AppendOnlyFileStore.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/AppendOnlyFileStore.java
@@ -77,7 +77,7 @@ public class AppendOnlyFileStore extends AbstractFileStore<RowData> {
                 rowType,
                 snapshotManager(),
                 schemaManager,
-                schemaManager.schema(schemaId),
+                schemaId,
                 manifestFileFactory(),
                 manifestListFactory(),
                 options.bucket(),

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValueFileStore.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValueFileStore.java
@@ -24,7 +24,7 @@ import org.apache.flink.table.store.file.mergetree.compact.MergeFunction;
 import org.apache.flink.table.store.file.operation.KeyValueFileStoreRead;
 import org.apache.flink.table.store.file.operation.KeyValueFileStoreScan;
 import org.apache.flink.table.store.file.operation.KeyValueFileStoreWrite;
-import org.apache.flink.table.store.file.schema.SchemaFieldTypeExtractor;
+import org.apache.flink.table.store.file.schema.KeyFieldsExtractor;
 import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.utils.KeyComparatorSupplier;
 import org.apache.flink.table.types.logical.RowType;
@@ -40,7 +40,7 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
     private final RowType bucketKeyType;
     private final RowType keyType;
     private final RowType valueType;
-    private final SchemaFieldTypeExtractor schemaFieldTypeExtractor;
+    private final KeyFieldsExtractor keyFieldsExtractor;
     private final Supplier<Comparator<RowData>> keyComparatorSupplier;
     private final MergeFunction<KeyValue> mergeFunction;
 
@@ -52,13 +52,13 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
             RowType bucketKeyType,
             RowType keyType,
             RowType valueType,
-            SchemaFieldTypeExtractor schemaFieldTypeExtractor,
+            KeyFieldsExtractor keyFieldsExtractor,
             MergeFunction<KeyValue> mergeFunction) {
         super(schemaManager, schemaId, options, partitionType);
         this.bucketKeyType = bucketKeyType;
         this.keyType = keyType;
         this.valueType = valueType;
-        this.schemaFieldTypeExtractor = schemaFieldTypeExtractor;
+        this.keyFieldsExtractor = keyFieldsExtractor;
         this.mergeFunction = mergeFunction;
         this.keyComparatorSupplier = new KeyComparatorSupplier(keyType);
     }
@@ -105,7 +105,7 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
                 snapshotManager(),
                 schemaManager,
                 schemaId,
-                schemaFieldTypeExtractor,
+                keyFieldsExtractor,
                 manifestFileFactory(),
                 manifestListFactory(),
                 options.bucket(),

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValueFileStore.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValueFileStore.java
@@ -104,7 +104,7 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
                 keyType,
                 snapshotManager(),
                 schemaManager,
-                schemaManager.schema(schemaId),
+                schemaId,
                 schemaFieldTypeExtractor,
                 manifestFileFactory(),
                 manifestListFactory(),

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValueFileStore.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValueFileStore.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.store.file.mergetree.compact.MergeFunction;
 import org.apache.flink.table.store.file.operation.KeyValueFileStoreRead;
 import org.apache.flink.table.store.file.operation.KeyValueFileStoreScan;
 import org.apache.flink.table.store.file.operation.KeyValueFileStoreWrite;
+import org.apache.flink.table.store.file.schema.SchemaFieldTypeExtractor;
 import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.utils.KeyComparatorSupplier;
 import org.apache.flink.table.types.logical.RowType;
@@ -39,6 +40,7 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
     private final RowType bucketKeyType;
     private final RowType keyType;
     private final RowType valueType;
+    private final SchemaFieldTypeExtractor schemaFieldTypeExtractor;
     private final Supplier<Comparator<RowData>> keyComparatorSupplier;
     private final MergeFunction<KeyValue> mergeFunction;
 
@@ -50,11 +52,13 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
             RowType bucketKeyType,
             RowType keyType,
             RowType valueType,
+            SchemaFieldTypeExtractor schemaFieldTypeExtractor,
             MergeFunction<KeyValue> mergeFunction) {
         super(schemaManager, schemaId, options, partitionType);
         this.bucketKeyType = bucketKeyType;
         this.keyType = keyType;
         this.valueType = valueType;
+        this.schemaFieldTypeExtractor = schemaFieldTypeExtractor;
         this.mergeFunction = mergeFunction;
         this.keyComparatorSupplier = new KeyComparatorSupplier(keyType);
     }
@@ -99,6 +103,9 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
                 bucketKeyType,
                 keyType,
                 snapshotManager(),
+                schemaManager,
+                schemaManager.schema(schemaId),
+                schemaFieldTypeExtractor,
                 manifestFileFactory(),
                 manifestListFactory(),
                 options.bucket(),

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AbstractFileStoreScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AbstractFileStoreScan.java
@@ -257,11 +257,11 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
         };
     }
 
-    protected TableSchema getTableSchema() {
-        return getTableSchema(this.schemaId);
+    protected TableSchema scanTableSchema() {
+        return scanTableSchema(this.schemaId);
     }
 
-    protected TableSchema getTableSchema(long id) {
+    protected TableSchema scanTableSchema(long id) {
         return tableSchemas.computeIfAbsent(id, key -> schemaManager.schema(id));
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AbstractFileStoreScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AbstractFileStoreScan.java
@@ -29,6 +29,8 @@ import org.apache.flink.table.store.file.manifest.ManifestList;
 import org.apache.flink.table.store.file.predicate.BucketSelector;
 import org.apache.flink.table.store.file.predicate.Predicate;
 import org.apache.flink.table.store.file.predicate.PredicateBuilder;
+import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.stats.FieldStatsArraySerializer;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 import org.apache.flink.table.store.file.utils.FileUtils;
@@ -41,7 +43,9 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -59,6 +63,10 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
     private final boolean checkNumOfBuckets;
     private final CoreOptions.ChangelogProducer changelogProducer;
 
+    private final Map<Long, TableSchema> tableSchemas;
+    private final SchemaManager schemaManager;
+    private final long schemaId;
+
     private Predicate partitionFilter;
     private BucketSelector bucketSelector;
 
@@ -72,6 +80,8 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
             RowType partitionType,
             RowType bucketKeyType,
             SnapshotManager snapshotManager,
+            SchemaManager schemaManager,
+            long schemaId,
             ManifestFile.Factory manifestFileFactory,
             ManifestList.Factory manifestListFactory,
             int numOfBuckets,
@@ -83,11 +93,14 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
                 bucketKeyType.getFieldCount() > 0, "The bucket keys should not be empty.");
         this.bucketKeyType = bucketKeyType;
         this.snapshotManager = snapshotManager;
+        this.schemaManager = schemaManager;
+        this.schemaId = schemaId;
         this.manifestFileFactory = manifestFileFactory;
         this.manifestList = manifestListFactory.create();
         this.numOfBuckets = numOfBuckets;
         this.checkNumOfBuckets = checkNumOfBuckets;
         this.changelogProducer = changelogProducer;
+        this.tableSchemas = new HashMap<>();
     }
 
     @Override
@@ -242,6 +255,14 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
                 return files;
             }
         };
+    }
+
+    protected TableSchema getTableSchema() {
+        return getTableSchema(this.schemaId);
+    }
+
+    protected TableSchema getTableSchema(long id) {
+        return tableSchemas.computeIfAbsent(id, key -> schemaManager.schema(id));
     }
 
     private boolean filterManifestFileMeta(ManifestFileMeta manifest) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AppendOnlyFileStoreScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AppendOnlyFileStoreScan.java
@@ -102,8 +102,8 @@ public class AppendOnlyFileStoreScan extends AbstractFileStoreScan {
         return schemaRowStatsConverters.computeIfAbsent(
                 schemaId,
                 id -> {
-                    TableSchema tableSchema = getTableSchema();
-                    TableSchema schema = getTableSchema(id);
+                    TableSchema tableSchema = scanTableSchema();
+                    TableSchema schema = scanTableSchema(id);
                     return new FieldStatsArraySerializer(
                             schema.logicalRowType(),
                             tableSchema.id() == id

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AppendOnlyFileStoreScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AppendOnlyFileStoreScan.java
@@ -23,11 +23,16 @@ import org.apache.flink.table.store.file.manifest.ManifestEntry;
 import org.apache.flink.table.store.file.manifest.ManifestFile;
 import org.apache.flink.table.store.file.manifest.ManifestList;
 import org.apache.flink.table.store.file.predicate.Predicate;
+import org.apache.flink.table.store.file.schema.SchemaEvolutionUtil;
+import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.stats.FieldStatsArraySerializer;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
 import org.apache.flink.table.types.logical.RowType;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.apache.flink.table.store.file.predicate.PredicateBuilder.and;
 import static org.apache.flink.table.store.file.predicate.PredicateBuilder.pickTransformFieldMapping;
@@ -36,7 +41,10 @@ import static org.apache.flink.table.store.file.predicate.PredicateBuilder.split
 /** {@link FileStoreScan} for {@link org.apache.flink.table.store.file.AppendOnlyFileStore}. */
 public class AppendOnlyFileStoreScan extends AbstractFileStoreScan {
 
-    private final FieldStatsArraySerializer rowStatsConverter;
+    //    private final FieldStatsArraySerializer rowStatsConverter;
+    private final SchemaManager schemaManager;
+    private final TableSchema tableSchema;
+    private final Map<Long, FieldStatsArraySerializer> schemaRowStatsConverters;
     private final RowType rowType;
 
     private Predicate filter;
@@ -46,6 +54,8 @@ public class AppendOnlyFileStoreScan extends AbstractFileStoreScan {
             RowType bucketKeyType,
             RowType rowType,
             SnapshotManager snapshotManager,
+            SchemaManager schemaManager,
+            TableSchema tableSchema,
             ManifestFile.Factory manifestFileFactory,
             ManifestList.Factory manifestListFactory,
             int numOfBuckets,
@@ -59,7 +69,9 @@ public class AppendOnlyFileStoreScan extends AbstractFileStoreScan {
                 numOfBuckets,
                 checkNumOfBuckets,
                 CoreOptions.ChangelogProducer.NONE);
-        this.rowStatsConverter = new FieldStatsArraySerializer(rowType);
+        this.schemaManager = schemaManager;
+        this.tableSchema = tableSchema;
+        this.schemaRowStatsConverters = new HashMap<>();
         this.rowType = rowType;
     }
 
@@ -84,6 +96,22 @@ public class AppendOnlyFileStoreScan extends AbstractFileStoreScan {
                         entry.file().rowCount(),
                         entry.file()
                                 .valueStats()
-                                .fields(rowStatsConverter, entry.file().rowCount()));
+                                .fields(
+                                        getFieldStatsArraySerializer(entry.file().schemaId()),
+                                        entry.file().rowCount()));
+    }
+
+    private FieldStatsArraySerializer getFieldStatsArraySerializer(long schemaId) {
+        return schemaRowStatsConverters.computeIfAbsent(
+                schemaId,
+                id -> {
+                    TableSchema schema = schemaManager.schema(id);
+                    return new FieldStatsArraySerializer(
+                            schema.logicalRowType(),
+                            tableSchema.id() == id
+                                    ? null
+                                    : SchemaEvolutionUtil.createIndexMapping(
+                                            tableSchema.fields(), schema.fields()));
+                });
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreScan.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.store.file.manifest.ManifestList;
 import org.apache.flink.table.store.file.predicate.Predicate;
 import org.apache.flink.table.store.file.schema.DataField;
 import org.apache.flink.table.store.file.schema.KeyFieldsExtractor;
+import org.apache.flink.table.store.file.schema.RowDataType;
 import org.apache.flink.table.store.file.schema.SchemaEvolutionUtil;
 import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.schema.TableSchema;
@@ -112,7 +113,7 @@ public class KeyValueFileStoreScan extends AbstractFileStoreScan {
                     final TableSchema schema = scanTableSchema(key);
                     final List<DataField> keyFields = keyFieldsExtractor.keyFields(schema);
                     return new FieldStatsArraySerializer(
-                            keyFieldsExtractor.keyType(keyFields),
+                            RowDataType.toRowType(false, keyFields),
                             tableSchema.id() == key
                                     ? null
                                     : SchemaEvolutionUtil.createIndexMapping(

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/KeyFieldsExtractor.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/KeyFieldsExtractor.java
@@ -24,15 +24,7 @@ import java.io.Serializable;
 import java.util.List;
 
 /** Extractor of schema for different tables. */
-public interface SchemaFieldTypeExtractor extends Serializable {
-    /**
-     * Extract key type from table schema.
-     *
-     * @param schema the table schema
-     * @return the key type
-     */
-    RowType keyType(TableSchema schema);
-
+public interface KeyFieldsExtractor extends Serializable {
     /**
      * Extract key fields from table schema.
      *
@@ -40,4 +32,12 @@ public interface SchemaFieldTypeExtractor extends Serializable {
      * @return the key fields
      */
     List<DataField> keyFields(TableSchema schema);
+
+    /**
+     * Extract key type from table schema.
+     *
+     * @param keyFields the data fields of key type
+     * @return the key type
+     */
+    RowType keyType(List<DataField> keyFields);
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/KeyFieldsExtractor.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/KeyFieldsExtractor.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.table.store.file.schema;
 
-import org.apache.flink.table.types.logical.RowType;
-
 import java.io.Serializable;
 import java.util.List;
 
@@ -32,12 +30,4 @@ public interface KeyFieldsExtractor extends Serializable {
      * @return the key fields
      */
     List<DataField> keyFields(TableSchema schema);
-
-    /**
-     * Extract key type from table schema.
-     *
-     * @param keyFields the data fields of key type
-     * @return the key type
-     */
-    RowType keyType(List<DataField> keyFields);
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/RowDataType.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/RowDataType.java
@@ -40,7 +40,7 @@ public class RowDataType extends DataType {
         this.fields = fields;
     }
 
-    private static RowType toRowType(boolean isNullable, List<DataField> fields) {
+    public static RowType toRowType(boolean isNullable, List<DataField> fields) {
         List<RowType.RowField> typeFields = new ArrayList<>(fields.size());
         for (DataField field : fields) {
             typeFields.add(

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaEvolutionUtil.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaEvolutionUtil.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.schema;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Utils for schema evolution. */
+public class SchemaEvolutionUtil {
+
+    private static final int NULL_FIELD_INDEX = -1;
+
+    /**
+     * Create index mapping from table fields to underlying data fields.
+     *
+     * @param tableFields the fields of table
+     * @param dataFields the fields of underlying data
+     * @return the index mapping
+     */
+    public static int[] createIndexMapping(
+            List<DataField> tableFields, List<DataField> dataFields) {
+        int[] indexMapping = new int[tableFields.size()];
+        Map<Integer, Integer> fieldIdToIndex = new HashMap<>();
+        for (int i = 0; i < dataFields.size(); i++) {
+            fieldIdToIndex.put(dataFields.get(i).id(), i);
+        }
+
+        for (int i = 0; i < tableFields.size(); i++) {
+            int fieldId = tableFields.get(i).id();
+            Integer dataFieldIndex = fieldIdToIndex.get(fieldId);
+            if (dataFieldIndex != null) {
+                indexMapping[i] = dataFieldIndex;
+            } else {
+                indexMapping[i] = NULL_FIELD_INDEX;
+            }
+        }
+
+        for (int i = 0; i < indexMapping.length; i++) {
+            if (indexMapping[i] != i) {
+                return indexMapping;
+            }
+        }
+        return null;
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaEvolutionUtil.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaEvolutionUtil.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.store.file.schema;
 
+import javax.annotation.Nullable;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +36,7 @@ public class SchemaEvolutionUtil {
      * @param dataFields the fields of underlying data
      * @return the index mapping
      */
+    @Nullable
     public static int[] createIndexMapping(
             List<DataField> tableFields, List<DataField> dataFields) {
         int[] indexMapping = new int[tableFields.size()];

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaFieldTypeExtractor.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaFieldTypeExtractor.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.schema;
+
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.List;
+
+/** Extractor of schema for different tables. */
+public interface SchemaFieldTypeExtractor {
+    /**
+     * Extract key type from table schema.
+     *
+     * @param schema the table schema
+     * @return the key type
+     */
+    RowType keyType(TableSchema schema);
+
+    /**
+     * Extract key fields from table schema.
+     *
+     * @param schema the table schema
+     * @return the key fields
+     */
+    List<DataField> keyFields(TableSchema schema);
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaFieldTypeExtractor.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaFieldTypeExtractor.java
@@ -20,10 +20,11 @@ package org.apache.flink.table.store.file.schema;
 
 import org.apache.flink.table.types.logical.RowType;
 
+import java.io.Serializable;
 import java.util.List;
 
 /** Extractor of schema for different tables. */
-public interface SchemaFieldTypeExtractor {
+public interface SchemaFieldTypeExtractor extends Serializable {
     /**
      * Extract key type from table schema.
      *

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/TableSchema.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/TableSchema.java
@@ -195,20 +195,25 @@ public class TableSchema implements Serializable {
         return projectedLogicalRowType(trimmedPrimaryKeys());
     }
 
+    public List<DataField> trimmedPrimaryKeysFields() {
+        return projectedDataFields(trimmedPrimaryKeys());
+    }
+
     public int[] projection(List<String> projectedFieldNames) {
         List<String> fieldNames = fieldNames();
         return projectedFieldNames.stream().mapToInt(fieldNames::indexOf).toArray();
     }
 
-    private RowType projectedLogicalRowType(List<String> projectedFieldNames) {
+    private List<DataField> projectedDataFields(List<String> projectedFieldNames) {
         List<String> fieldNames = fieldNames();
+        return projectedFieldNames.stream()
+                .map(k -> fields.get(fieldNames.indexOf(k)))
+                .collect(Collectors.toList());
+    }
+
+    private RowType projectedLogicalRowType(List<String> projectedFieldNames) {
         return (RowType)
-                new RowDataType(
-                                false,
-                                projectedFieldNames.stream()
-                                        .map(k -> fields.get(fieldNames.indexOf(k)))
-                                        .collect(Collectors.toList()))
-                        .logicalType;
+                new RowDataType(false, projectedDataFields(projectedFieldNames)).logicalType;
     }
 
     public TableSchema copy(Map<String, String> newOptions) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTable.java
@@ -29,6 +29,8 @@ import org.apache.flink.table.store.file.mergetree.compact.MergeFunction;
 import org.apache.flink.table.store.file.mergetree.compact.ValueCountMergeFunction;
 import org.apache.flink.table.store.file.operation.KeyValueFileStoreScan;
 import org.apache.flink.table.store.file.predicate.Predicate;
+import org.apache.flink.table.store.file.schema.DataField;
+import org.apache.flink.table.store.file.schema.SchemaFieldTypeExtractor;
 import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
@@ -46,6 +48,8 @@ import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.RowKind;
+
+import java.util.List;
 
 /** {@link FileStoreTable} for {@link WriteMode#CHANGE_LOG} write mode without primary keys. */
 public class ChangelogValueCountFileStoreTable extends AbstractFileStoreTable {
@@ -70,6 +74,7 @@ public class ChangelogValueCountFileStoreTable extends AbstractFileStoreTable {
                         tableSchema.logicalBucketKeyType(),
                         tableSchema.logicalRowType(),
                         countType,
+                        ValueCountTableSchemaFieldTypeExtractor.EXTRACTOR,
                         mergeFunction);
     }
 
@@ -145,5 +150,26 @@ public class ChangelogValueCountFileStoreTable extends AbstractFileStoreTable {
     @Override
     public KeyValueFileStore store() {
         return store;
+    }
+
+    /**
+     * {@link SchemaFieldTypeExtractor} implementation for {@link
+     * ChangelogValueCountFileStoreTable}.
+     */
+    static class ValueCountTableSchemaFieldTypeExtractor implements SchemaFieldTypeExtractor {
+        static final ValueCountTableSchemaFieldTypeExtractor EXTRACTOR =
+                new ValueCountTableSchemaFieldTypeExtractor();
+
+        private ValueCountTableSchemaFieldTypeExtractor() {}
+
+        @Override
+        public RowType keyType(TableSchema schema) {
+            return schema.logicalRowType();
+        }
+
+        @Override
+        public List<DataField> keyFields(TableSchema schema) {
+            return schema.fields();
+        }
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTable.java
@@ -74,7 +74,7 @@ public class ChangelogValueCountFileStoreTable extends AbstractFileStoreTable {
                         new CoreOptions(tableSchema.options()),
                         tableSchema.logicalPartitionType(),
                         tableSchema.logicalBucketKeyType(),
-                        extractor.keyType(extractor.keyFields(tableSchema)),
+                        RowDataType.toRowType(false, extractor.keyFields(tableSchema)),
                         countType,
                         extractor,
                         mergeFunction);
@@ -162,11 +162,6 @@ public class ChangelogValueCountFileStoreTable extends AbstractFileStoreTable {
                 new ValueCountTableKeyFieldsExtractor();
 
         private ValueCountTableKeyFieldsExtractor() {}
-
-        @Override
-        public RowType keyType(List<DataField> keyFields) {
-            return (RowType) new RowDataType(false, keyFields).logicalType();
-        }
 
         @Override
         public List<DataField> keyFields(TableSchema schema) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTable.java
@@ -157,6 +157,8 @@ public class ChangelogValueCountFileStoreTable extends AbstractFileStoreTable {
      * ChangelogValueCountFileStoreTable}.
      */
     static class ValueCountTableSchemaFieldTypeExtractor implements SchemaFieldTypeExtractor {
+        private static final long serialVersionUID = 1L;
+
         static final ValueCountTableSchemaFieldTypeExtractor EXTRACTOR =
                 new ValueCountTableSchemaFieldTypeExtractor();
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
@@ -220,6 +220,8 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
     }
 
     static class ChangelogWithKeySchemaFieldTypeExtractor implements SchemaFieldTypeExtractor {
+        private static final long serialVersionUID = 1L;
+
         static final ChangelogWithKeySchemaFieldTypeExtractor EXTRACTOR =
                 new ChangelogWithKeySchemaFieldTypeExtractor();
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
@@ -112,7 +112,7 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
                         options,
                         tableSchema.logicalPartitionType(),
                         addKeyNamePrefix(tableSchema.logicalBucketKeyType()),
-                        extractor.keyType(extractor.keyFields(tableSchema)),
+                        RowDataType.toRowType(false, extractor.keyFields(tableSchema)),
                         rowType,
                         extractor,
                         mergeFunction);
@@ -129,6 +129,18 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
                                                 f.getType(),
                                                 f.getDescription().orElse(null)))
                         .collect(Collectors.toList()));
+    }
+
+    private static List<DataField> addKeyNamePrefix(List<DataField> keyFields) {
+        return keyFields.stream()
+                .map(
+                        f ->
+                                new DataField(
+                                        f.id(),
+                                        KEY_FIELD_PREFIX + f.name(),
+                                        f.type(),
+                                        f.description()))
+                .collect(Collectors.toList());
     }
 
     @Override
@@ -230,13 +242,8 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
         private ChangelogWithKeyKeyFieldsExtractor() {}
 
         @Override
-        public RowType keyType(List<DataField> keyFields) {
-            return addKeyNamePrefix((RowType) new RowDataType(false, keyFields).logicalType());
-        }
-
-        @Override
         public List<DataField> keyFields(TableSchema schema) {
-            return schema.trimmedPrimaryKeysFields();
+            return addKeyNamePrefix(schema.trimmedPrimaryKeysFields());
         }
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -38,7 +38,7 @@ import org.apache.flink.table.store.file.operation.FileStoreCommitImpl;
 import org.apache.flink.table.store.file.operation.FileStoreExpireImpl;
 import org.apache.flink.table.store.file.operation.FileStoreRead;
 import org.apache.flink.table.store.file.operation.FileStoreScan;
-import org.apache.flink.table.store.file.schema.SchemaFieldTypeExtractor;
+import org.apache.flink.table.store.file.schema.KeyFieldsExtractor;
 import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 import org.apache.flink.table.store.file.utils.RecordReaderIterator;
@@ -93,7 +93,7 @@ public class TestFileStore extends KeyValueFileStore {
             RowType partitionType,
             RowType keyType,
             RowType valueType,
-            SchemaFieldTypeExtractor schemaFieldTypeExtractor,
+            KeyFieldsExtractor keyFieldsExtractor,
             MergeFunction<KeyValue> mergeFunction) {
         super(
                 new SchemaManager(options.path()),
@@ -103,7 +103,7 @@ public class TestFileStore extends KeyValueFileStore {
                 keyType,
                 keyType,
                 valueType,
-                schemaFieldTypeExtractor,
+                keyFieldsExtractor,
                 mergeFunction);
         this.root = root;
         this.keySerializer = new RowDataSerializer(keyType);
@@ -456,7 +456,7 @@ public class TestFileStore extends KeyValueFileStore {
         private final RowType partitionType;
         private final RowType keyType;
         private final RowType valueType;
-        private final SchemaFieldTypeExtractor schemaFieldTypeExtractor;
+        private final KeyFieldsExtractor keyFieldsExtractor;
         private final MergeFunction<KeyValue> mergeFunction;
 
         private CoreOptions.ChangelogProducer changelogProducer;
@@ -468,7 +468,7 @@ public class TestFileStore extends KeyValueFileStore {
                 RowType partitionType,
                 RowType keyType,
                 RowType valueType,
-                SchemaFieldTypeExtractor schemaFieldTypeExtractor,
+                KeyFieldsExtractor keyFieldsExtractor,
                 MergeFunction<KeyValue> mergeFunction) {
             this.format = format;
             this.root = root;
@@ -476,7 +476,7 @@ public class TestFileStore extends KeyValueFileStore {
             this.partitionType = partitionType;
             this.keyType = keyType;
             this.valueType = valueType;
-            this.schemaFieldTypeExtractor = schemaFieldTypeExtractor;
+            this.keyFieldsExtractor = keyFieldsExtractor;
             this.mergeFunction = mergeFunction;
 
             this.changelogProducer = CoreOptions.ChangelogProducer.NONE;
@@ -511,7 +511,7 @@ public class TestFileStore extends KeyValueFileStore {
                     partitionType,
                     keyType,
                     valueType,
-                    schemaFieldTypeExtractor,
+                    keyFieldsExtractor,
                     mergeFunction);
         }
     }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -38,6 +38,7 @@ import org.apache.flink.table.store.file.operation.FileStoreCommitImpl;
 import org.apache.flink.table.store.file.operation.FileStoreExpireImpl;
 import org.apache.flink.table.store.file.operation.FileStoreRead;
 import org.apache.flink.table.store.file.operation.FileStoreScan;
+import org.apache.flink.table.store.file.schema.SchemaFieldTypeExtractor;
 import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 import org.apache.flink.table.store.file.utils.RecordReaderIterator;
@@ -92,6 +93,7 @@ public class TestFileStore extends KeyValueFileStore {
             RowType partitionType,
             RowType keyType,
             RowType valueType,
+            SchemaFieldTypeExtractor schemaFieldTypeExtractor,
             MergeFunction<KeyValue> mergeFunction) {
         super(
                 new SchemaManager(options.path()),
@@ -101,6 +103,7 @@ public class TestFileStore extends KeyValueFileStore {
                 keyType,
                 keyType,
                 valueType,
+                schemaFieldTypeExtractor,
                 mergeFunction);
         this.root = root;
         this.keySerializer = new RowDataSerializer(keyType);
@@ -453,6 +456,7 @@ public class TestFileStore extends KeyValueFileStore {
         private final RowType partitionType;
         private final RowType keyType;
         private final RowType valueType;
+        private final SchemaFieldTypeExtractor schemaFieldTypeExtractor;
         private final MergeFunction<KeyValue> mergeFunction;
 
         private CoreOptions.ChangelogProducer changelogProducer;
@@ -464,6 +468,7 @@ public class TestFileStore extends KeyValueFileStore {
                 RowType partitionType,
                 RowType keyType,
                 RowType valueType,
+                SchemaFieldTypeExtractor schemaFieldTypeExtractor,
                 MergeFunction<KeyValue> mergeFunction) {
             this.format = format;
             this.root = root;
@@ -471,6 +476,7 @@ public class TestFileStore extends KeyValueFileStore {
             this.partitionType = partitionType;
             this.keyType = keyType;
             this.valueType = valueType;
+            this.schemaFieldTypeExtractor = schemaFieldTypeExtractor;
             this.mergeFunction = mergeFunction;
 
             this.changelogProducer = CoreOptions.ChangelogProducer.NONE;
@@ -500,7 +506,13 @@ public class TestFileStore extends KeyValueFileStore {
             conf.set(CoreOptions.CHANGELOG_PRODUCER, changelogProducer);
 
             return new TestFileStore(
-                    root, new CoreOptions(conf), partitionType, keyType, valueType, mergeFunction);
+                    root,
+                    new CoreOptions(conf),
+                    partitionType,
+                    keyType,
+                    valueType,
+                    schemaFieldTypeExtractor,
+                    mergeFunction);
         }
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestKeyValueGenerator.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestKeyValueGenerator.java
@@ -26,8 +26,8 @@ import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.runtime.generated.RecordComparator;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.store.file.schema.DataField;
+import org.apache.flink.table.store.file.schema.KeyFieldsExtractor;
 import org.apache.flink.table.store.file.schema.RowDataType;
-import org.apache.flink.table.store.file.schema.SchemaFieldTypeExtractor;
 import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
@@ -330,19 +330,18 @@ public class TestKeyValueGenerator {
         MULTI_PARTITIONED
     }
 
-    /** {@link SchemaFieldTypeExtractor} implementation for test. */
-    public static class TestSchemaFieldTypeExtractor implements SchemaFieldTypeExtractor {
+    /** {@link KeyFieldsExtractor} implementation for test. */
+    public static class TestKeyFieldsExtractor implements KeyFieldsExtractor {
         private static final long serialVersionUID = 1L;
 
-        public static final TestSchemaFieldTypeExtractor EXTRACTOR =
-                new TestSchemaFieldTypeExtractor();
+        public static final TestKeyFieldsExtractor EXTRACTOR = new TestKeyFieldsExtractor();
 
         @Override
-        public RowType keyType(TableSchema schema) {
+        public RowType keyType(List<DataField> keyFields) {
             return (RowType)
                     new RowDataType(
                                     false,
-                                    keyFields(schema).stream()
+                                    keyFields.stream()
                                             .map(
                                                     f ->
                                                             new DataField(

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestKeyValueGenerator.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestKeyValueGenerator.java
@@ -27,7 +27,6 @@ import org.apache.flink.table.runtime.generated.RecordComparator;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.store.file.schema.DataField;
 import org.apache.flink.table.store.file.schema.KeyFieldsExtractor;
-import org.apache.flink.table.store.file.schema.RowDataType;
 import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
@@ -337,25 +336,10 @@ public class TestKeyValueGenerator {
         public static final TestKeyFieldsExtractor EXTRACTOR = new TestKeyFieldsExtractor();
 
         @Override
-        public RowType keyType(List<DataField> keyFields) {
-            return (RowType)
-                    new RowDataType(
-                                    false,
-                                    keyFields.stream()
-                                            .map(
-                                                    f ->
-                                                            new DataField(
-                                                                    f.id(),
-                                                                    "key_" + f.name(),
-                                                                    f.type()))
-                                            .collect(Collectors.toList()))
-                            .logicalType();
-        }
-
-        @Override
         public List<DataField> keyFields(TableSchema schema) {
             return schema.fields().stream()
                     .filter(f -> KEY_NAME_LIST.contains(f.name()))
+                    .map(f -> new DataField(f.id(), "key_" + f.name(), f.type(), f.description()))
                     .collect(Collectors.toList());
         }
     }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestKeyValueGenerator.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestKeyValueGenerator.java
@@ -332,6 +332,8 @@ public class TestKeyValueGenerator {
 
     /** {@link SchemaFieldTypeExtractor} implementation for test. */
     public static class TestSchemaFieldTypeExtractor implements SchemaFieldTypeExtractor {
+        private static final long serialVersionUID = 1L;
+
         public static final TestSchemaFieldTypeExtractor EXTRACTOR =
                 new TestSchemaFieldTypeExtractor();
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestKeyValueGenerator.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestKeyValueGenerator.java
@@ -25,6 +25,10 @@ import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.runtime.generated.RecordComparator;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.table.store.file.schema.DataField;
+import org.apache.flink.table.store.file.schema.RowDataType;
+import org.apache.flink.table.store.file.schema.SchemaFieldTypeExtractor;
+import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.IntType;
@@ -103,6 +107,8 @@ public class TestKeyValueGenerator {
                     },
                     new String[] {"shopId", "orderId", "itemId", "priceAmount", "comment"});
     public static final RowType NON_PARTITIONED_PART_TYPE = RowType.of();
+
+    public static final List<String> KEY_NAME_LIST = Arrays.asList("shopId", "orderId");
 
     public static final RowType KEY_TYPE =
             RowType.of(
@@ -322,5 +328,34 @@ public class TestKeyValueGenerator {
         NON_PARTITIONED,
         SINGLE_PARTITIONED,
         MULTI_PARTITIONED
+    }
+
+    /** {@link SchemaFieldTypeExtractor} implementation for test. */
+    public static class TestSchemaFieldTypeExtractor implements SchemaFieldTypeExtractor {
+        public static final TestSchemaFieldTypeExtractor EXTRACTOR =
+                new TestSchemaFieldTypeExtractor();
+
+        @Override
+        public RowType keyType(TableSchema schema) {
+            return (RowType)
+                    new RowDataType(
+                                    false,
+                                    keyFields(schema).stream()
+                                            .map(
+                                                    f ->
+                                                            new DataField(
+                                                                    f.id(),
+                                                                    "key_" + f.name(),
+                                                                    f.type()))
+                                            .collect(Collectors.toList()))
+                            .logicalType();
+        }
+
+        @Override
+        public List<DataField> keyFields(TableSchema schema) {
+            return schema.fields().stream()
+                    .filter(f -> KEY_NAME_LIST.contains(f.name()))
+                    .collect(Collectors.toList());
+        }
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/io/DataFileTestUtils.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/io/DataFileTestUtils.java
@@ -86,4 +86,14 @@ public class DataFileTestUtils {
         writer.complete();
         return row;
     }
+
+    public static BinaryRowData row(int... values) {
+        BinaryRowData row = new BinaryRowData(values.length);
+        BinaryRowWriter writer = new BinaryRowWriter(row);
+        for (int i = 0; i < values.length; i++) {
+            writer.writeInt(i, values[i]);
+        }
+        writer.complete();
+        return row;
+    }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreCommitTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreCommitTest.java
@@ -537,6 +537,7 @@ public class FileStoreCommitTest {
                         TestKeyValueGenerator.DEFAULT_PART_TYPE,
                         TestKeyValueGenerator.KEY_TYPE,
                         TestKeyValueGenerator.DEFAULT_ROW_TYPE,
+                        TestKeyValueGenerator.TestSchemaFieldTypeExtractor.EXTRACTOR,
                         new DeduplicateMergeFunction())
                 .changelogProducer(changelogProducer)
                 .build();

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreCommitTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreCommitTest.java
@@ -537,7 +537,7 @@ public class FileStoreCommitTest {
                         TestKeyValueGenerator.DEFAULT_PART_TYPE,
                         TestKeyValueGenerator.KEY_TYPE,
                         TestKeyValueGenerator.DEFAULT_ROW_TYPE,
-                        TestKeyValueGenerator.TestSchemaFieldTypeExtractor.EXTRACTOR,
+                        TestKeyValueGenerator.TestKeyFieldsExtractor.EXTRACTOR,
                         new DeduplicateMergeFunction())
                 .changelogProducer(changelogProducer)
                 .build();

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreExpireTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreExpireTest.java
@@ -92,6 +92,7 @@ public class FileStoreExpireTest {
                         TestKeyValueGenerator.DEFAULT_PART_TYPE,
                         TestKeyValueGenerator.KEY_TYPE,
                         TestKeyValueGenerator.DEFAULT_ROW_TYPE,
+                        TestKeyValueGenerator.TestSchemaFieldTypeExtractor.EXTRACTOR,
                         new DeduplicateMergeFunction())
                 .changelogProducer(changelogProducer)
                 .build();

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreExpireTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreExpireTest.java
@@ -92,7 +92,7 @@ public class FileStoreExpireTest {
                         TestKeyValueGenerator.DEFAULT_PART_TYPE,
                         TestKeyValueGenerator.KEY_TYPE,
                         TestKeyValueGenerator.DEFAULT_ROW_TYPE,
-                        TestKeyValueGenerator.TestSchemaFieldTypeExtractor.EXTRACTOR,
+                        TestKeyValueGenerator.TestKeyFieldsExtractor.EXTRACTOR,
                         new DeduplicateMergeFunction())
                 .changelogProducer(changelogProducer)
                 .build();

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreReadTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreReadTest.java
@@ -30,8 +30,8 @@ import org.apache.flink.table.store.file.mergetree.compact.DeduplicateMergeFunct
 import org.apache.flink.table.store.file.mergetree.compact.MergeFunction;
 import org.apache.flink.table.store.file.mergetree.compact.ValueCountMergeFunction;
 import org.apache.flink.table.store.file.schema.DataField;
+import org.apache.flink.table.store.file.schema.KeyFieldsExtractor;
 import org.apache.flink.table.store.file.schema.RowDataType;
-import org.apache.flink.table.store.file.schema.SchemaFieldTypeExtractor;
 import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.schema.UpdateSchema;
@@ -113,13 +113,12 @@ public class KeyValueFileStoreReadTest {
                         partitionType,
                         keyType,
                         valueType,
-                        new SchemaFieldTypeExtractor() {
+                        new KeyFieldsExtractor() {
                             private static final long serialVersionUID = 1L;
 
                             @Override
-                            public RowType keyType(TableSchema schema) {
-                                return (RowType)
-                                        new RowDataType(false, keyFields(schema)).logicalType();
+                            public RowType keyType(List<DataField> keyFields) {
+                                return (RowType) new RowDataType(false, keyFields).logicalType();
                             }
 
                             @Override
@@ -168,7 +167,7 @@ public class KeyValueFileStoreReadTest {
                         TestKeyValueGenerator.DEFAULT_PART_TYPE,
                         TestKeyValueGenerator.KEY_TYPE,
                         TestKeyValueGenerator.DEFAULT_ROW_TYPE,
-                        TestKeyValueGenerator.TestSchemaFieldTypeExtractor.EXTRACTOR,
+                        TestKeyValueGenerator.TestKeyFieldsExtractor.EXTRACTOR,
                         new DeduplicateMergeFunction());
 
         RowDataSerializer projectedValueSerializer =
@@ -257,7 +256,7 @@ public class KeyValueFileStoreReadTest {
             RowType partitionType,
             RowType keyType,
             RowType valueType,
-            SchemaFieldTypeExtractor extractor,
+            KeyFieldsExtractor extractor,
             MergeFunction<KeyValue> mergeFunction)
             throws Exception {
         SchemaManager schemaManager = new SchemaManager(new Path(tempDir.toUri()));

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreReadTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreReadTest.java
@@ -31,7 +31,6 @@ import org.apache.flink.table.store.file.mergetree.compact.MergeFunction;
 import org.apache.flink.table.store.file.mergetree.compact.ValueCountMergeFunction;
 import org.apache.flink.table.store.file.schema.DataField;
 import org.apache.flink.table.store.file.schema.KeyFieldsExtractor;
-import org.apache.flink.table.store.file.schema.RowDataType;
 import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.schema.UpdateSchema;
@@ -115,11 +114,6 @@ public class KeyValueFileStoreReadTest {
                         valueType,
                         new KeyFieldsExtractor() {
                             private static final long serialVersionUID = 1L;
-
-                            @Override
-                            public RowType keyType(List<DataField> keyFields) {
-                                return (RowType) new RowDataType(false, keyFields).logicalType();
-                            }
 
                             @Override
                             public List<DataField> keyFields(TableSchema schema) {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreReadTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreReadTest.java
@@ -114,6 +114,8 @@ public class KeyValueFileStoreReadTest {
                         keyType,
                         valueType,
                         new SchemaFieldTypeExtractor() {
+                            private static final long serialVersionUID = 1L;
+
                             @Override
                             public RowType keyType(TableSchema schema) {
                                 return (RowType)

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreScanTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreScanTest.java
@@ -71,7 +71,7 @@ public class KeyValueFileStoreScanTest {
                                 TestKeyValueGenerator.DEFAULT_PART_TYPE,
                                 TestKeyValueGenerator.KEY_TYPE,
                                 TestKeyValueGenerator.DEFAULT_ROW_TYPE,
-                                TestKeyValueGenerator.TestSchemaFieldTypeExtractor.EXTRACTOR,
+                                TestKeyValueGenerator.TestKeyFieldsExtractor.EXTRACTOR,
                                 new DeduplicateMergeFunction())
                         .build();
         snapshotManager = store.snapshotManager();

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreScanTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreScanTest.java
@@ -71,6 +71,7 @@ public class KeyValueFileStoreScanTest {
                                 TestKeyValueGenerator.DEFAULT_PART_TYPE,
                                 TestKeyValueGenerator.KEY_TYPE,
                                 TestKeyValueGenerator.DEFAULT_ROW_TYPE,
+                                TestKeyValueGenerator.TestSchemaFieldTypeExtractor.EXTRACTOR,
                                 new DeduplicateMergeFunction())
                         .build();
         snapshotManager = store.snapshotManager();

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/schema/SchemaEvolutionUtilTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/schema/SchemaEvolutionUtilTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.schema;
+
+import org.apache.flink.table.api.DataTypes;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link SchemaEvolutionUtil}. */
+public class SchemaEvolutionUtilTest {
+    @Test
+    public void testCreateIndexMapping() {
+        List<DataField> dataFields =
+                Arrays.asList(
+                        new DataField(0, "a", new AtomicDataType(DataTypes.INT().getLogicalType())),
+                        new DataField(1, "b", new AtomicDataType(DataTypes.INT().getLogicalType())),
+                        new DataField(2, "c", new AtomicDataType(DataTypes.INT().getLogicalType())),
+                        new DataField(
+                                3, "d", new AtomicDataType(DataTypes.INT().getLogicalType())));
+        List<DataField> tableFields =
+                Arrays.asList(
+                        new DataField(1, "c", new AtomicDataType(DataTypes.INT().getLogicalType())),
+                        new DataField(3, "a", new AtomicDataType(DataTypes.INT().getLogicalType())),
+                        new DataField(5, "d", new AtomicDataType(DataTypes.INT().getLogicalType())),
+                        new DataField(
+                                6, "e", new AtomicDataType(DataTypes.INT().getLogicalType())));
+        int[] indexMapping = SchemaEvolutionUtil.createIndexMapping(tableFields, dataFields);
+
+        assertThat(indexMapping.length).isEqualTo(tableFields.size()).isEqualTo(4);
+        assertThat(indexMapping[0]).isEqualTo(1);
+        assertThat(indexMapping[1]).isEqualTo(3);
+        assertThat(indexMapping[2]).isLessThan(0);
+        assertThat(indexMapping[3]).isLessThan(0);
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/stats/FieldStatsArraySerializerTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/stats/FieldStatsArraySerializerTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.stats;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.store.file.schema.AtomicDataType;
+import org.apache.flink.table.store.file.schema.DataField;
+import org.apache.flink.table.store.file.schema.SchemaEvolutionUtil;
+import org.apache.flink.table.store.file.schema.TableSchema;
+import org.apache.flink.table.store.format.FieldStats;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.apache.flink.table.store.file.io.DataFileTestUtils.row;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link FieldStatsArraySerializer}. */
+public class FieldStatsArraySerializerTest {
+    @Test
+    public void testFromBinary() {
+        TableSchema dataSchema =
+                new TableSchema(
+                        0,
+                        Arrays.asList(
+                                new DataField(
+                                        0,
+                                        "a",
+                                        new AtomicDataType(DataTypes.INT().getLogicalType())),
+                                new DataField(
+                                        1,
+                                        "b",
+                                        new AtomicDataType(DataTypes.INT().getLogicalType())),
+                                new DataField(
+                                        2,
+                                        "c",
+                                        new AtomicDataType(DataTypes.INT().getLogicalType())),
+                                new DataField(
+                                        3,
+                                        "d",
+                                        new AtomicDataType(DataTypes.INT().getLogicalType()))),
+                        3,
+                        Collections.EMPTY_LIST,
+                        Collections.EMPTY_LIST,
+                        Collections.EMPTY_MAP,
+                        "");
+        TableSchema tableSchema =
+                new TableSchema(
+                        0,
+                        Arrays.asList(
+                                new DataField(
+                                        1,
+                                        "c",
+                                        new AtomicDataType(DataTypes.INT().getLogicalType())),
+                                new DataField(
+                                        3,
+                                        "a",
+                                        new AtomicDataType(DataTypes.INT().getLogicalType())),
+                                new DataField(
+                                        5,
+                                        "d",
+                                        new AtomicDataType(DataTypes.INT().getLogicalType())),
+                                new DataField(
+                                        6,
+                                        "e",
+                                        new AtomicDataType(DataTypes.INT().getLogicalType())),
+                                new DataField(
+                                        7,
+                                        "b",
+                                        new AtomicDataType(DataTypes.INT().getLogicalType()))),
+                        7,
+                        Collections.EMPTY_LIST,
+                        Collections.EMPTY_LIST,
+                        Collections.EMPTY_MAP,
+                        "");
+
+        FieldStatsArraySerializer fieldStatsArraySerializer =
+                new FieldStatsArraySerializer(
+                        tableSchema.logicalRowType(),
+                        SchemaEvolutionUtil.createIndexMapping(
+                                tableSchema.fields(), dataSchema.fields()));
+        BinaryRowData minRowData = row(1, 2, 3, 4);
+        BinaryRowData maxRowData = row(100, 99, 98, 97);
+        long[] nullCounts = new long[] {1, 0, 10, 100};
+        BinaryTableStats dataTableStats = new BinaryTableStats(minRowData, maxRowData, nullCounts);
+
+        FieldStats[] fieldStatsArray = dataTableStats.fields(fieldStatsArraySerializer, 1000L);
+        assertThat(fieldStatsArray.length).isEqualTo(tableSchema.fields().size()).isEqualTo(5);
+        checkFieldStats(fieldStatsArray[0], 2, 99, 0L);
+        checkFieldStats(fieldStatsArray[1], 4, 97, 100L);
+        checkFieldStats(fieldStatsArray[2], null, null, 1000L);
+        checkFieldStats(fieldStatsArray[3], null, null, 1000L);
+        checkFieldStats(fieldStatsArray[4], null, null, 1000L);
+    }
+
+    private void checkFieldStats(FieldStats fieldStats, Integer min, Integer max, Long nullCount) {
+        assertThat(fieldStats.minValue()).isEqualTo(min);
+        assertThat(fieldStats.maxValue()).isEqualTo(max);
+        assertThat(fieldStats.nullCount()).isEqualTo(nullCount);
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyTableFileMetaFilterTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyTableFileMetaFilterTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.table;
+
+import org.apache.flink.table.store.CoreOptions;
+import org.apache.flink.table.store.file.WriteMode;
+
+import org.junit.jupiter.api.BeforeEach;
+
+/** Tests for meta files in {@link AppendOnlyFileStoreTable} with schema evolution. */
+public class AppendOnlyTableFileMetaFilterTest extends FileMetaFilterTestBase {
+
+    @BeforeEach
+    public void before() throws Exception {
+        super.before();
+        tableConfig.set(CoreOptions.WRITE_MODE, WriteMode.APPEND_ONLY);
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyTableFileMetaFilterTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyTableFileMetaFilterTest.java
@@ -20,8 +20,14 @@ package org.apache.flink.table.store.table;
 
 import org.apache.flink.table.store.CoreOptions;
 import org.apache.flink.table.store.file.WriteMode;
+import org.apache.flink.table.store.file.io.DataFileMeta;
+import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.file.schema.TableSchema;
+import org.apache.flink.table.store.file.stats.BinaryTableStats;
 
 import org.junit.jupiter.api.BeforeEach;
+
+import java.util.Map;
 
 /** Tests for meta files in {@link AppendOnlyFileStoreTable} with schema evolution. */
 public class AppendOnlyTableFileMetaFilterTest extends FileMetaFilterTestBase {
@@ -30,5 +36,16 @@ public class AppendOnlyTableFileMetaFilterTest extends FileMetaFilterTestBase {
     public void before() throws Exception {
         super.before();
         tableConfig.set(CoreOptions.WRITE_MODE, WriteMode.APPEND_ONLY);
+    }
+
+    @Override
+    protected FileStoreTable createFileStoreTable(Map<Long, TableSchema> tableSchemas) {
+        SchemaManager schemaManager = new TestingSchemaManager(tablePath, tableSchemas);
+        return new AppendOnlyFileStoreTable(tablePath, schemaManager, schemaManager.latest().get());
+    }
+
+    @Override
+    protected BinaryTableStats getTableValueStats(DataFileMeta fileMeta) {
+        return fileMeta.valueStats();
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogValueCountFileMetaFilterTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogValueCountFileMetaFilterTest.java
@@ -20,11 +20,16 @@ package org.apache.flink.table.store.table;
 
 import org.apache.flink.table.store.CoreOptions;
 import org.apache.flink.table.store.file.WriteMode;
+import org.apache.flink.table.store.file.io.DataFileMeta;
+import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.file.schema.TableSchema;
+import org.apache.flink.table.store.file.stats.BinaryTableStats;
 
 import org.junit.jupiter.api.BeforeEach;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /** Tests for meta files in {@link ChangelogValueCountFileStoreTable} with schema evolution. */
 public class ChangelogValueCountFileMetaFilterTest extends FileMetaFilterTestBase {
@@ -38,5 +43,17 @@ public class ChangelogValueCountFileMetaFilterTest extends FileMetaFilterTestBas
     @Override
     protected List<String> getPrimaryKeyNames() {
         return Collections.emptyList();
+    }
+
+    @Override
+    protected FileStoreTable createFileStoreTable(Map<Long, TableSchema> tableSchemas) {
+        SchemaManager schemaManager = new TestingSchemaManager(tablePath, tableSchemas);
+        return new ChangelogValueCountFileStoreTable(
+                tablePath, schemaManager, schemaManager.latest().get());
+    }
+
+    @Override
+    protected BinaryTableStats getTableValueStats(DataFileMeta fileMeta) {
+        return fileMeta.keyStats();
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogValueCountFileMetaFilterTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogValueCountFileMetaFilterTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.table;
+
+import org.apache.flink.table.store.CoreOptions;
+import org.apache.flink.table.store.file.WriteMode;
+
+import org.junit.jupiter.api.BeforeEach;
+
+import java.util.Collections;
+import java.util.List;
+
+/** Tests for meta files in {@link ChangelogValueCountFileStoreTable} with schema evolution. */
+public class ChangelogValueCountFileMetaFilterTest extends FileMetaFilterTestBase {
+
+    @BeforeEach
+    public void before() throws Exception {
+        super.before();
+        tableConfig.set(CoreOptions.WRITE_MODE, WriteMode.CHANGE_LOG);
+    }
+
+    @Override
+    protected List<String> getPrimaryKeyNames() {
+        return Collections.emptyList();
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileMetaFilterTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileMetaFilterTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.table;
+
+import org.apache.flink.table.store.CoreOptions;
+import org.apache.flink.table.store.file.WriteMode;
+
+import org.junit.jupiter.api.BeforeEach;
+
+/** Tests for meta files in {@link ChangelogWithKeyFileStoreTable} with schema evolution. */
+public class ChangelogWithKeyFileMetaFilterTest extends FileMetaFilterTestBase {
+    @BeforeEach
+    public void before() throws Exception {
+        super.before();
+        tableConfig.set(CoreOptions.WRITE_MODE, WriteMode.CHANGE_LOG);
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileMetaFilterTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileMetaFilterTest.java
@@ -20,14 +20,118 @@ package org.apache.flink.table.store.table;
 
 import org.apache.flink.table.store.CoreOptions;
 import org.apache.flink.table.store.file.WriteMode;
+import org.apache.flink.table.store.file.io.DataFileMeta;
+import org.apache.flink.table.store.file.predicate.Predicate;
+import org.apache.flink.table.store.file.predicate.PredicateBuilder;
+import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.file.schema.TableSchema;
+import org.apache.flink.table.store.file.stats.BinaryTableStats;
+import org.apache.flink.table.store.table.source.DataTableScan;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /** Tests for meta files in {@link ChangelogWithKeyFileStoreTable} with schema evolution. */
 public class ChangelogWithKeyFileMetaFilterTest extends FileMetaFilterTestBase {
+
     @BeforeEach
     public void before() throws Exception {
         super.before();
         tableConfig.set(CoreOptions.WRITE_MODE, WriteMode.CHANGE_LOG);
+    }
+
+    @Test
+    @Override
+    public void testTableScan() throws Exception {
+        writeAndCheckFileMeta(
+                schemas -> {
+                    FileStoreTable table = createFileStoreTable(schemas);
+                    DataTableScan.DataFilePlan plan = table.newScan().plan();
+                    checkFilterRowCount(plan, 6L);
+                    return plan.splits.stream()
+                            .flatMap(s -> s.files().stream())
+                            .collect(Collectors.toList());
+                },
+                (files, schemas) -> {
+                    FileStoreTable table = createFileStoreTable(schemas);
+                    DataTableScan.DataFilePlan plan = table.newScan().plan();
+                    checkFilterRowCount(plan, 12L);
+                },
+                getPrimaryKeyNames(),
+                tableConfig,
+                this::createFileStoreTable);
+    }
+
+    @Test
+    @Override
+    public void testTableScanFilterExistFields() throws Exception {
+        writeAndCheckFileMeta(
+                schemas -> {
+                    FileStoreTable table = createFileStoreTable(schemas);
+                    // results of field "b" in [14, 19] in SCHEMA_0_FIELDS, "b" is renamed to "d" in
+                    // SCHEMA_1_FIELDS
+                    Predicate predicate =
+                            new PredicateBuilder(table.schema().logicalRowType())
+                                    .between(2, 14, 19);
+                    DataTableScan.DataFilePlan plan = table.newScan().withFilter(predicate).plan();
+                    checkFilterRowCount(plan, 6L);
+                    return plan.splits.stream()
+                            .flatMap(s -> s.files().stream())
+                            .collect(Collectors.toList());
+                },
+                (files, schemas) -> {
+                    FileStoreTable table = createFileStoreTable(schemas);
+                    PredicateBuilder builder =
+                            new PredicateBuilder(table.schema().logicalRowType());
+                    // results of field "d" in [14, 19] in SCHEMA_1_FIELDS
+                    Predicate predicate = builder.between(1, 14, 19);
+                    DataTableScan.DataFilePlan plan = table.newScan().withFilter(predicate).plan();
+                    checkFilterRowCount(plan, 12L);
+                },
+                getPrimaryKeyNames(),
+                tableConfig,
+                this::createFileStoreTable);
+    }
+
+    @Test
+    @Override
+    public void testTableScanFilterNewFields() throws Exception {
+        writeAndCheckFileMeta(
+                schemas -> {
+                    FileStoreTable table = createFileStoreTable(schemas);
+                    DataTableScan.DataFilePlan plan = table.newScan().plan();
+                    checkFilterRowCount(plan, 6L);
+                    return plan.splits.stream()
+                            .flatMap(s -> s.files().stream())
+                            .collect(Collectors.toList());
+                },
+                (files, schemas) -> {
+                    FileStoreTable table = createFileStoreTable(schemas);
+                    PredicateBuilder builder =
+                            new PredicateBuilder(table.schema().logicalRowType());
+                    // results of field "a" in (1120, -] in SCHEMA_1_FIELDS, "a" is not existed in
+                    // SCHEMA_0_FIELDS
+                    Predicate predicate = builder.greaterThan(3, 1120);
+                    DataTableScan.DataFilePlan plan = table.newScan().withFilter(predicate).plan();
+                    checkFilterRowCount(plan, 12L);
+                },
+                getPrimaryKeyNames(),
+                tableConfig,
+                this::createFileStoreTable);
+    }
+
+    @Override
+    protected FileStoreTable createFileStoreTable(Map<Long, TableSchema> tableSchemas) {
+        SchemaManager schemaManager = new TestingSchemaManager(tablePath, tableSchemas);
+        return new ChangelogWithKeyFileStoreTable(
+                tablePath, schemaManager, schemaManager.latest().get());
+    }
+
+    @Override
+    protected BinaryTableStats getTableValueStats(DataFileMeta fileMeta) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/FileMetaFilterTestBase.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/FileMetaFilterTestBase.java
@@ -1,0 +1,583 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.table;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.store.CoreOptions;
+import org.apache.flink.table.store.file.io.DataFileMeta;
+import org.apache.flink.table.store.file.predicate.Predicate;
+import org.apache.flink.table.store.file.predicate.PredicateBuilder;
+import org.apache.flink.table.store.file.schema.AtomicDataType;
+import org.apache.flink.table.store.file.schema.DataField;
+import org.apache.flink.table.store.file.schema.SchemaChange;
+import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.file.schema.TableSchema;
+import org.apache.flink.table.store.file.schema.UpdateSchema;
+import org.apache.flink.table.store.file.utils.TestAtomicRenameFileSystem;
+import org.apache.flink.table.store.file.utils.TraceableFileSystem;
+import org.apache.flink.table.store.format.FieldStats;
+import org.apache.flink.table.store.table.sink.TableCommit;
+import org.apache.flink.table.store.table.sink.TableWrite;
+import org.apache.flink.table.store.table.source.DataSplit;
+import org.apache.flink.table.store.table.source.DataTableScan;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Base test class for schema evolution in {@link FileStoreTable}. */
+public abstract class FileMetaFilterTestBase {
+    protected static final List<DataField> SCHEMA_0_FIELDS =
+            Arrays.asList(
+                    new DataField(0, "a", new AtomicDataType(DataTypes.STRING().getLogicalType())),
+                    new DataField(1, "pt", new AtomicDataType(DataTypes.INT().getLogicalType())),
+                    new DataField(2, "b", new AtomicDataType(DataTypes.INT().getLogicalType())),
+                    new DataField(3, "c", new AtomicDataType(DataTypes.STRING().getLogicalType())),
+                    new DataField(4, "kt", new AtomicDataType(DataTypes.BIGINT().getLogicalType())),
+                    new DataField(5, "d", new AtomicDataType(DataTypes.STRING().getLogicalType())));
+    protected static final List<DataField> SCHEMA_1_FIELDS =
+            Arrays.asList(
+                    new DataField(1, "pt", new AtomicDataType(DataTypes.INT().getLogicalType())),
+                    new DataField(2, "d", new AtomicDataType(DataTypes.INT().getLogicalType())),
+                    new DataField(4, "kt", new AtomicDataType(DataTypes.BIGINT().getLogicalType())),
+                    new DataField(6, "a", new AtomicDataType(DataTypes.INT().getLogicalType())),
+                    new DataField(7, "f", new AtomicDataType(DataTypes.STRING().getLogicalType())),
+                    new DataField(8, "b", new AtomicDataType(DataTypes.STRING().getLogicalType())));
+    protected static final List<String> PARTITION_NAMES = Collections.singletonList("pt");
+    protected static final List<String> PRIMARY_KEY_NAMES = Arrays.asList("pt", "kt");
+
+    protected Path tablePath;
+    protected String commitUser;
+    protected final Configuration tableConfig = new Configuration();
+
+    @TempDir java.nio.file.Path tempDir;
+
+    @BeforeEach
+    public void before() throws Exception {
+        tablePath = new Path(TestAtomicRenameFileSystem.SCHEME + "://" + tempDir.toString());
+        commitUser = UUID.randomUUID().toString();
+        tableConfig.set(CoreOptions.PATH, tablePath.toString());
+        tableConfig.set(CoreOptions.BUCKET, 2);
+    }
+
+    @AfterEach
+    public void after() throws IOException {
+        // assert all connections are closed
+        FileSystem fileSystem = tablePath.getFileSystem();
+        assertThat(fileSystem).isInstanceOf(TraceableFileSystem.class);
+        TraceableFileSystem traceableFileSystem = (TraceableFileSystem) fileSystem;
+
+        java.util.function.Predicate<Path> pathPredicate =
+                path -> path.toString().contains(tempDir.toString());
+        assertThat(traceableFileSystem.openInputStreams(pathPredicate)).isEmpty();
+        assertThat(traceableFileSystem.openOutputStreams(pathPredicate)).isEmpty();
+    }
+
+    @Test
+    public void testTableScan() throws Exception {
+        writeAndCheckFileMeta(
+                schemas -> {
+                    FileStoreTable table = createFileStoreTable(schemas);
+                    DataTableScan.DataFilePlan plan = table.newScan().plan();
+                    checkFilterRowCount(plan, 6L);
+                    return plan.splits.stream()
+                            .flatMap(s -> s.files().stream())
+                            .collect(Collectors.toList());
+                },
+                (files, schemas) -> {
+                    FileStoreTable table = createFileStoreTable(schemas);
+                    DataTableScan.DataFilePlan plan =
+                            table.newScan()
+                                    .withFilter(
+                                            new PredicateBuilder(table.schema().logicalRowType())
+                                                    .greaterOrEqual(1, 0))
+                                    .plan();
+                    checkFilterRowCount(plan, 12L);
+
+                    List<String> filesName =
+                            files.stream().map(DataFileMeta::fileName).collect(Collectors.toList());
+                    assertThat(filesName.size()).isGreaterThan(0);
+
+                    List<DataFileMeta> fileMetaList =
+                            plan.splits.stream()
+                                    .flatMap(s -> s.files().stream())
+                                    .collect(Collectors.toList());
+                    assertThat(
+                                    fileMetaList.stream()
+                                            .map(DataFileMeta::fileName)
+                                            .collect(Collectors.toList()))
+                            .containsAll(filesName);
+
+                    for (DataFileMeta fileMeta : fileMetaList) {
+                        FieldStats[] statsArray = fileMeta.valueStats().fields(null);
+                        assertThat(statsArray.length).isEqualTo(6);
+                        if (filesName.contains(fileMeta.fileName())) {
+                            assertThat(statsArray[0].minValue()).isNotNull();
+                            assertThat(statsArray[0].maxValue()).isNotNull();
+                            assertThat(statsArray[1].minValue()).isNotNull();
+                            assertThat(statsArray[1].maxValue()).isNotNull();
+                            assertThat(statsArray[2].minValue()).isNotNull();
+                            assertThat(statsArray[2].maxValue()).isNotNull();
+
+                            assertThat(statsArray[3].minValue()).isNull();
+                            assertThat(statsArray[3].maxValue()).isNull();
+                            assertThat(statsArray[4].minValue()).isNull();
+                            assertThat(statsArray[4].maxValue()).isNull();
+                            assertThat(statsArray[5].minValue()).isNull();
+                            assertThat(statsArray[5].maxValue()).isNull();
+                        } else {
+                            assertThat(statsArray[0].minValue()).isNotNull();
+                            assertThat(statsArray[0].maxValue()).isNotNull();
+                            assertThat(statsArray[1].minValue()).isNotNull();
+                            assertThat(statsArray[1].maxValue()).isNotNull();
+                            assertThat(statsArray[2].minValue()).isNotNull();
+                            assertThat(statsArray[2].maxValue()).isNotNull();
+                            assertThat(statsArray[3].minValue()).isNotNull();
+                            assertThat(statsArray[3].maxValue()).isNotNull();
+                            assertThat(statsArray[4].minValue()).isNotNull();
+                            assertThat(statsArray[4].maxValue()).isNotNull();
+                            assertThat(statsArray[5].minValue()).isNotNull();
+                            assertThat(statsArray[5].maxValue()).isNotNull();
+                        }
+                    }
+                });
+    }
+
+    @Test
+    public void testTableScanFilterExistFields() throws Exception {
+        writeAndCheckFileMeta(
+                schemas -> {
+                    FileStoreTable table = createFileStoreTable(schemas);
+                    // results of field "b" in [14, 19] in SCHEMA_0_FIELDS, "b" is renamed to "d" in
+                    // SCHEMA_1_FIELDS
+                    Predicate predicate =
+                            new PredicateBuilder(table.schema().logicalRowType())
+                                    .between(2, 14, 19);
+                    List<DataFileMeta> files =
+                            table.newScan().withFilter(predicate).plan().splits.stream()
+                                    .flatMap(s -> s.files().stream())
+                                    .collect(Collectors.toList());
+                    assertThat(files.size()).isGreaterThan(0);
+                    checkFilterRowCount(files, 3L);
+                    return files;
+                },
+                (files, schemas) -> {
+                    FileStoreTable table = createFileStoreTable(schemas);
+                    PredicateBuilder builder =
+                            new PredicateBuilder(table.schema().logicalRowType());
+                    // results of field "d" in [14, 19] in SCHEMA_1_FIELDS
+                    Predicate predicate = builder.between(1, 14, 19);
+                    DataTableScan.DataFilePlan filterFilePlan =
+                            table.newScan().withFilter(predicate).plan();
+                    List<DataFileMeta> filterFileMetas =
+                            filterFilePlan.splits.stream()
+                                    .flatMap(s -> s.files().stream())
+                                    .collect(Collectors.toList());
+                    checkFilterRowCount(filterFileMetas, 6L);
+
+                    List<String> fileNameList =
+                            filterFileMetas.stream()
+                                    .map(DataFileMeta::fileName)
+                                    .collect(Collectors.toList());
+                    Set<String> fileNames =
+                            filterFileMetas.stream()
+                                    .map(DataFileMeta::fileName)
+                                    .collect(Collectors.toSet());
+                    assertThat(fileNameList.size()).isEqualTo(fileNames.size());
+
+                    builder = new PredicateBuilder(table.schema().logicalRowType());
+                    // get all meta files with filter
+                    DataTableScan.DataFilePlan filterAllFilePlan =
+                            table.newScan().withFilter(builder.greaterOrEqual(1, 0)).plan();
+                    assertThat(
+                                    filterAllFilePlan.splits.stream()
+                                            .flatMap(
+                                                    s ->
+                                                            s.files().stream()
+                                                                    .map(DataFileMeta::fileName))
+                                            .collect(Collectors.toList()))
+                            .containsAll(
+                                    files.stream()
+                                            .map(DataFileMeta::fileName)
+                                            .collect(Collectors.toList()));
+
+                    // get all meta files without filter
+                    DataTableScan.DataFilePlan allFilePlan = table.newScan().plan();
+                    assertThat(filterAllFilePlan.splits).isEqualTo(allFilePlan.splits);
+
+                    Set<String> filterFileNames = new HashSet<>();
+                    for (DataSplit dataSplit : filterAllFilePlan.splits) {
+                        for (DataFileMeta dataFileMeta : dataSplit.files()) {
+                            FieldStats[] fieldStats = dataFileMeta.valueStats().fields(null);
+                            int minValue = (Integer) fieldStats[1].minValue();
+                            int maxValue = (Integer) fieldStats[1].maxValue();
+                            if (minValue >= 14
+                                    && minValue <= 19
+                                    && maxValue >= 14
+                                    && maxValue <= 19) {
+                                filterFileNames.add(dataFileMeta.fileName());
+                            }
+                        }
+                    }
+                    assertThat(filterFileNames).isEqualTo(fileNames);
+                });
+    }
+
+    @Test
+    public void testTableScanFilterNewFields() throws Exception {
+        writeAndCheckFileMeta(
+                schemas -> {
+                    FileStoreTable table = createFileStoreTable(schemas);
+                    List<DataFileMeta> files =
+                            table.newScan().plan().splits.stream()
+                                    .flatMap(s -> s.files().stream())
+                                    .collect(Collectors.toList());
+                    assertThat(files.size()).isGreaterThan(0);
+                    checkFilterRowCount(files, 6L);
+                    return files;
+                },
+                (files, schemas) -> {
+                    FileStoreTable table = createFileStoreTable(schemas);
+                    PredicateBuilder builder =
+                            new PredicateBuilder(table.schema().logicalRowType());
+
+                    // results of field "a" in (1120, -] in SCHEMA_1_FIELDS, "a" is not existed in
+                    // SCHEMA_0_FIELDS
+                    Predicate predicate = builder.greaterThan(3, 1120);
+                    DataTableScan.DataFilePlan filterFilePlan =
+                            table.newScan().withFilter(predicate).plan();
+                    checkFilterRowCount(filterFilePlan, 2L);
+
+                    List<DataFileMeta> filterFileMetas =
+                            filterFilePlan.splits.stream()
+                                    .flatMap(s -> s.files().stream())
+                                    .collect(Collectors.toList());
+                    List<String> fileNameList =
+                            filterFileMetas.stream()
+                                    .map(DataFileMeta::fileName)
+                                    .collect(Collectors.toList());
+                    Set<String> fileNames =
+                            filterFileMetas.stream()
+                                    .map(DataFileMeta::fileName)
+                                    .collect(Collectors.toSet());
+                    assertThat(fileNameList.size()).isEqualTo(fileNames.size());
+
+                    List<String> filesName =
+                            files.stream().map(DataFileMeta::fileName).collect(Collectors.toList());
+                    assertThat(fileNameList).doesNotContainAnyElementsOf(filesName);
+
+                    DataTableScan.DataFilePlan allFilePlan =
+                            table.newScan().withFilter(builder.greaterOrEqual(1, 0)).plan();
+                    checkFilterRowCount(allFilePlan, 12L);
+
+                    Set<String> filterFileNames = new HashSet<>();
+                    for (DataSplit dataSplit : allFilePlan.splits) {
+                        for (DataFileMeta dataFileMeta : dataSplit.files()) {
+                            FieldStats[] fieldStats = dataFileMeta.valueStats().fields(null);
+                            Integer minValue = (Integer) fieldStats[3].minValue();
+                            Integer maxValue = (Integer) fieldStats[3].maxValue();
+                            if (minValue != null
+                                    && maxValue != null
+                                    && minValue > 1120
+                                    && maxValue > 1120) {
+                                filterFileNames.add(dataFileMeta.fileName());
+                            }
+                        }
+                    }
+                    assertThat(filterFileNames).isEqualTo(fileNames);
+                });
+    }
+
+    @Test
+    public void testTableScanFilterPartition() throws Exception {
+        writeAndCheckFileMeta(
+                schemas -> {
+                    FileStoreTable table = createFileStoreTable(schemas);
+                    checkFilterRowCount(table, 1, 1, 3L);
+                    checkFilterRowCount(table, 1, 2, 3L);
+                    return null;
+                },
+                (files, schemas) -> {
+                    FileStoreTable table = createFileStoreTable(schemas);
+                    checkFilterRowCount(table, 0, 1, 7L);
+                    checkFilterRowCount(table, 0, 2, 5L);
+                });
+    }
+
+    @Test
+    public void testTableScanFilterPrimaryKey() throws Exception {
+        writeAndCheckFileMeta(
+                schemas -> {
+                    FileStoreTable table = createFileStoreTable(schemas);
+                    PredicateBuilder builder =
+                            new PredicateBuilder(table.schema().logicalRowType());
+                    Predicate predicate = builder.between(4, 115L, 120L);
+                    DataTableScan.DataFilePlan plan = table.newScan().withFilter(predicate).plan();
+                    checkFilterRowCount(plan, 2L);
+                    return null;
+                },
+                (files, schemas) -> {
+                    FileStoreTable table = createFileStoreTable(schemas);
+                    PredicateBuilder builder =
+                            new PredicateBuilder(table.schema().logicalRowType());
+                    Predicate predicate = builder.between(2, 115L, 120L);
+                    DataTableScan.DataFilePlan plan = table.newScan().withFilter(predicate).plan();
+                    checkFilterRowCount(plan, 6L);
+                });
+    }
+
+    protected List<String> getPrimaryKeyNames() {
+        return PRIMARY_KEY_NAMES;
+    }
+
+    protected void checkFilterRowCount(
+            FileStoreTable table, int index, int value, long expectedRowCount) {
+        PredicateBuilder builder = new PredicateBuilder(table.schema().logicalRowType());
+        DataTableScan.DataFilePlan plan =
+                table.newScan().withFilter(builder.equal(index, value)).plan();
+        checkFilterRowCount(plan, expectedRowCount);
+    }
+
+    protected void checkFilterRowCount(DataTableScan.DataFilePlan plan, long expectedRowCount) {
+        List<DataFileMeta> fileMetaList =
+                plan.splits.stream().flatMap(s -> s.files().stream()).collect(Collectors.toList());
+        checkFilterRowCount(fileMetaList, expectedRowCount);
+    }
+
+    protected void checkFilterRowCount(List<DataFileMeta> fileMetaList, long expectedRowCount) {
+        assertThat(fileMetaList.stream().mapToLong(DataFileMeta::rowCount).sum())
+                .isEqualTo(expectedRowCount);
+    }
+
+    protected FileStoreTable createFileStoreTable(Map<Long, TableSchema> tableSchemas) {
+        SchemaManager schemaManager = new TestingSchemaManager(tablePath, tableSchemas);
+        return new AppendOnlyFileStoreTable(tablePath, schemaManager, schemaManager.latest().get());
+    }
+
+    protected <R> void writeAndCheckFileMeta(
+            Function<Map<Long, TableSchema>, R> firstChecker,
+            BiConsumer<R, Map<Long, TableSchema>> secondChecker)
+            throws Exception {
+        Map<Long, TableSchema> tableSchemas = new HashMap<>();
+        tableSchemas.put(
+                0L,
+                new TableSchema(
+                        0,
+                        SCHEMA_0_FIELDS,
+                        5,
+                        PARTITION_NAMES,
+                        PRIMARY_KEY_NAMES,
+                        tableConfig.toMap(),
+                        ""));
+        FileStoreTable table = createFileStoreTable(tableSchemas);
+        TableWrite write = table.newWrite("user");
+        TableCommit commit = table.newCommit("user");
+
+        write.write(
+                GenericRowData.of(
+                        StringData.fromString("S001"),
+                        1,
+                        11,
+                        StringData.fromString("S11"),
+                        111L,
+                        StringData.fromString("S111")));
+        write.write(
+                GenericRowData.of(
+                        StringData.fromString("S002"),
+                        2,
+                        12,
+                        StringData.fromString("S12"),
+                        112L,
+                        StringData.fromString("S112")));
+        write.write(
+                GenericRowData.of(
+                        StringData.fromString("S003"),
+                        1,
+                        13,
+                        StringData.fromString("S13"),
+                        113L,
+                        StringData.fromString("S113")));
+        commit.commit(0, write.prepareCommit(true, 0));
+
+        write.write(
+                GenericRowData.of(
+                        StringData.fromString("S004"),
+                        1,
+                        14,
+                        StringData.fromString("S14"),
+                        114L,
+                        StringData.fromString("S114")));
+        write.write(
+                GenericRowData.of(
+                        StringData.fromString("S005"),
+                        2,
+                        15,
+                        StringData.fromString("S15"),
+                        115L,
+                        StringData.fromString("S115")));
+        write.write(
+                GenericRowData.of(
+                        StringData.fromString("S006"),
+                        2,
+                        16,
+                        StringData.fromString("S16"),
+                        116L,
+                        StringData.fromString("S116")));
+        commit.commit(0, write.prepareCommit(true, 0));
+        write.close();
+        R result = firstChecker.apply(tableSchemas);
+
+        tableSchemas.put(
+                1L,
+                new TableSchema(
+                        1,
+                        SCHEMA_1_FIELDS,
+                        8,
+                        PARTITION_NAMES,
+                        PRIMARY_KEY_NAMES,
+                        tableConfig.toMap(),
+                        ""));
+        table = createFileStoreTable(tableSchemas);
+        write = table.newWrite("user");
+        commit = table.newCommit("user");
+
+        write.write(
+                GenericRowData.of(
+                        1,
+                        17,
+                        117L,
+                        1117,
+                        StringData.fromString("S007"),
+                        StringData.fromString("S17")));
+        write.write(
+                GenericRowData.of(
+                        2,
+                        18,
+                        118L,
+                        1118,
+                        StringData.fromString("S008"),
+                        StringData.fromString("S18")));
+        write.write(
+                GenericRowData.of(
+                        1,
+                        19,
+                        119L,
+                        1119,
+                        StringData.fromString("S009"),
+                        StringData.fromString("S19")));
+        commit.commit(0, write.prepareCommit(true, 0));
+
+        write.write(
+                GenericRowData.of(
+                        2,
+                        20,
+                        120L,
+                        1120,
+                        StringData.fromString("S010"),
+                        StringData.fromString("S20")));
+        write.write(
+                GenericRowData.of(
+                        1,
+                        21,
+                        121L,
+                        1121,
+                        StringData.fromString("S011"),
+                        StringData.fromString("S21")));
+        write.write(
+                GenericRowData.of(
+                        1,
+                        22,
+                        122L,
+                        1122,
+                        StringData.fromString("S012"),
+                        StringData.fromString("S22")));
+        commit.commit(0, write.prepareCommit(true, 0));
+        write.close();
+
+        secondChecker.accept(result, tableSchemas);
+    }
+
+    /** {@link SchemaManager} subclass for testing. */
+    protected static class TestingSchemaManager extends SchemaManager {
+        private final Map<Long, TableSchema> tableSchemas;
+
+        public TestingSchemaManager(Path tableRoot, Map<Long, TableSchema> tableSchemas) {
+            super(tableRoot);
+            this.tableSchemas = tableSchemas;
+        }
+
+        @Override
+        public Optional<TableSchema> latest() {
+            return Optional.of(
+                    tableSchemas.get(
+                            tableSchemas.keySet().stream()
+                                    .max(Long::compareTo)
+                                    .orElseThrow(IllegalStateException::new)));
+        }
+
+        @Override
+        public List<TableSchema> listAll() {
+            return new ArrayList<>(tableSchemas.values());
+        }
+
+        @Override
+        public List<Long> listAllIds() {
+            return new ArrayList<>(tableSchemas.keySet());
+        }
+
+        @Override
+        public TableSchema commitNewVersion(UpdateSchema updateSchema) throws Exception {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public TableSchema commitChanges(List<SchemaChange> changes) throws Exception {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public TableSchema schema(long id) {
+            return checkNotNull(tableSchemas.get(id));
+        }
+    }
+}


### PR DESCRIPTION
Currently, the table store uses the latest schema id to read the data file meta. When the schema evolves, it will cause errors, for example:
1. the schema of underlying data is [1->a, 2->b, 3->c, 4->d] and schema id is 0, where 1/2/3/4 is field id and a/b/c/d is field name
2. After schema evolution, schema id is 1, and the new schema is [1->a, 3->c, 5->f, 6->b, 7->g]

When table store reads the field stats from data file meta, it should mapping schema 1 to 0 according to their field ids.

This PR will read and parse the data according to the schema id in the meta file when reading the data file meta, and create index mapping from the table schema and the meta schema, so that the table store can read the correct file meta data through its latest schema.

The main codes are as follows:
1. Added `SchemaFieldTypeExtractor` to extract key fields for `ChangelogValueCountFileStoreTable` and `ChangelogWithKeyFileStoreTable`
2. Added `SchemaEvolutionUtil` to create index mapping from table schema to meta file schema
3. Updated `FieldStatsArraySerializer` to read field stats with given index mapping

The main tests include:
1. Added `SchemaEvolutionUtilTest` to create index mapping between two schemas.
2. Added `FieldStatsArraSerializerTest` to read meta from table schema
3. Added `AppendOnlyTableFileMetaFilterTest`, `ChangelogValueCountFileMetaFilterTest` and `ChangelogWithKeyFileMetaFilterTest` to filter old field, new field, partition field and primary key in data file meta in table scan.