### PR TITLE
[FLINK-30205] Modify compact interface for TableWrite and FileStoreWrite to support normal compaction in Table Store

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/FullChangelogStoreWriteOperator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/FullChangelogStoreWriteOperator.java
@@ -208,7 +208,7 @@ public class FullChangelogStoreWriteOperator extends StoreWriteOperator {
                     }
                     compactedBuckets.add(bucket);
                     try {
-                        write.compact(bucket.f0, bucket.f1);
+                        write.compact(bucket.f0, bucket.f1, true);
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     }

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreCompactOperator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreCompactOperator.java
@@ -99,7 +99,7 @@ public class StoreCompactOperator extends PrepareCommitOperator {
                         bucket);
             }
             try {
-                write.compact(partition, bucket);
+                write.compact(partition, bucket, true);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/append/AppendOnlyWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/append/AppendOnlyWriter.java
@@ -94,8 +94,8 @@ public class AppendOnlyWriter implements RecordWriter<RowData> {
     }
 
     @Override
-    public void fullCompaction() throws Exception {
-        flushWriter(true);
+    public void compact(boolean fullCompaction) throws Exception {
+        flushWriter(fullCompaction);
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeWriter.java
@@ -139,8 +139,8 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
     }
 
     @Override
-    public void fullCompaction() throws Exception {
-        flushWriteBuffer(true);
+    public void compact(boolean fullCompaction) throws Exception {
+        flushWriteBuffer(fullCompaction);
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeWriter.java
@@ -130,7 +130,7 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
                         : kv.sequenceNumber();
         boolean success = writeBuffer.put(sequenceNumber, kv.valueKind(), kv.key(), kv.value());
         if (!success) {
-            flushWriteBuffer(false);
+            flushWriteBuffer(false, false);
             success = writeBuffer.put(sequenceNumber, kv.valueKind(), kv.key(), kv.value());
             if (!success) {
                 throw new RuntimeException("Mem table is too small to hold a single element.");
@@ -140,7 +140,7 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
 
     @Override
     public void compact(boolean fullCompaction) throws Exception {
-        flushWriteBuffer(fullCompaction);
+        flushWriteBuffer(true, fullCompaction);
     }
 
     @Override
@@ -152,15 +152,15 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
     public void flushMemory() throws Exception {
         boolean success = writeBuffer.flushMemory();
         if (!success) {
-            flushWriteBuffer(false);
+            flushWriteBuffer(false, false);
         }
     }
 
-    private void flushWriteBuffer(boolean forcedFullCompaction) throws Exception {
+    private void flushWriteBuffer(boolean waitForLatestCompaction, boolean forcedFullCompaction)
+            throws Exception {
         if (writeBuffer.size() > 0) {
             if (compactManager.shouldWaitCompaction()) {
-                // stop writing, wait for compaction finished
-                trySyncLatestCompaction(true);
+                waitForLatestCompaction = true;
             }
 
             final RollingFileWriter<KeyValue, DataFileMeta> changelogWriter =
@@ -194,12 +194,14 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
 
             writeBuffer.clear();
         }
-        submitCompaction(forcedFullCompaction);
+
+        trySyncLatestCompaction(waitForLatestCompaction);
+        compactManager.triggerCompaction(forcedFullCompaction);
     }
 
     @Override
     public CommitIncrement prepareCommit(boolean blocking) throws Exception {
-        flushWriteBuffer(false);
+        flushWriteBuffer(false, false);
         trySyncLatestCompaction(blocking || commitForceCompact);
         return drainIncrement();
     }
@@ -258,11 +260,6 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
         }
         compactAfter.addAll(result.after());
         compactChangelog.addAll(result.changelog());
-    }
-
-    private void submitCompaction(boolean forcedFullCompaction) throws Exception {
-        trySyncLatestCompaction(forcedFullCompaction);
-        compactManager.triggerCompaction(forcedFullCompaction);
     }
 
     private void trySyncLatestCompaction(boolean blocking) throws Exception {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AbstractFileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AbstractFileStoreWrite.java
@@ -108,8 +108,9 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
     }
 
     @Override
-    public void compact(BinaryRowData partition, int bucket) throws Exception {
-        getWriter(partition, bucket).fullCompaction();
+    public void compact(BinaryRowData partition, int bucket, boolean fullCompaction)
+            throws Exception {
+        getWriter(partition, bucket).compact(fullCompaction);
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreWrite.java
@@ -60,9 +60,10 @@ public interface FileStoreWrite<T> {
      *
      * @param partition the partition to compact
      * @param bucket the bucket to compact
+     * @param fullCompaction whether to trigger full compaction or just normal compaction
      * @throws Exception the thrown exception when compacting the records
      */
-    void compact(BinaryRowData partition, int bucket) throws Exception;
+    void compact(BinaryRowData partition, int bucket, boolean fullCompaction) throws Exception;
 
     /**
      * Prepare commit in the write.

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RecordWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RecordWriter.java
@@ -34,10 +34,12 @@ public interface RecordWriter<T> {
     void write(T record) throws Exception;
 
     /**
-     * Compact all files related to the writer. Note that compaction process is only submitted and
-     * may not be completed when the method returns.
+     * Compact files related to the writer. Note that compaction process is only submitted and may
+     * not be completed when the method returns.
+     *
+     * @param fullCompaction whether to trigger full compaction or just normal compaction
      */
-    void fullCompaction() throws Exception;
+    void compact(boolean fullCompaction) throws Exception;
 
     /**
      * Prepare for a commit.

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWrite.java
@@ -39,7 +39,7 @@ public interface TableWrite extends AutoCloseable {
     /** Log record need to preserve original pk (which includes partition fields). */
     SinkRecord toLogRecord(SinkRecord record);
 
-    void compact(BinaryRowData partition, int bucket) throws Exception;
+    void compact(BinaryRowData partition, int bucket, boolean fullCompaction) throws Exception;
 
     List<FileCommittable> prepareCommit(boolean blocking, long commitIdentifier) throws Exception;
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWriteImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWriteImpl.java
@@ -70,8 +70,9 @@ public class TableWriteImpl<T> implements TableWrite {
     }
 
     @Override
-    public void compact(BinaryRowData partition, int bucket) throws Exception {
-        write.compact(partition, bucket);
+    public void compact(BinaryRowData partition, int bucket, boolean fullCompaction)
+            throws Exception {
+        write.compact(partition, bucket, fullCompaction);
     }
 
     @Override

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
@@ -168,7 +168,7 @@ public class TestCommitThread extends Thread {
                 for (BinaryRowData partition : writtenPartitions) {
                     MergeTreeWriter writer =
                             writers.computeIfAbsent(partition, p -> createWriter(p, false));
-                    writer.fullCompaction();
+                    writer.compact(true);
                     RecordWriter.CommitIncrement inc = writer.prepareCommit(true);
                     committable.addFileCommittable(
                             new FileCommittable(

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTableTest.java
@@ -260,8 +260,8 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         write.write(rowData(2, 10, 210L));
         write.write(rowData(2, 20, 220L));
         write.write(rowDataWithKind(RowKind.DELETE, 2, 10, 210L));
-        write.compact(binaryRow(1), 0);
-        write.compact(binaryRow(2), 0);
+        write.compact(binaryRow(1), 0, true);
+        write.compact(binaryRow(2), 0, true);
         commit.commit(0, write.prepareCommit(true, 0));
 
         List<Split> splits = table.newScan().withIncremental(true).plan().splits();
@@ -281,8 +281,8 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
 
         write.write(rowDataWithKind(RowKind.DELETE, 1, 40, 140L));
         write.write(rowData(2, 40, 241L));
-        write.compact(binaryRow(1), 0);
-        write.compact(binaryRow(2), 0);
+        write.compact(binaryRow(1), 0, true);
+        write.compact(binaryRow(2), 0, true);
         commit.commit(2, write.prepareCommit(true, 2));
 
         splits = table.newScan().withIncremental(true).plan().splits();
@@ -305,8 +305,8 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         write.write(rowData(2, 20, 221L));
         write.write(rowDataWithKind(RowKind.DELETE, 2, 20, 221L));
         write.write(rowData(2, 40, 242L));
-        write.compact(binaryRow(1), 0);
-        write.compact(binaryRow(2), 0);
+        write.compact(binaryRow(1), 0, true);
+        write.compact(binaryRow(2), 0, true);
         commit.commit(4, write.prepareCommit(true, 4));
 
         splits = table.newScan().withIncremental(true).plan().splits();


### PR DESCRIPTION
Currently the compact interface in `TableWrite` and `FileStoreWrite` can only trigger full compaction. However a separated compact job should not only perform full compaction, but also perform normal compaction once in a while, just like what the current Table Store sinks do.

We need to modify compact interface for `TableWrite` and `FileStoreWrite` to support normal compaction.