### PR TITLE
[FLINK-28812] Read read-compacted from options

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSource.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSource.java
@@ -78,10 +78,7 @@ public class FileStoreSource extends FlinkSource {
         Long snapshotId;
         Collection<FileStoreSourceSplit> splits;
         if (checkpoint == null) {
-            DataFilePlan plan =
-                    isContinuous
-                            ? SnapshotEnumerator.startup(scan)
-                            : scan.withReadCompacted(table.options().readCompacted()).plan();
+            DataFilePlan plan = isContinuous ? SnapshotEnumerator.startup(scan) : scan.plan();
             snapshotId = plan.snapshotId;
             splits = new FileStoreSourceSplitGenerator().createSplits(plan);
         } else {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/AppendOnlyFileStore.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/AppendOnlyFileStore.java
@@ -81,7 +81,8 @@ public class AppendOnlyFileStore extends AbstractFileStore<RowData> {
                 manifestFileFactory(),
                 manifestListFactory(),
                 options.bucket(),
-                checkNumOfBuckets);
+                checkNumOfBuckets,
+                options.readCompacted());
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValueFileStore.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValueFileStore.java
@@ -110,7 +110,8 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
                 manifestListFactory(),
                 options.bucket(),
                 checkNumOfBuckets,
-                options.changelogProducer());
+                options.changelogProducer(),
+                options.readCompacted());
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AbstractFileStoreScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AbstractFileStoreScan.java
@@ -62,6 +62,7 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
     private final int numOfBuckets;
     private final boolean checkNumOfBuckets;
     private final CoreOptions.ChangelogProducer changelogProducer;
+    private final boolean readCompacted;
 
     private final Map<Long, TableSchema> tableSchemas;
     private final SchemaManager schemaManager;
@@ -75,7 +76,6 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
     private List<ManifestFileMeta> specifiedManifests = null;
     private boolean isIncremental = false;
     private Integer specifiedLevel = null;
