### PR TITLE
[FLINK-30206] Allow FileStoreScan to read incremental changes from OVERWRITE snapshot in Table Store

### DIFF
--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitGeneratorTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitGeneratorTest.java
@@ -77,7 +77,9 @@ public class FileStoreSourceSplitGeneratorTest {
                 };
         List<DataSplit> scanSplits =
                 DataTableScan.generateSplits(
-                        false, Collections::singletonList, plan.groupByPartFiles());
+                        false,
+                        Collections::singletonList,
+                        plan.groupByPartFiles(plan.files(FileKind.ADD)));
         DataTableScan.DataFilePlan tableScanPlan = new DataTableScan.DataFilePlan(1L, scanSplits);
 
         List<FileStoreSourceSplit> splits =

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AbstractFileStoreScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AbstractFileStoreScan.java
@@ -209,7 +209,8 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
                     FileUtils.COMMON_IO_FORK_JOIN_POOL
                             .submit(
                                     () ->
-                                            readManifests.parallelStream()
+                                            readManifests
+                                                    .parallelStream()
                                                     .filter(this::filterManifestFileMeta)
                                                     .flatMap(m -> readManifestFileMeta(m).stream())
                                                     .filter(this::filterManifestEntry)

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AbstractFileStoreScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AbstractFileStoreScan.java
@@ -209,8 +209,7 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
                     FileUtils.COMMON_IO_FORK_JOIN_POOL
                             .submit(
                                     () ->
-                                            readManifests
-                                                    .parallelStream()
+                                            readManifests.parallelStream()
                                                     .filter(this::filterManifestFileMeta)
                                                     .flatMap(m -> readManifestFileMeta(m).stream())
                                                     .filter(this::filterManifestEntry)
@@ -221,7 +220,7 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
         }
 
         List<ManifestEntry> files = new ArrayList<>();
-        for (ManifestEntry file : ManifestEntry.mergeManifestEntries(entries)) {
+        for (ManifestEntry file : ManifestEntry.mergeEntries(entries)) {
             if (checkNumOfBuckets && file.totalBuckets() != numOfBuckets) {
                 String partInfo =
                         partitionConverter.getArity() > 0
@@ -333,13 +332,13 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
                     return manifestList.read(snapshot.changelogManifestList());
                 }
             case NONE:
-                if (snapshot.commitKind() == Snapshot.CommitKind.APPEND) {
-                    return manifestList.read(snapshot.deltaManifestList());
+                if (snapshot.commitKind() == Snapshot.CommitKind.COMPACT) {
+                    throw new IllegalStateException(
+                            String.format(
+                                    "Incremental scan does not accept %s snapshot",
+                                    snapshot.commitKind()));
                 }
-                throw new IllegalStateException(
-                        String.format(
-                                "Incremental scan does not accept %s snapshot",
-                                snapshot.commitKind()));
+                return manifestList.read(snapshot.deltaManifestList());
             default:
                 throw new UnsupportedOperationException(
                         "Unknown changelog producer " + changelogProducer.name());

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
@@ -626,7 +626,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         Collection<ManifestEntry> mergedEntries;
         try {
             // merge manifest entries and also check if the files we want to delete are still there
-            mergedEntries = ManifestEntry.mergeManifestEntries(allEntries);
+            mergedEntries = ManifestEntry.mergeEntries(allEntries);
+            ManifestEntry.assertNoDelete(mergedEntries);
         } catch (Throwable e) {
             LOG.warn("File deletion conflicts detected! Give up committing.", e);
             throw createConflictException(

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/DataTableScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/DataTableScan.java
@@ -36,7 +36,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static org.apache.flink.table.store.file.predicate.PredicateBuilder.transformFieldMapping;
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/DataTableScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/DataTableScan.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.store.CoreOptions;
 import org.apache.flink.table.store.file.io.DataFileMeta;
+import org.apache.flink.table.store.file.manifest.FileKind;
 import org.apache.flink.table.store.file.operation.FileStoreScan;
 import org.apache.flink.table.store.file.predicate.Predicate;
 import org.apache.flink.table.store.file.predicate.PredicateBuilder;
@@ -35,6 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.table.store.file.predicate.PredicateBuilder.transformFieldMapping;
 
@@ -112,7 +114,8 @@ public abstract class DataTableScan implements TableScan {
     @Override
     public DataFilePlan plan() {
         FileStoreScan.Plan plan = scan.plan();
-        return new DataFilePlan(plan.snapshotId(), generateSplits(plan.groupByPartFiles()));
+        return new DataFilePlan(
+                plan.snapshotId(), generateSplits(plan.groupByPartFiles(plan.files(FileKind.ADD))));
     }
 
     private List<DataSplit> generateSplits(


### PR DESCRIPTION
Currently `AbstractFileStoreScan` can only read incremental changes from APPEND snapshots. However in OVERWRITE snapshots, users will also append new records to table. These changes must be discovered by compact job source so that the overwritten partition can be compacted.