### PR TITLE
[FLINK-30013] Add check update column type

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
@@ -207,8 +207,10 @@ public class SchemaManager implements Serializable {
                                         LogicalTypeCasts.supportsImplicitCast(
                                                 field.type().logicalType, update.newLogicalType()),
                                         String.format(
-                                                "Row type %s cannot be converted to %s without loosing information.",
-                                                field.type().logicalType, update.newLogicalType()));
+                                                "Column type %s[%s] cannot be converted to %s without loosing information.",
+                                                field.name(),
+                                                field.type().logicalType,
+                                                update.newLogicalType()));
                                 if (dummyId.get() != 0) {
                                     throw new RuntimeException(
                                             String.format(

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
@@ -199,10 +199,6 @@ public class SchemaManager implements Serializable {
                             newFields,
                             update.fieldName(),
                             (field) -> {
-                                AtomicInteger dummyId = new AtomicInteger(0);
-                                DataType newType =
-                                        TableSchema.toDataType(
-                                                update.newLogicalType(), new AtomicInteger(0));
                                 checkState(
                                         LogicalTypeCasts.supportsImplicitCast(
                                                 field.type().logicalType, update.newLogicalType()),
@@ -211,6 +207,10 @@ public class SchemaManager implements Serializable {
                                                 field.name(),
                                                 field.type().logicalType,
                                                 update.newLogicalType()));
+                                AtomicInteger dummyId = new AtomicInteger(0);
+                                DataType newType =
+                                        TableSchema.toDataType(
+                                                update.newLogicalType(), new AtomicInteger(0));
                                 if (dummyId.get() != 0) {
                                     throw new RuntimeException(
                                             String.format(

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.store.file.utils.AtomicFileWriter;
 import org.apache.flink.table.store.file.utils.FileUtils;
 import org.apache.flink.table.store.file.utils.JsonSerdeUtil;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeCasts;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.commons.lang3.StringUtils;
@@ -54,6 +55,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.table.store.file.utils.FileUtils.listVersionedFiles;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /** Schema Manager to manage schema versions. */
 public class SchemaManager implements Serializable {
@@ -201,6 +203,12 @@ public class SchemaManager implements Serializable {
                                 DataType newType =
                                         TableSchema.toDataType(
                                                 update.newLogicalType(), new AtomicInteger(0));
+                                checkState(
+                                        LogicalTypeCasts.supportsImplicitCast(
+                                                field.type().logicalType, update.newLogicalType()),
+                                        String.format(
+                                                "Row type %s cannot be converted to %s without loosing information.",
+                                                field.type().logicalType, update.newLogicalType()));
                                 if (dummyId.get() != 0) {
                                     throw new RuntimeException(
                                             String.format(

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/SchemaEvolutionTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/SchemaEvolutionTest.java
@@ -147,6 +147,32 @@ public class SchemaEvolutionTest {
                 .hasMessage("The column [%s] exists in the table[%s].", columnName, tablePath);
     }
 
+    @Test
+    public void testUpdateFieldType() throws Exception {
+        UpdateSchema updateSchema =
+                new UpdateSchema(
+                        RowType.of(new IntType(), new BigIntType()),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        new HashMap<>(),
+                        "");
+        schemaManager.commitNewVersion(updateSchema);
+
+        schemaManager.commitChanges(
+                Collections.singletonList(SchemaChange.updateColumnType("f0", new BigIntType())));
+        assertThatThrownBy(
+                        () ->
+                                schemaManager.commitChanges(
+                                        Collections.singletonList(
+                                                SchemaChange.updateColumnType(
+                                                        "f0", new IntType()))))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage(
+                        String.format(
+                                "Row type %s cannot be converted to %s without loosing information.",
+                                new BigIntType(), new IntType()));
+    }
+
     private List<Row> readRecords(FileStoreTable table, Predicate filter) throws IOException {
         RowRowConverter converter =
                 RowRowConverter.create(

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/SchemaEvolutionTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/SchemaEvolutionTest.java
@@ -169,8 +169,8 @@ public class SchemaEvolutionTest {
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage(
                         String.format(
-                                "Row type %s cannot be converted to %s without loosing information.",
-                                new BigIntType(), new IntType()));
+                                "Column type %s[%s] cannot be converted to %s without loosing information.",
+                                "f0", new BigIntType(), new IntType()));
     }
 
     private List<Row> readRecords(FileStoreTable table, Predicate filter) throws IOException {


### PR DESCRIPTION
Check the source and target column types in `SchemaManager` to avoid data type conversion failures when reading data