### PR TITLE
[FLINK-29987] Use Awaitility in PartialUpdateITCase#testForeignKeyJoin

### DIFF
--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/PartialUpdateITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/PartialUpdateITCase.java
@@ -23,11 +23,13 @@ import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.CloseableIterator;
 
+import org.awaitility.Awaitility;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -105,15 +107,25 @@ public class PartialUpdateITCase extends FileStoreTableITCase {
 
         batchSql("INSERT INTO ods_orders VALUES (1, 2, 3)");
         batchSql("INSERT INTO dim_persons VALUES (3, 'snow', 'jon', 23)");
-        Thread.sleep(1000);
-        assertThat(rowsToList(batchSql("SELECT * FROM dwd_orders")))
-                .containsExactly(Arrays.asList(1, 2, 3, "snow", "jon", 23));
+        Awaitility.await()
+                .pollInSameThread()
+                .atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () ->
+                                assertThat(rowsToList(batchSql("SELECT * FROM dwd_orders")))
+                                        .containsExactly(
+                                                Arrays.asList(1, 2, 3, "snow", "jon", 23)));
 
         batchSql("INSERT INTO ods_orders VALUES (1, 4, 3)");
         batchSql("INSERT INTO dim_persons VALUES (3, 'snow', 'targaryen', 23)");
-        Thread.sleep(1000);
-        assertThat(rowsToList(batchSql("SELECT * FROM dwd_orders")))
-                .containsExactly(Arrays.asList(1, 4, 3, "snow", "targaryen", 23));
+        Awaitility.await()
+                .pollInSameThread()
+                .atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () ->
+                                assertThat(rowsToList(batchSql("SELECT * FROM dwd_orders")))
+                                        .containsExactly(
+                                                Arrays.asList(1, 4, 3, "snow", "targaryen", 23)));
 
         iter.close();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,7 @@ under the License.
         <flink.forkCount>1C</flink.forkCount>
         <flink.reuseForks>true</flink.reuseForks>
         <testcontainers.version>1.17.2</testcontainers.version>
+        <awaitility.version>4.2.0</awaitility.version>
 
         <!-- Can be set to any value to reproduce a specific build. -->
         <test.randomization.seed/>
@@ -181,6 +182,13 @@ under the License.
             <!-- API bridge between log4j 1 and 2 -->
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-1.2-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This patch stabilizes `PartialUpdateITCase#testForeignKeyJoin` and introduces a new test dependency - [Awaitility](https://github.com/awaitility/awaitility) that can be conveniently used to prevent similar issues in the future.