### PR TITLE
[FLINK-30271] Introduce Table.copy from dynamic options

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/MetadataCatalogTable.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/MetadataCatalogTable.java
@@ -60,7 +60,7 @@ public class MetadataCatalogTable implements CatalogTable {
 
     @Override
     public CatalogTable copy(Map<String, String> map) {
-        return copy();
+        return new MetadataCatalogTable(table.copy(map));
     }
 
     @Override
@@ -75,7 +75,7 @@ public class MetadataCatalogTable implements CatalogTable {
 
     @Override
     public CatalogTable copy() {
-        return new MetadataCatalogTable(table);
+        return copy(Collections.emptyMap());
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
@@ -372,7 +372,7 @@ public class SchemaManager implements Serializable {
         return new Path(tableRoot + "/schema/" + SCHEMA_PREFIX + id);
     }
 
-    private void checkAlterTableOption(String key) {
+    public static void checkAlterTableOption(String key) {
         if (CoreOptions.getImmutableOptionKeys().contains(key)) {
             throw new UnsupportedOperationException(
                     String.format("Change '%s' is not supported yet.", key));

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AbstractFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AbstractFileStoreTable.java
@@ -62,11 +62,14 @@ public abstract class AbstractFileStoreTable implements FileStoreTable {
 
         Configuration newOptions = Configuration.fromMap(options);
 
+        // merge dynamic options into schema.options
+        dynamicOptions.forEach(newOptions::setString);
+
         // set path always
         newOptions.set(PATH, path.toString());
 
-        // merge dynamic options into schema.options
-        dynamicOptions.forEach(newOptions::setString);
+        // set dynamic options with default values
+        CoreOptions.setDefaultValues(newOptions);
 
         // copy a new table store to contain dynamic options
         TableSchema newTableSchema = tableSchema.copy(newOptions.toMap());

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AbstractFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AbstractFileStoreTable.java
@@ -18,19 +18,26 @@
 
 package org.apache.flink.table.store.table;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.store.CoreOptions;
 import org.apache.flink.table.store.file.FileStore;
+import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
 import org.apache.flink.table.store.table.sink.TableCommit;
+
+import java.util.Map;
+import java.util.Objects;
+
+import static org.apache.flink.table.store.CoreOptions.PATH;
 
 /** Abstract {@link FileStoreTable}. */
 public abstract class AbstractFileStoreTable implements FileStoreTable {
 
     private static final long serialVersionUID = 1L;
 
-    private final Path path;
+    protected final Path path;
     protected final TableSchema tableSchema;
 
     public AbstractFileStoreTable(Path path, TableSchema tableSchema) {
@@ -39,6 +46,40 @@ public abstract class AbstractFileStoreTable implements FileStoreTable {
     }
 
     protected abstract FileStore<?> store();
+
+    protected abstract FileStoreTable copy(TableSchema newTableSchema);
+
+    @Override
+    public FileStoreTable copy(Map<String, String> dynamicOptions) {
+        // check option is not immutable
+        Map<String, String> options = tableSchema.options();
+        dynamicOptions.forEach(
+                (k, v) -> {
+                    if (!Objects.equals(v, options.get(k))) {
+                        SchemaManager.checkAlterTableOption(k);
+                    }
+                });
+
+        Configuration newOptions = Configuration.fromMap(options);
+
+        // set path always
+        newOptions.set(PATH, path.toString());
+
+        // merge dynamic options into schema.options
+        dynamicOptions.forEach(newOptions::setString);
+
+        // copy a new table store to contain dynamic options
+        TableSchema newTableSchema = tableSchema.copy(newOptions.toMap());
+
+        // validate schema wit new options
+        CoreOptions.validateTableSchema(newTableSchema);
+
+        return copy(newTableSchema);
+    }
+
+    protected SchemaManager schemaManager() {
+        return new SchemaManager(path);
+    }
 
     @Override
     public CoreOptions options() {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/FileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/FileStoreTable.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.store.table.source.DataTableScan;
 import org.apache.flink.table.types.logical.RowType;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * An abstraction layer above {@link org.apache.flink.table.store.file.FileStore} to provide reading
@@ -56,6 +57,9 @@ public interface FileStoreTable extends Table, SupportsPartition, SupportsWrite 
     TableSchema schema();
 
     SnapshotManager snapshotManager();
+
+    @Override
+    FileStoreTable copy(Map<String, String> dynamicOptions);
 
     @Override
     DataTableScan newScan();

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/Table.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/Table.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.store.table.source.TableScan;
 import org.apache.flink.table.types.logical.RowType;
 
 import java.io.Serializable;
+import java.util.Map;
 
 /** A table provides basic abstraction for table type and table scan and table read. */
 public interface Table extends Serializable {
@@ -34,4 +35,6 @@ public interface Table extends Serializable {
     TableScan newScan();
 
     TableRead newRead();
+
+    Table copy(Map<String, String> dynamicOptions);
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/metadata/OptionsTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/metadata/OptionsTable.java
@@ -84,6 +84,11 @@ public class OptionsTable implements Table {
         return new OptionsRead();
     }
 
+    @Override
+    public Table copy(Map<String, String> dynamicOptions) {
+        return new OptionsTable(location);
+    }
+
     private class OptionsScan implements TableScan {
 
         @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/metadata/SnapshotsTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/metadata/SnapshotsTable.java
@@ -47,6 +47,7 @@ import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Objects;
 
 import static org.apache.flink.table.store.file.catalog.Catalog.METADATA_TABLE_SPLITTER;
@@ -94,6 +95,11 @@ public class SnapshotsTable implements Table {
     @Override
     public TableRead newRead() {
         return new SnapshotsRead();
+    }
+
+    @Override
+    public Table copy(Map<String, String> dynamicOptions) {
+        return new SnapshotsTable(location);
     }
 
     private class SnapshotsScan implements TableScan {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyFileDataTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyFileDataTableTest.java
@@ -29,6 +29,11 @@ public class AppendOnlyFileDataTableTest extends FileDataFilterTestBase {
     @Override
     protected FileStoreTable createFileStoreTable(Map<Long, TableSchema> tableSchemas) {
         SchemaManager schemaManager = new TestingSchemaManager(tablePath, tableSchemas);
-        return new AppendOnlyFileStoreTable(tablePath, schemaManager, schemaManager.latest().get());
+        return new AppendOnlyFileStoreTable(tablePath, schemaManager.latest().get()) {
+            @Override
+            protected SchemaManager schemaManager() {
+                return schemaManager;
+            }
+        };
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTableTest.java
@@ -246,15 +246,15 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         conf.set(CoreOptions.PATH, tablePath.toString());
         conf.set(CoreOptions.WRITE_MODE, WriteMode.APPEND_ONLY);
         configure.accept(conf);
-        SchemaManager schemaManager = new SchemaManager(tablePath);
         TableSchema tableSchema =
-                schemaManager.commitNewVersion(
-                        new UpdateSchema(
-                                ROW_TYPE,
-                                Collections.singletonList("pt"),
-                                Collections.emptyList(),
-                                conf.toMap(),
-                                ""));
-        return new AppendOnlyFileStoreTable(tablePath, schemaManager, tableSchema);
+                new SchemaManager(tablePath)
+                        .commitNewVersion(
+                                new UpdateSchema(
+                                        ROW_TYPE,
+                                        Collections.singletonList("pt"),
+                                        Collections.emptyList(),
+                                        conf.toMap(),
+                                        ""));
+        return new AppendOnlyFileStoreTable(tablePath, tableSchema);
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyTableFileMetaFilterTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyTableFileMetaFilterTest.java
@@ -41,7 +41,12 @@ public class AppendOnlyTableFileMetaFilterTest extends FileMetaFilterTestBase {
     @Override
     protected FileStoreTable createFileStoreTable(Map<Long, TableSchema> tableSchemas) {
         SchemaManager schemaManager = new TestingSchemaManager(tablePath, tableSchemas);
-        return new AppendOnlyFileStoreTable(tablePath, schemaManager, schemaManager.latest().get());
+        return new AppendOnlyFileStoreTable(tablePath, schemaManager.latest().get()) {
+            @Override
+            protected SchemaManager schemaManager() {
+                return schemaManager;
+            }
+        };
     }
 
     @Override

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogValueCountFileDataTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogValueCountFileDataTableTest.java
@@ -46,7 +46,11 @@ public class ChangelogValueCountFileDataTableTest extends FileDataFilterTestBase
     @Override
     protected FileStoreTable createFileStoreTable(Map<Long, TableSchema> tableSchemas) {
         SchemaManager schemaManager = new TestingSchemaManager(tablePath, tableSchemas);
-        return new ChangelogValueCountFileStoreTable(
-                tablePath, schemaManager, schemaManager.latest().get());
+        return new ChangelogValueCountFileStoreTable(tablePath, schemaManager.latest().get()) {
+            @Override
+            protected SchemaManager schemaManager() {
+                return schemaManager;
+            }
+        };
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogValueCountFileMetaFilterTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogValueCountFileMetaFilterTest.java
@@ -48,8 +48,12 @@ public class ChangelogValueCountFileMetaFilterTest extends FileMetaFilterTestBas
     @Override
     protected FileStoreTable createFileStoreTable(Map<Long, TableSchema> tableSchemas) {
         SchemaManager schemaManager = new TestingSchemaManager(tablePath, tableSchemas);
-        return new ChangelogValueCountFileStoreTable(
-                tablePath, schemaManager, schemaManager.latest().get());
+        return new ChangelogValueCountFileStoreTable(tablePath, schemaManager.latest().get()) {
+            @Override
+            protected SchemaManager schemaManager() {
+                return schemaManager;
+            }
+        };
     }
 
     @Override

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTableTest.java
@@ -213,6 +213,6 @@ public class ChangelogValueCountFileStoreTableTest extends FileStoreTableTestBas
                                 Collections.emptyList(),
                                 conf.toMap(),
                                 ""));
-        return new ChangelogValueCountFileStoreTable(tablePath, schemaManager, tableSchema);
+        return new ChangelogValueCountFileStoreTable(tablePath, tableSchema);
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileDataTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileDataTableTest.java
@@ -224,7 +224,6 @@ public class ChangelogWithKeyFileDataTableTest extends FileDataFilterTestBase {
     @Override
     protected FileStoreTable createFileStoreTable(Map<Long, TableSchema> tableSchemas) {
         SchemaManager schemaManager = new TestingSchemaManager(tablePath, tableSchemas);
-        return new ChangelogWithKeyFileStoreTable(
-                tablePath, schemaManager, schemaManager.latest().get());
+        return new ChangelogWithKeyFileStoreTable(tablePath, schemaManager.latest().get());
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileDataTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileDataTableTest.java
@@ -224,6 +224,12 @@ public class ChangelogWithKeyFileDataTableTest extends FileDataFilterTestBase {
     @Override
     protected FileStoreTable createFileStoreTable(Map<Long, TableSchema> tableSchemas) {
         SchemaManager schemaManager = new TestingSchemaManager(tablePath, tableSchemas);
-        return new ChangelogWithKeyFileStoreTable(tablePath, schemaManager.latest().get());
+        return new ChangelogWithKeyFileStoreTable(tablePath, schemaManager.latest().get()) {
+
+            @Override
+            protected SchemaManager schemaManager() {
+                return schemaManager;
+            }
+        };
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileMetaFilterTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileMetaFilterTest.java
@@ -144,8 +144,12 @@ public class ChangelogWithKeyFileMetaFilterTest extends FileMetaFilterTestBase {
     @Override
     protected FileStoreTable createFileStoreTable(Map<Long, TableSchema> tableSchemas) {
         SchemaManager schemaManager = new TestingSchemaManager(tablePath, tableSchemas);
-        return new ChangelogWithKeyFileStoreTable(
-                tablePath, schemaManager, schemaManager.latest().get());
+        return new ChangelogWithKeyFileStoreTable(tablePath, schemaManager.latest().get()) {
+            @Override
+            protected SchemaManager schemaManager() {
+                return schemaManager;
+            }
+        };
     }
 
     @Override

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTableTest.java
@@ -631,6 +631,6 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
                                 Arrays.asList("pt", "a"),
                                 conf.toMap(),
                                 ""));
-        return new ChangelogWithKeyFileStoreTable(tablePath, schemaManager, tableSchema);
+        return new ChangelogWithKeyFileStoreTable(tablePath, tableSchema);
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/FileStoreTableTestBase.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/FileStoreTableTestBase.java
@@ -379,8 +379,14 @@ public abstract class FileStoreTableTestBase {
             int bucket,
             Function<RowData, String> rowDataToString)
             throws Exception {
+        return getResult(read, getSplitsFor(splits, partition, bucket), rowDataToString);
+    }
+
+    protected List<String> getResult(
+            TableRead read, List<Split> splits, Function<RowData, String> rowDataToString)
+            throws Exception {
         List<ReaderSupplier<RowData>> readers = new ArrayList<>();
-        for (Split split : getSplitsFor(splits, partition, bucket)) {
+        for (Split split : splits) {
             readers.add(() -> read.createReader(split));
         }
         RecordReader<RowData> recordReader = ConcatRecordReader.create(readers);

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/WritePreemptMemoryTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/WritePreemptMemoryTest.java
@@ -105,6 +105,6 @@ public class WritePreemptMemoryTest extends FileStoreTableTestBase {
                                 Arrays.asList("pt", "a"),
                                 conf.toMap(),
                                 ""));
-        return new ChangelogWithKeyFileStoreTable(tablePath, schemaManager, schema);
+        return new ChangelogWithKeyFileStoreTable(tablePath, schema);
     }
 }


### PR DESCRIPTION
At present, our processing of dynamic options is relatively independent. In FileStoreTableFactory, this is not conducive to other engines configuring dynamic options.

We should propose an interface on the Table, and dynamic options can be configured at any time.