-    private boolean readCompacted = false;
 
     public AbstractFileStoreScan(
             RowType partitionType,
@@ -87,7 +87,8 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
             ManifestList.Factory manifestListFactory,
             int numOfBuckets,
             boolean checkNumOfBuckets,
-            CoreOptions.ChangelogProducer changelogProducer) {
+            CoreOptions.ChangelogProducer changelogProducer,
+            boolean readCompacted) {
         this.partitionStatsConverter = new FieldStatsArraySerializer(partitionType);
         this.partitionConverter = new RowDataToObjectArrayConverter(partitionType);
         Preconditions.checkArgument(
@@ -101,6 +102,7 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
         this.numOfBuckets = numOfBuckets;
         this.checkNumOfBuckets = checkNumOfBuckets;
         this.changelogProducer = changelogProducer;
+        this.readCompacted = readCompacted;
         this.tableSchemas = new HashMap<>();
     }
 
@@ -173,12 +175,6 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
     @Override
     public FileStoreScan withLevel(int level) {
         this.specifiedLevel = level;
-        return this;
-    }
-
-    @Override
-    public FileStoreScan withReadCompacted(boolean readCompacted) {
-        this.readCompacted = readCompacted;
         return this;
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AppendOnlyFileStoreScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AppendOnlyFileStoreScan.java
@@ -56,7 +56,8 @@ public class AppendOnlyFileStoreScan extends AbstractFileStoreScan {
             ManifestFile.Factory manifestFileFactory,
             ManifestList.Factory manifestListFactory,
             int numOfBuckets,
-            boolean checkNumOfBuckets) {
+            boolean checkNumOfBuckets,
+            boolean readCompacted) {
         super(
                 partitionType,
                 bucketKeyType,
@@ -67,7 +68,8 @@ public class AppendOnlyFileStoreScan extends AbstractFileStoreScan {
                 manifestListFactory,
                 numOfBuckets,
                 checkNumOfBuckets,
-                CoreOptions.ChangelogProducer.NONE);
+                CoreOptions.ChangelogProducer.NONE,
+                readCompacted);
         this.schemaRowStatsConverters = new HashMap<>();
         this.rowType = rowType;
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreScan.java
@@ -51,8 +51,6 @@ public interface FileStoreScan {
 
     FileStoreScan withLevel(int level);
 
-    FileStoreScan withReadCompacted(boolean readCompacted);
-
     /** Produce a {@link Plan}. */
     Plan plan();
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreScan.java
@@ -62,7 +62,8 @@ public class KeyValueFileStoreScan extends AbstractFileStoreScan {
             ManifestList.Factory manifestListFactory,
             int numOfBuckets,
             boolean checkNumOfBuckets,
-            CoreOptions.ChangelogProducer changelogProducer) {
+            CoreOptions.ChangelogProducer changelogProducer,
+            boolean readCompacted) {
         super(
                 partitionType,
                 bucketKeyType,
@@ -73,7 +74,8 @@ public class KeyValueFileStoreScan extends AbstractFileStoreScan {
                 manifestListFactory,
                 numOfBuckets,
                 checkNumOfBuckets,
-                changelogProducer);
+                changelogProducer,
+                readCompacted);
         this.keyFieldsExtractor = keyFieldsExtractor;
         this.schemaKeyStatsConverters = new HashMap<>();
         this.keyType = keyType;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/DataTableScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/DataTableScan.java
@@ -103,11 +103,6 @@ public abstract class DataTableScan implements TableScan {
         return this;
     }
 
-    public DataTableScan withReadCompacted(boolean readCompacted) {
-        scan.withReadCompacted(readCompacted);
-        return this;
-    }
-
     @VisibleForTesting
     public DataTableScan withBucket(int bucket) {
         scan.withBucket(bucket);

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/SnapshotEnumerator.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/SnapshotEnumerator.java
@@ -122,10 +122,7 @@ public class SnapshotEnumerator implements Callable<SnapshotEnumerator.Enumerato
                 if (options.changelogProducer() == FULL_COMPACTION) {
                     // Read the results of the last full compaction.
                     // Only full compaction results will appear on the max level.
-                    plan =
-                            scan.withReadCompacted(options.readCompacted())
-                                    .withLevel(options.numLevels() - 1)
-                                    .plan();
+                    plan = scan.withLevel(options.numLevels() - 1).plan();
                 } else {
                     plan = scan.plan();
                 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/FileStoreTableTestBase.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/FileStoreTableTestBase.java
@@ -72,6 +72,7 @@ import java.util.stream.Collectors;
 import static org.apache.flink.table.store.CoreOptions.BUCKET;
 import static org.apache.flink.table.store.CoreOptions.BUCKET_KEY;
 import static org.apache.flink.table.store.CoreOptions.COMPACTION_MAX_FILE_NUM;
+import static org.apache.flink.table.store.CoreOptions.READ_COMPACTED;
 import static org.apache.flink.table.store.CoreOptions.WRITE_COMPACTION_SKIP;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -322,9 +323,9 @@ public abstract class FileStoreTableTestBase {
     @Test
     public void testReadCompactedSnapshot() throws Exception {
         writeCompactData();
-        FileStoreTable table = createFileStoreTable();
+        FileStoreTable table = createFileStoreTable(conf -> conf.set(READ_COMPACTED, true));
 
-        DataTableScan.DataFilePlan plan = table.newScan().withReadCompacted(true).plan();
+        DataTableScan.DataFilePlan plan = table.newScan().plan();
         Snapshot compactedSnapshot = table.snapshotManager().snapshot(plan.snapshotId);
         Iterator<Snapshot> snapshotIterator = table.snapshotManager().snapshots();
         while (snapshotIterator.hasNext()) {


### PR DESCRIPTION
At present, `read-compacted` does not affect the work of scan in various situations. We can read it directly from options.