### PR TITLE
[FLINK-30091] Update maven-shade-plugin version to 3.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -791,7 +791,7 @@ under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.4.1</version>
                 </plugin>
 
                 <!-- configure scala style -->


### PR DESCRIPTION
Without this patch `mvn package verify` fails with

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:3.1.1:shade (shade-flink) on project flink-table-store-dist: Error creating shaded jar: duplicate entry: META-INF/services/org.apache.flink.table.store.shaded.org.apache.kafka.common.config.provider.ConfigProvider -> [Help 1]
```

This patch fixes the issue by upgrading the version of `maven-shade-plugin` to 3.4.1.