### PR TITLE
[FLINK-30082] Enable write-buffer-spillable by default only for object storage

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -250,9 +250,9 @@
         </tr>
         <tr>
             <td><h5>write-buffer-spillable</h5></td>
-            <td style="word-wrap: break-word;">true</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Boolean</td>
-            <td>Whether the write buffer can be spillable.</td>
+            <td>Whether the write buffer can be spillable. Enabled by default when using object storage.</td>
         </tr>
         <tr>
             <td><h5>write-mode</h5></td>

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
@@ -461,11 +461,7 @@ public class CoreOptions implements Serializable {
     }
 
     public boolean writeBufferSpillable(boolean usingObjectStore) {
-        Boolean bufferSpillable = options.get(WRITE_BUFFER_SPILLABLE);
-        if (bufferSpillable == null) {
-            bufferSpillable = usingObjectStore;
-        }
-        return bufferSpillable;
+        return options.getOptional(WRITE_BUFFER_SPILLABLE).orElse(usingObjectStore);
     }
 
     public int localSortMaxNumFileHandles() {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
@@ -192,8 +192,9 @@ public class CoreOptions implements Serializable {
     public static final ConfigOption<Boolean> WRITE_BUFFER_SPILLABLE =
             ConfigOptions.key("write-buffer-spillable")
                     .booleanType()
-                    .defaultValue(true)
-                    .withDescription("Whether the write buffer can be spillable.");
+                    .noDefaultValue()
+                    .withDescription(
+                            "Whether the write buffer can be spillable. Enabled by default when using object storage.");
 
     public static final ConfigOption<Integer> LOCAL_SORT_MAX_NUM_FILE_HANDLES =
             ConfigOptions.key("local-sort.max-num-file-handles")
@@ -459,8 +460,12 @@ public class CoreOptions implements Serializable {
         return options.get(WRITE_BUFFER_SIZE).getBytes();
     }
 
-    public boolean writeBufferSpillable() {
-        return options.get(WRITE_BUFFER_SPILLABLE);
+    public boolean writeBufferSpillable(boolean usingObjectStore) {
+        Boolean bufferSpillable = options.get(WRITE_BUFFER_SPILLABLE);
+        if (bufferSpillable == null) {
+            bufferSpillable = usingObjectStore;
+        }
+        return bufferSpillable;
     }
 
     public int localSortMaxNumFileHandles() {


### PR DESCRIPTION
After a lot of tests, it is found that the participation of spillable does not improve HDFS greatly, but will bring some jitters.
In this jira, spillable is enabled only when the object is stored by default, so that the performance can be improved without affecting hdfs.