### PR TITLE
[hotfix] Fix test unstable: use MergeFunctionFactory in TestFileStore

### DIFF
--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -31,7 +31,7 @@ import org.apache.flink.table.store.file.manifest.ManifestFileMeta;
 import org.apache.flink.table.store.file.manifest.ManifestList;
 import org.apache.flink.table.store.file.memory.HeapMemorySegmentPool;
 import org.apache.flink.table.store.file.memory.MemoryOwner;
-import org.apache.flink.table.store.file.mergetree.compact.MergeFunction;
+import org.apache.flink.table.store.file.mergetree.compact.MergeFunctionFactory;
 import org.apache.flink.table.store.file.operation.AbstractFileStoreWrite;
 import org.apache.flink.table.store.file.operation.FileStoreCommit;
 import org.apache.flink.table.store.file.operation.FileStoreCommitImpl;
@@ -94,7 +94,7 @@ public class TestFileStore extends KeyValueFileStore {
             RowType keyType,
             RowType valueType,
             KeyValueFieldsExtractor keyValueFieldsExtractor,
-            MergeFunction<KeyValue> mergeFunction) {
+            MergeFunctionFactory<KeyValue> mfFactory) {
         super(
                 new SchemaManager(options.path()),
                 0L,
@@ -104,7 +104,7 @@ public class TestFileStore extends KeyValueFileStore {
                 keyType,
                 valueType,
                 keyValueFieldsExtractor,
-                p -> mergeFunction);
+                mfFactory);
         this.root = root;
         this.keySerializer = new RowDataSerializer(keyType);
         this.valueSerializer = new RowDataSerializer(valueType);
@@ -457,7 +457,7 @@ public class TestFileStore extends KeyValueFileStore {
         private final RowType keyType;
         private final RowType valueType;
         private final KeyValueFieldsExtractor keyValueFieldsExtractor;
-        private final MergeFunction<KeyValue> mergeFunction;
+        private final MergeFunctionFactory<KeyValue> mfFactory;
 
         private CoreOptions.ChangelogProducer changelogProducer;
 
@@ -469,7 +469,7 @@ public class TestFileStore extends KeyValueFileStore {
                 RowType keyType,
                 RowType valueType,
                 KeyValueFieldsExtractor keyValueFieldsExtractor,
-                MergeFunction<KeyValue> mergeFunction) {
+                MergeFunctionFactory<KeyValue> mfFactory) {
             this.format = format;
             this.root = root;
             this.numBuckets = numBuckets;
@@ -477,7 +477,7 @@ public class TestFileStore extends KeyValueFileStore {
             this.keyType = keyType;
             this.valueType = valueType;
             this.keyValueFieldsExtractor = keyValueFieldsExtractor;
-            this.mergeFunction = mergeFunction;
+            this.mfFactory = mfFactory;
 
             this.changelogProducer = CoreOptions.ChangelogProducer.NONE;
         }
@@ -512,7 +512,7 @@ public class TestFileStore extends KeyValueFileStore {
                     keyType,
                     valueType,
                     keyValueFieldsExtractor,
-                    mergeFunction);
+                    mfFactory);
         }
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreCommitTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreCommitTest.java
@@ -538,7 +538,7 @@ public class FileStoreCommitTest {
                         TestKeyValueGenerator.KEY_TYPE,
                         TestKeyValueGenerator.DEFAULT_ROW_TYPE,
                         TestKeyValueGenerator.TestKeyValueFieldsExtractor.EXTRACTOR,
-                        DeduplicateMergeFunction.factory().create())
+                        DeduplicateMergeFunction.factory())
                 .changelogProducer(changelogProducer)
                 .build();
     }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreExpireTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/FileStoreExpireTest.java
@@ -93,7 +93,7 @@ public class FileStoreExpireTest {
                         TestKeyValueGenerator.KEY_TYPE,
                         TestKeyValueGenerator.DEFAULT_ROW_TYPE,
                         TestKeyValueGenerator.TestKeyValueFieldsExtractor.EXTRACTOR,
-                        DeduplicateMergeFunction.factory().create())
+                        DeduplicateMergeFunction.factory())
                 .changelogProducer(changelogProducer)
                 .build();
     }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreReadTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreReadTest.java
@@ -28,7 +28,7 @@ import org.apache.flink.table.store.file.TestFileStore;
 import org.apache.flink.table.store.file.TestKeyValueGenerator;
 import org.apache.flink.table.store.file.manifest.ManifestEntry;
 import org.apache.flink.table.store.file.mergetree.compact.DeduplicateMergeFunction;
-import org.apache.flink.table.store.file.mergetree.compact.MergeFunction;
+import org.apache.flink.table.store.file.mergetree.compact.MergeFunctionFactory;
 import org.apache.flink.table.store.file.mergetree.compact.ValueCountMergeFunction;
 import org.apache.flink.table.store.file.schema.AtomicDataType;
 import org.apache.flink.table.store.file.schema.DataField;
@@ -134,7 +134,7 @@ public class KeyValueFileStoreReadTest {
                                                         DataTypes.BIGINT().getLogicalType())));
                             }
                         },
-                        ValueCountMergeFunction.factory().create());
+                        ValueCountMergeFunction.factory());
         List<KeyValue> readData =
                 writeThenRead(
                         data,
@@ -174,7 +174,7 @@ public class KeyValueFileStoreReadTest {
                         TestKeyValueGenerator.KEY_TYPE,
                         TestKeyValueGenerator.DEFAULT_ROW_TYPE,
                         TestKeyValueGenerator.TestKeyValueFieldsExtractor.EXTRACTOR,
-                        DeduplicateMergeFunction.factory().create());
+                        DeduplicateMergeFunction.factory());
 
         RowDataSerializer projectedValueSerializer =
                 new RowDataSerializer(
@@ -263,10 +263,10 @@ public class KeyValueFileStoreReadTest {
             RowType keyType,
             RowType valueType,
             KeyValueFieldsExtractor extractor,
-            MergeFunction<KeyValue> mergeFunction)
+            MergeFunctionFactory<KeyValue> mfFactory)
             throws Exception {
         SchemaManager schemaManager = new SchemaManager(new Path(tempDir.toUri()));
-        boolean valueCountMode = mergeFunction instanceof ValueCountMergeFunction;
+        boolean valueCountMode = mfFactory.create() instanceof ValueCountMergeFunction;
         schemaManager.commitNewVersion(
                 new UpdateSchema(
                         valueCountMode ? keyType : valueType,
@@ -288,7 +288,7 @@ public class KeyValueFileStoreReadTest {
                         keyType,
                         valueType,
                         extractor,
-                        mergeFunction)
+                        mfFactory)
                 .build();
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreScanTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreScanTest.java
@@ -72,7 +72,7 @@ public class KeyValueFileStoreScanTest {
                                 TestKeyValueGenerator.KEY_TYPE,
                                 TestKeyValueGenerator.DEFAULT_ROW_TYPE,
                                 TestKeyValueGenerator.TestKeyValueFieldsExtractor.EXTRACTOR,
-                                DeduplicateMergeFunction.factory().create())
+                                DeduplicateMergeFunction.factory())
                         .build();
         snapshotManager = store.snapshotManager();
 


### PR DESCRIPTION
Currently, without copy, merge function may produce wrong results in `TestFileStore`.