### PR TITLE
[FLINK-30269] Validate table name for metadata table

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/FlinkCatalog.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/FlinkCatalog.java
@@ -56,6 +56,7 @@ import java.util.Optional;
 
 import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
 import static org.apache.flink.table.store.CoreOptions.PATH;
+import static org.apache.flink.table.store.file.catalog.Catalog.METADATA_TABLE_SPLITTER;
 
 /** Catalog for table store. */
 public class FlinkCatalog extends AbstractCatalog {
@@ -189,6 +190,12 @@ public class FlinkCatalog extends AbstractCatalog {
         if (!(table instanceof CatalogTable)) {
             throw new UnsupportedOperationException(
                     "Only support CatalogTable, but is: " + table.getClass());
+        }
+        if (tablePath.getObjectName().contains(METADATA_TABLE_SPLITTER)) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Table name[%s] cannot contain '%s' separator",
+                            tablePath.getObjectName(), METADATA_TABLE_SPLITTER));
         }
         CatalogTable catalogTable = (CatalogTable) table;
         Map<String, String> options = table.getOptions();

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/FlinkCatalog.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/FlinkCatalog.java
@@ -56,7 +56,6 @@ import java.util.Optional;
 
 import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
 import static org.apache.flink.table.store.CoreOptions.PATH;
-import static org.apache.flink.table.store.file.catalog.Catalog.METADATA_TABLE_SPLITTER;
 
 /** Catalog for table store. */
 public class FlinkCatalog extends AbstractCatalog {
@@ -190,12 +189,6 @@ public class FlinkCatalog extends AbstractCatalog {
         if (!(table instanceof CatalogTable)) {
             throw new UnsupportedOperationException(
                     "Only support CatalogTable, but is: " + table.getClass());
-        }
-        if (tablePath.getObjectName().contains(METADATA_TABLE_SPLITTER)) {
-            throw new IllegalArgumentException(
-                    String.format(
-                            "Table name[%s] cannot contain '%s' separator",
-                            tablePath.getObjectName(), METADATA_TABLE_SPLITTER));
         }
         CatalogTable catalogTable = (CatalogTable) table;
         Map<String, String> options = table.getOptions();

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/CatalogTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/CatalogTableITCase.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import java.util.List;
 
+import static org.apache.flink.table.store.file.catalog.Catalog.METADATA_TABLE_SPLITTER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -54,5 +55,19 @@ public class CatalogTableITCase extends CatalogITCaseBase {
 
         List<Row> result = sql("SELECT * FROM T$options");
         assertThat(result).containsExactly(Row.of("snapshot.time-retained", "5 h"));
+    }
+
+    @Test
+    public void testCreateMetaTable() {
+        assertThatThrownBy(() -> sql("CREATE TABLE T$snapshots (a INT, b INT)"))
+                .hasRootCauseMessage(
+                        String.format(
+                                "Table name[%s] cannot contain '%s' separator",
+                                "T$snapshots", METADATA_TABLE_SPLITTER));
+        assertThatThrownBy(() -> sql("CREATE TABLE T$aa$bb (a INT, b INT)"))
+                .hasRootCauseMessage(
+                        String.format(
+                                "Table name[%s] cannot contain '%s' separator",
+                                "T$aa$bb", METADATA_TABLE_SPLITTER));
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/AbstractCatalog.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/AbstractCatalog.java
@@ -34,6 +34,12 @@ public abstract class AbstractCatalog implements Catalog {
 
     @Override
     public Path getTableLocation(ObjectPath tablePath) {
+        if (tablePath.getObjectName().contains(METADATA_TABLE_SPLITTER)) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Table name[%s] cannot contain '%s' separator",
+                            tablePath.getObjectName(), METADATA_TABLE_SPLITTER));
+        }
         return new Path(databasePath(tablePath.getDatabaseName()), tablePath.getObjectName());
     }
 


### PR DESCRIPTION
Currently user can create tables `tablename` and `tablename$snapshots`, but can't insert into values into `tablename$snapshots` and execute query on it.

At the same time, user can create table `tablename$aaa$bbb`, but cannot execute query on it and event cannot drop it.

This PR aims to validate the table name and user cannot create the table whose name contains `$`