### PR TITLE
[FLINK-30164] Expose BucketComputer from SupportsWrite

### DIFF
--- a/flink-table-store-common/src/main/java/org/apache/flink/table/store/file/predicate/PredicateFilter.java
+++ b/flink-table-store-common/src/main/java/org/apache/flink/table/store/file/predicate/PredicateFilter.java
@@ -24,11 +24,17 @@ import org.apache.flink.table.types.logical.RowType;
 
 import javax.annotation.Nullable;
 
+import java.util.List;
+
 /** A {@link java.util.function.Predicate} to filter {@link RowData}. */
 public class PredicateFilter implements java.util.function.Predicate<RowData> {
 
     private final RowDataToObjectArrayConverter arrayConverter;
     @Nullable private final Predicate predicate;
+
+    public PredicateFilter(RowType rowType, List<Predicate> predicates) {
+        this(rowType, predicates.isEmpty() ? null : PredicateBuilder.and(predicates));
+    }
 
     public PredicateFilter(RowType rowType, @Nullable Predicate predicate) {
         this.arrayConverter = new RowDataToObjectArrayConverter(rowType);

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/FlinkSinkBuilder.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/FlinkSinkBuilder.java
@@ -25,7 +25,6 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.transformations.PartitionTransformation;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.store.CoreOptions;
 import org.apache.flink.table.store.connector.FlinkConnectorOptions;
 import org.apache.flink.table.store.file.catalog.CatalogLock;
 import org.apache.flink.table.store.file.utils.JsonSerdeUtil;
@@ -91,10 +90,7 @@ public class FlinkSinkBuilder {
     }
 
     public DataStreamSink<?> build() {
-        int numBucket = conf.get(CoreOptions.BUCKET);
-
-        BucketStreamPartitioner partitioner =
-                new BucketStreamPartitioner(numBucket, table.schema());
+        BucketStreamPartitioner partitioner = new BucketStreamPartitioner(table.schema());
         PartitionTransformation<RowData> partitioned =
                 new PartitionTransformation<>(input.getTransformation(), partitioner);
         if (parallelism != null) {

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreWriteOperator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreWriteOperator.java
@@ -162,7 +162,7 @@ public class StoreWriteOperator extends PrepareCommitOperator {
 
         if (logSinkFunction != null) {
             // write to log store, need to preserve original pk (which includes partition fields)
-            SinkRecord logRecord = write.recordConverter().convertToLogSinkRecord(record);
+            SinkRecord logRecord = write.toLogRecord(record);
             logSinkFunction.invoke(logRecord, sinkContext);
         }
 

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/AppendOnlyTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/AppendOnlyTableITCase.java
@@ -196,10 +196,17 @@ public class AppendOnlyTableITCase extends FileStoreTableITCase {
         testRejectChanges(RowKind.UPDATE_BEFORE);
     }
 
+    @Test
+    public void testComplexType() {
+        batchSql("INSERT INTO complex_table VALUES (1, CAST(NULL AS MAP<INT, INT>))");
+        assertThat(batchSql("SELECT * FROM complex_table")).containsExactly(Row.of(1, null));
+    }
+
     @Override
     protected List<String> ddl() {
-        return Collections.singletonList(
-                "CREATE TABLE IF NOT EXISTS append_table (id INT, data STRING) WITH ('write-mode'='append-only')");
+        return Arrays.asList(
+                "CREATE TABLE IF NOT EXISTS append_table (id INT, data STRING) WITH ('write-mode'='append-only')",
+                "CREATE TABLE IF NOT EXISTS complex_table (id INT, data MAP<INT, INT>) WITH ('write-mode'='append-only')");
     }
 
     private void testRejectChanges(RowKind kind) {

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/PredicateITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/PredicateITCase.java
@@ -30,28 +30,58 @@ public class PredicateITCase extends CatalogITCaseBase {
     @Test
     public void testPkFilterBucket() throws Exception {
         sql("CREATE TABLE T (a INT PRIMARY KEY NOT ENFORCED, b INT) WITH ('bucket' = '5')");
-        innerTest();
+        writeRecords();
+        innerTestSingleField();
+        innerTestAllFields();
     }
 
     @Test
     public void testNoPkFilterBucket() throws Exception {
         sql("CREATE TABLE T (a INT, b INT) WITH ('bucket' = '5', 'bucket-key'='a')");
-        innerTest();
+        writeRecords();
+        innerTestSingleField();
+        innerTestAllFields();
     }
 
     @Test
     public void testAppendFilterBucket() throws Exception {
         sql(
                 "CREATE TABLE T (a INT, b INT) WITH ('bucket' = '5', 'bucket-key'='a', 'write-mode'='append-only')");
-        innerTest();
+        writeRecords();
+        innerTestSingleField();
+        innerTestAllFields();
     }
 
-    private void innerTest() throws Exception {
+    @Test
+    public void testAppendNoBucketKey() throws Exception {
+        sql("CREATE TABLE T (a INT, b INT) WITH ('write-mode'='append-only', 'bucket' = '5')");
+        writeRecords();
+        innerTestSingleField();
+        innerTestAllFields();
+    }
+
+    private void writeRecords() throws Exception {
         sql("INSERT INTO T VALUES (1, 2), (3, 4), (5, 6), (7, 8), (9, 10)");
+    }
+
+    private void innerTestSingleField() throws Exception {
         assertThat(sql("SELECT * FROM T WHERE a = 1")).containsExactlyInAnyOrder(Row.of(1, 2));
         assertThat(sql("SELECT * FROM T WHERE a = 3")).containsExactlyInAnyOrder(Row.of(3, 4));
         assertThat(sql("SELECT * FROM T WHERE a = 5")).containsExactlyInAnyOrder(Row.of(5, 6));
         assertThat(sql("SELECT * FROM T WHERE a = 7")).containsExactlyInAnyOrder(Row.of(7, 8));
         assertThat(sql("SELECT * FROM T WHERE a = 9")).containsExactlyInAnyOrder(Row.of(9, 10));
+    }
+
+    private void innerTestAllFields() throws Exception {
+        assertThat(sql("SELECT * FROM T WHERE a = 1 and b = 2"))
+                .containsExactlyInAnyOrder(Row.of(1, 2));
+        assertThat(sql("SELECT * FROM T WHERE a = 3 and b = 4"))
+                .containsExactlyInAnyOrder(Row.of(3, 4));
+        assertThat(sql("SELECT * FROM T WHERE a = 5 and b = 6"))
+                .containsExactlyInAnyOrder(Row.of(5, 6));
+        assertThat(sql("SELECT * FROM T WHERE a = 7 and b = 8"))
+                .containsExactlyInAnyOrder(Row.of(7, 8));
+        assertThat(sql("SELECT * FROM T WHERE a = 9 and b = 10"))
+                .containsExactlyInAnyOrder(Row.of(9, 10));
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/BucketSelector.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/predicate/BucketSelector.java
@@ -22,7 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
-import org.apache.flink.table.store.table.sink.SinkRecordConverter;
+import org.apache.flink.table.store.table.sink.BucketComputer;
 import org.apache.flink.table.types.logical.RowType;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
@@ -72,7 +72,7 @@ public class BucketSelector implements Serializable {
     Set<Integer> createBucketSet(int numBucket) {
         ImmutableSet.Builder<Integer> builder = new ImmutableSet.Builder<>();
         for (int hash : hashCodes) {
-            builder.add(SinkRecordConverter.bucket(hash, numBucket));
+            builder.add(BucketComputer.bucket(hash, numBucket));
         }
         return builder.build();
     }
@@ -140,7 +140,7 @@ public class BucketSelector implements Serializable {
 
     private static int hash(List<Object> columns, RowDataSerializer serializer) {
         BinaryRowData binaryRow = serializer.toBinaryRow(GenericRowData.of(columns.toArray()));
-        return SinkRecordConverter.hashcode(binaryRow);
+        return BucketComputer.hashcode(binaryRow);
     }
 
     private static void assembleRows(

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTable.java
@@ -105,11 +105,9 @@ public class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
 
     @Override
     public TableWrite newWrite(String commitUser) {
-        SinkRecordConverter recordConverter =
-                new SinkRecordConverter(store.options().bucket(), tableSchema);
         return new TableWriteImpl<>(
                 store.newWrite(commitUser),
-                recordConverter,
+                new SinkRecordConverter(tableSchema),
                 record -> {
                     Preconditions.checkState(
                             record.row().getRowKind() == RowKind.INSERT,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTable.java
@@ -125,12 +125,10 @@ public class ChangelogValueCountFileStoreTable extends AbstractFileStoreTable {
 
     @Override
     public TableWrite newWrite(String commitUser) {
-        SinkRecordConverter recordConverter =
-                new SinkRecordConverter(store.options().bucket(), tableSchema);
         final KeyValue kv = new KeyValue();
         return new TableWriteImpl<>(
                 store.newWrite(commitUser),
-                recordConverter,
+                new SinkRecordConverter(tableSchema),
                 record -> {
                     switch (record.row().getRowKind()) {
                         case INSERT:

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
@@ -204,8 +204,6 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
 
     @Override
     public TableWrite newWrite(String commitUser) {
-        SinkRecordConverter recordConverter =
-                new SinkRecordConverter(store.options().bucket(), tableSchema);
         final SequenceGenerator sequenceGenerator =
                 store.options()
                         .sequenceField()
@@ -214,7 +212,7 @@ public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
         final KeyValue kv = new KeyValue();
         return new TableWriteImpl<>(
                 store.newWrite(commitUser),
-                recordConverter,
+                new SinkRecordConverter(tableSchema),
                 record -> {
                     long sequenceNumber =
                             sequenceGenerator == null

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/FileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/FileStoreTable.java
@@ -22,6 +22,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.store.CoreOptions;
 import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
+import org.apache.flink.table.store.table.sink.BucketComputer;
 import org.apache.flink.table.store.table.source.DataTableScan;
 import org.apache.flink.table.types.logical.RowType;
 
@@ -58,4 +59,9 @@ public interface FileStoreTable extends Table, SupportsPartition, SupportsWrite 
 
     @Override
     DataTableScan newScan();
+
+    @Override
+    default BucketComputer bucketComputer() {
+        return new BucketComputer(schema());
+    }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/SupportsWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/SupportsWrite.java
@@ -18,11 +18,14 @@
 
 package org.apache.flink.table.store.table;
 
+import org.apache.flink.table.store.table.sink.BucketComputer;
 import org.apache.flink.table.store.table.sink.TableCommit;
 import org.apache.flink.table.store.table.sink.TableWrite;
 
 /** An interface for {@link Table} write support. */
-public interface SupportsWrite {
+public interface SupportsWrite extends Table {
+
+    BucketComputer bucketComputer();
 
     TableWrite newWrite(String commitUser);
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/BucketComputer.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/BucketComputer.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.table.sink;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.runtime.generated.Projection;
+import org.apache.flink.table.store.CoreOptions;
+import org.apache.flink.table.store.codegen.CodeGenUtils;
+import org.apache.flink.table.store.file.schema.TableSchema;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.RowKind;
+
+import java.util.stream.IntStream;
+
+/** A {@link BucketComputer} to compute bucket by bucket keys or primary keys or whole row. */
+public class BucketComputer {
+
+    private final int numBucket;
+
+    private final Projection<RowData, BinaryRowData> rowProjection;
+    private final Projection<RowData, BinaryRowData> bucketProjection;
+    private final Projection<RowData, BinaryRowData> pkProjection;
+
+    public BucketComputer(TableSchema tableSchema) {
+        this(
+                new CoreOptions(tableSchema.options()).bucket(),
+                tableSchema.logicalRowType(),
+                tableSchema.projection(tableSchema.originalBucketKeys()),
+                tableSchema.projection(tableSchema.trimmedPrimaryKeys()));
+    }
+
+    private BucketComputer(int numBucket, RowType rowType, int[] bucketKeys, int[] primaryKeys) {
+        this.numBucket = numBucket;
+        this.rowProjection =
+                CodeGenUtils.newProjection(
+                        rowType, IntStream.range(0, rowType.getFieldCount()).toArray());
+        this.bucketProjection = CodeGenUtils.newProjection(rowType, bucketKeys);
+        this.pkProjection = CodeGenUtils.newProjection(rowType, primaryKeys);
+    }
+
+    private int hashRow(RowData row) {
+        if (row instanceof BinaryRowData) {
+            RowKind rowKind = row.getRowKind();
+            row.setRowKind(RowKind.INSERT);
+            int hash = hashcode((BinaryRowData) row);
+            row.setRowKind(rowKind);
+            return hash;
+        } else {
+            return hashcode(rowProjection.apply(row));
+        }
+    }
+
+    public int bucket(RowData row) {
+        int hashcode = hashBucketKey(row);
+        return bucket(hashcode, numBucket);
+    }
+
+    public int bucket(RowData row, BinaryRowData pk) {
+        int hashcode = hashBucketKey(row, pk);
+        return bucket(hashcode, numBucket);
+    }
+
+    private int hashBucketKey(RowData row) {
+        BinaryRowData bucketKey = bucketProjection.apply(row);
+        if (bucketKey.getArity() == 0) {
+            bucketKey = pkProjection.apply(row);
+        }
+        if (bucketKey.getArity() == 0) {
+            return hashRow(row);
+        }
+        return bucketKey.hashCode();
+    }
+
+    private int hashBucketKey(RowData row, BinaryRowData pk) {
+        BinaryRowData bucketKey = bucketProjection.apply(row);
+        if (bucketKey.getArity() == 0) {
+            bucketKey = pk;
+        }
+        if (bucketKey.getArity() == 0) {
+            return hashRow(row);
+        }
+        return bucketKey.hashCode();
+    }
+
+    public static int hashcode(BinaryRowData rowData) {
+        assert rowData.getRowKind() == RowKind.INSERT;
+        return rowData.hashCode();
+    }
+
+    public static int bucket(int hashcode, int numBucket) {
+        return Math.abs(hashcode % numBucket);
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWrite.java
@@ -28,15 +28,16 @@ import java.util.List;
  * An abstraction layer above {@link org.apache.flink.table.store.file.operation.FileStoreWrite} to
  * provide {@link RowData} writing.
  */
-public interface TableWrite {
+public interface TableWrite extends AutoCloseable {
 
     TableWrite withOverwrite(boolean overwrite);
 
     TableWrite withIOManager(IOManager ioManager);
 
-    SinkRecordConverter recordConverter();
-
     SinkRecord write(RowData rowData) throws Exception;
+
+    /** Log record need to preserve original pk (which includes partition fields). */
+    SinkRecord toLogRecord(SinkRecord record);
 
     void compact(BinaryRowData partition, int bucket) throws Exception;
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWriteImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWriteImpl.java
@@ -58,15 +58,15 @@ public class TableWriteImpl<T> implements TableWrite {
     }
 
     @Override
-    public SinkRecordConverter recordConverter() {
-        return recordConverter;
-    }
-
-    @Override
     public SinkRecord write(RowData rowData) throws Exception {
         SinkRecord record = recordConverter.convert(rowData);
         write.write(record.partition(), record.bucket(), recordExtractor.extract(record));
         return record;
+    }
+
+    @Override
+    public SinkRecord toLogRecord(SinkRecord record) {
+        return recordConverter.convertToLogSinkRecord(record);
     }
 
     @Override

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTableTest.java
@@ -47,8 +47,8 @@ import java.util.Random;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.table.store.table.sink.SinkRecordConverter.bucket;
-import static org.apache.flink.table.store.table.sink.SinkRecordConverter.hashcode;
+import static org.apache.flink.table.store.table.sink.BucketComputer.bucket;
+import static org.apache.flink.table.store.table.sink.BucketComputer.hashcode;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link AppendOnlyFileStoreTable}. */

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/sink/SinkRecordConverterTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/sink/SinkRecordConverterTest.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.flink.table.store.CoreOptions.BUCKET;
 import static org.apache.flink.table.store.CoreOptions.BUCKET_KEY;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -85,6 +86,7 @@ public class SinkRecordConverterTest {
         List<DataField> fields = TableSchema.newFields(rowType);
         Map<String, String> options = new HashMap<>();
         options.put(BUCKET_KEY.key(), bk);
+        options.put(BUCKET.key(), "100");
         TableSchema schema =
                 new TableSchema(
                         0,
@@ -96,6 +98,6 @@ public class SinkRecordConverterTest {
                         "".equals(pk) ? Collections.emptyList() : Arrays.asList(pk.split(",")),
                         options,
                         "");
-        return new SinkRecordConverter(100, schema);
+        return new SinkRecordConverter(schema);
     }
 }


### PR DESCRIPTION
When other engines dock with Sink, they need to know the corresponding bucket rules before they can be correctly distributed to each bucket.

This is first refactor PR for https://github.com/apache/flink-table-store/pull/394