### PR TITLE
[FLINK-30110] Enable from-timestamp log scan when timestamp-millis is configured

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/FileStoreTableFactory.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/FileStoreTableFactory.java
@@ -61,6 +61,8 @@ public class FileStoreTableFactory {
         dynamicOptions.toMap().forEach(newOptions::setString);
         newOptions.set(PATH, tablePath.toString());
 
+        // set dynamic options with default values
+        CoreOptions.setDefaultValues(newOptions);
         // copy a new table store to contain dynamic options
         tableSchema = tableSchema.copy(newOptions.toMap());
         // validate schema wit new options


### PR DESCRIPTION
When `log.scan.timestamp-millis` is configured and `log.scan` isn't configured, the `log.scan` should be setting to `from-timestamp` by default.

**The brief change log**

- `FileStoreTableFactory#validateOptions` should validate the case that `log.scan.timestamp-millis` is configured.