### PR TITLE
[FLINK-30223] Refactor Lock to provide Lock.Factory

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/TableStoreSink.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/TableStoreSink.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.store.CoreOptions.LogChangelogMode;
 import org.apache.flink.table.store.connector.FlinkConnectorOptions;
 import org.apache.flink.table.store.connector.TableStoreDataStreamSinkProvider;
 import org.apache.flink.table.store.file.catalog.CatalogLock;
+import org.apache.flink.table.store.file.operation.Lock;
 import org.apache.flink.table.store.log.LogSinkProvider;
 import org.apache.flink.table.store.log.LogStoreTableFactory;
 import org.apache.flink.table.store.table.AppendOnlyFileStoreTable;
@@ -122,12 +123,13 @@ public class TableStoreSink implements DynamicTableSink, SupportsOverwrite, Supp
                         : (logSinkProvider == null ? null : logSinkProvider.createSink());
         return new TableStoreDataStreamSinkProvider(
                 (dataStream) ->
-                        new FlinkSinkBuilder(tableIdentifier, table)
+                        new FlinkSinkBuilder(table)
                                 .withInput(
                                         new DataStream<>(
                                                 dataStream.getExecutionEnvironment(),
                                                 dataStream.getTransformation()))
-                                .withLockFactory(lockFactory)
+                                .withLockFactory(
+                                        Lock.factory(lockFactory, tableIdentifier.toObjectPath()))
                                 .withLogSinkFunction(logSinkFunction)
                                 .withOverwritePartition(overwrite ? staticPartitions : null)
                                 .withParallelism(conf.get(FlinkConnectorOptions.SINK_PARALLELISM))

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileStoreITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileStoreITCase.java
@@ -132,7 +132,7 @@ public class FileStoreITCase extends AbstractTestBase {
         FileStoreTable table = buildFileStoreTable(new int[] {1}, new int[] {1, 2});
 
         // write
-        new FlinkSinkBuilder(IDENTIFIER, table).withInput(buildTestSource(env, isBatch)).build();
+        new FlinkSinkBuilder(table).withInput(buildTestSource(env, isBatch)).build();
         env.execute();
 
         // read
@@ -152,7 +152,7 @@ public class FileStoreITCase extends AbstractTestBase {
         FileStoreTable table = buildFileStoreTable(new int[0], new int[] {2});
 
         // write
-        new FlinkSinkBuilder(IDENTIFIER, table).withInput(buildTestSource(env, isBatch)).build();
+        new FlinkSinkBuilder(table).withInput(buildTestSource(env, isBatch)).build();
         env.execute();
 
         // read
@@ -171,7 +171,7 @@ public class FileStoreITCase extends AbstractTestBase {
         FileStoreTable table = buildFileStoreTable(new int[] {1}, new int[] {1, 2});
 
         // write
-        new FlinkSinkBuilder(IDENTIFIER, table).withInput(buildTestSource(env, isBatch)).build();
+        new FlinkSinkBuilder(table).withInput(buildTestSource(env, isBatch)).build();
         env.execute();
 
         // overwrite p2
@@ -182,7 +182,7 @@ public class FileStoreITCase extends AbstractTestBase {
                         InternalTypeInfo.of(TABLE_TYPE));
         Map<String, String> overwrite = new HashMap<>();
         overwrite.put("p", "p2");
-        new FlinkSinkBuilder(IDENTIFIER, table)
+        new FlinkSinkBuilder(table)
                 .withInput(partialData)
                 .withOverwritePartition(overwrite)
                 .build();
@@ -201,7 +201,7 @@ public class FileStoreITCase extends AbstractTestBase {
                         Collections.singletonList(
                                 wrap(GenericRowData.of(19, StringData.fromString("p2"), 6))),
                         InternalTypeInfo.of(TABLE_TYPE));
-        new FlinkSinkBuilder(IDENTIFIER, table)
+        new FlinkSinkBuilder(table)
                 .withInput(partialData)
                 .withOverwritePartition(new HashMap<>())
                 .build();
@@ -218,7 +218,7 @@ public class FileStoreITCase extends AbstractTestBase {
         FileStoreTable table = buildFileStoreTable(new int[] {1}, new int[0]);
 
         // write
-        new FlinkSinkBuilder(IDENTIFIER, table).withInput(buildTestSource(env, isBatch)).build();
+        new FlinkSinkBuilder(table).withInput(buildTestSource(env, isBatch)).build();
         env.execute();
 
         // read
@@ -247,7 +247,7 @@ public class FileStoreITCase extends AbstractTestBase {
 
     private void testProjection(FileStoreTable table) throws Exception {
         // write
-        new FlinkSinkBuilder(IDENTIFIER, table).withInput(buildTestSource(env, isBatch)).build();
+        new FlinkSinkBuilder(table).withInput(buildTestSource(env, isBatch)).build();
         env.execute();
 
         // read
@@ -334,7 +334,7 @@ public class FileStoreITCase extends AbstractTestBase {
         }
         DataStreamSource<RowData> source =
                 env.addSource(new FiniteTestSource<>(src, true), InternalTypeInfo.of(TABLE_TYPE));
-        new FlinkSinkBuilder(IDENTIFIER, table).withInput(source).build();
+        new FlinkSinkBuilder(table).withInput(source).build();
         env.execute();
         assertThat(iterator.collect(expected.length)).containsExactlyInAnyOrder(expected);
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/Lock.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/Lock.java
@@ -73,22 +73,23 @@ public interface Lock extends AutoCloseable {
 
         @Override
         public Lock create() {
-            return new Lock() {
-                @Override
-                public <T> T runWithLock(Callable<T> callable) throws Exception {
-                    return callable.call();
-                }
-
-                @Override
-                public void close() {}
-            };
+            return new EmptyLock();
         }
     }
 
-    @Nullable
+    class EmptyLock implements Lock {
+        @Override
+        public <T> T runWithLock(Callable<T> callable) throws Exception {
+            return callable.call();
+        }
+
+        @Override
+        public void close() {}
+    }
+
     static Lock fromCatalog(CatalogLock lock, ObjectPath tablePath) {
         if (lock == null) {
-            return null;
+            return new EmptyLock();
         }
         return new CatalogLockImpl(lock, tablePath);
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/Lock.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/Lock.java
@@ -77,6 +77,7 @@ public interface Lock extends AutoCloseable {
         }
     }
 
+    /** An empty lock. */
     class EmptyLock implements Lock {
         @Override
         public <T> T runWithLock(Callable<T> callable) throws Exception {

--- a/flink-table-store-hive/flink-table-store-hive-catalog/src/main/java/org/apache/flink/table/store/hive/HiveCatalog.java
+++ b/flink-table-store-hive/flink-table-store-hive-catalog/src/main/java/org/apache/flink/table/store/hive/HiveCatalog.java
@@ -376,7 +376,7 @@ public class HiveCatalog extends AbstractCatalog {
 
     private Lock lock(ObjectPath tablePath) {
         if (!lockEnabled()) {
-            return null;
+            return new Lock.EmptyLock();
         }
 
         HiveCatalogLock lock =


### PR DESCRIPTION
For the core, it should not see too many Flink Table concepts, such as database and tableName. It only needs to create a Lock.