### PR TITLE
[FLINK-29988] Using lower case fields in hive catalog

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaChange.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaChange.java
@@ -57,6 +57,8 @@ public interface SchemaChange {
         return new UpdateColumnComment(fieldNames, comment);
     }
 
+    SchemaChange toLowerCase();
+
     /** A SchemaChange to set a table option. */
     final class SetOption implements SchemaChange {
         private final String key;
@@ -73,6 +75,11 @@ public interface SchemaChange {
 
         public String value() {
             return value;
+        }
+
+        @Override
+        public SchemaChange toLowerCase() {
+            return this;
         }
 
         @Override
@@ -103,6 +110,11 @@ public interface SchemaChange {
 
         public String key() {
             return key;
+        }
+
+        @Override
+        public SchemaChange toLowerCase() {
+            return this;
         }
 
         @Override
@@ -156,6 +168,11 @@ public interface SchemaChange {
         }
 
         @Override
+        public SchemaChange toLowerCase() {
+            return new AddColumn(fieldName.toLowerCase(), logicalType, isNullable, description);
+        }
+
+        @Override
         public boolean equals(Object o) {
             if (this == o) {
                 return true;
@@ -194,6 +211,11 @@ public interface SchemaChange {
 
         public LogicalType newLogicalType() {
             return newLogicalType;
+        }
+
+        @Override
+        public SchemaChange toLowerCase() {
+            return new UpdateColumnType(fieldName.toLowerCase(), newLogicalType);
         }
 
         @Override
@@ -236,6 +258,13 @@ public interface SchemaChange {
         }
 
         @Override
+        public SchemaChange toLowerCase() {
+            return new UpdateColumnNullability(
+                    Arrays.stream(fieldNames).map(String::toLowerCase).toArray(String[]::new),
+                    newNullability);
+        }
+
+        @Override
         public boolean equals(Object o) {
             if (this == o) {
                 return true;
@@ -272,6 +301,13 @@ public interface SchemaChange {
 
         public String newDescription() {
             return newDescription;
+        }
+
+        @Override
+        public SchemaChange toLowerCase() {
+            return new UpdateColumnComment(
+                    Arrays.stream(fieldNames).map(String::toLowerCase).toArray(String[]::new),
+                    newDescription);
         }
 
         @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/UpdateSchema.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/UpdateSchema.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.table.descriptors.Schema.SCHEMA;
 import static org.apache.flink.table.types.utils.TypeConversions.fromLogicalToDataType;
@@ -169,6 +170,25 @@ public class UpdateSchema {
         }
 
         return new CatalogTableImpl(schema, partitionKeys, newOptions, comment);
+    }
+
+    public UpdateSchema toLowerCase() {
+        RowType rowType =
+                new RowType(
+                        this.rowType.isNullable(),
+                        this.rowType.getFields().stream()
+                                .map(
+                                        f ->
+                                                new RowType.RowField(
+                                                        f.getName().toLowerCase(),
+                                                        f.getType(),
+                                                        f.getDescription().orElse("")))
+                                .collect(Collectors.toList()));
+        List<String> partitionKeys =
+                this.partitionKeys.stream().map(String::toLowerCase).collect(Collectors.toList());
+        List<String> primaryKeys =
+                this.primaryKeys.stream().map(String::toLowerCase).collect(Collectors.toList());
+        return new UpdateSchema(rowType, partitionKeys, primaryKeys, options, comment);
     }
 
     public static UpdateSchema fromCatalogTable(CatalogTable catalogTable) {


### PR DESCRIPTION
Hive metastore only supports lower case table name and fields, we should convert them to lower case in `HiveCatalog`