### PR TITLE
[FLINK-30319] Validate column name in ddl

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
@@ -50,6 +50,9 @@ import java.util.Set;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.configuration.description.TextElement.text;
+import static org.apache.flink.table.store.file.schema.TableSchema.KEY_FIELD_PREFIX;
+import static org.apache.flink.table.store.file.schema.TableSchema.SYSTEM_FIELD_NAMES;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /** Core options for table store. */
 public class CoreOptions implements Serializable {
@@ -788,6 +791,22 @@ public class CoreOptions implements Serializable {
             throw new UnsupportedOperationException(
                     "Changelog table with full compaction must have primary keys");
         }
+
+        // Check column names in schema
+        schema.fieldNames()
+                .forEach(
+                        f -> {
+                            checkState(
+                                    !SYSTEM_FIELD_NAMES.contains(f),
+                                    String.format(
+                                            "Field name[%s] in schema cannot be exist in [%s]",
+                                            f, SYSTEM_FIELD_NAMES.toString()));
+                            checkState(
+                                    !f.startsWith(KEY_FIELD_PREFIX),
+                                    String.format(
+                                            "Field name[%s] in schema cannot start with [%s]",
+                                            f, KEY_FIELD_PREFIX));
+                        });
     }
 
     @Internal

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValue.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValue.java
@@ -34,6 +34,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.apache.flink.table.store.file.schema.TableSchema.SEQUENCE_NUMBER;
+import static org.apache.flink.table.store.file.schema.TableSchema.VALUE_KIND;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
@@ -41,8 +43,6 @@ import static org.apache.flink.util.Preconditions.checkState;
  * reused.
  */
 public class KeyValue {
-    private static final String SEQUENCE_NUMBER = "_SEQUENCE_NUMBER";
-    private static final String VALUE_KIND = "_VALUE_KIND";
 
     public static final long UNKNOWN_SEQUENCE = -1;
     public static final int UNKNOWN_LEVEL = -1;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/TableSchema.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/TableSchema.java
@@ -53,6 +53,15 @@ public class TableSchema implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    /** System field names. */
+    public static final String KEY_FIELD_PREFIX = "_KEY_";
+
+    public static final String VALUE_COUNT = "_VALUE_COUNT";
+    public static final String SEQUENCE_NUMBER = "_SEQUENCE_NUMBER";
+    public static final String VALUE_KIND = "_VALUE_KIND";
+    public static final List<String> SYSTEM_FIELD_NAMES =
+            Arrays.asList(VALUE_COUNT, SEQUENCE_NUMBER, VALUE_KIND);
+
     private final long id;
 
     private final List<DataField> fields;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogValueCountFileStoreTable.java
@@ -51,6 +51,8 @@ import org.apache.flink.types.RowKind;
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.flink.table.store.file.schema.TableSchema.VALUE_COUNT;
+
 /** {@link FileStoreTable} for {@link WriteMode#CHANGE_LOG} write mode without primary keys. */
 public class ChangelogValueCountFileStoreTable extends AbstractFileStoreTable {
 
@@ -173,7 +175,7 @@ public class ChangelogValueCountFileStoreTable extends AbstractFileStoreTable {
         @Override
         public List<DataField> valueFields(TableSchema schema) {
             return Collections.singletonList(
-                    new DataField(0, "_VALUE_COUNT", new AtomicDataType(new BigIntType(false))));
+                    new DataField(0, VALUE_COUNT, new AtomicDataType(new BigIntType(false))));
         }
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTable.java
@@ -55,11 +55,10 @@ import java.util.stream.Collectors;
 import static org.apache.flink.table.store.file.predicate.PredicateBuilder.and;
 import static org.apache.flink.table.store.file.predicate.PredicateBuilder.pickTransformFieldMapping;
 import static org.apache.flink.table.store.file.predicate.PredicateBuilder.splitAnd;
+import static org.apache.flink.table.store.file.schema.TableSchema.KEY_FIELD_PREFIX;
 
 /** {@link FileStoreTable} for {@link WriteMode#CHANGE_LOG} write mode with primary keys. */
 public class ChangelogWithKeyFileStoreTable extends AbstractFileStoreTable {
-
-    private static final String KEY_FIELD_PREFIX = "_KEY_";
 
     private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
There're some system field names such as column with prefix `_KEY_`, column names `_VALUE_COUNT`, `_SEQUENCE_NUMBER` and `_VALUE_KIND`. User can use them to create table in table store, but it will throw exception when user try to `insert values ...` to the table as followed:
Caused by: org.apache.flink.table.api.ValidationException: Field names must be unique. Found duplicates: [_KEY_word]
	at org.apache.flink.table.types.logical.RowType.validateFields(RowType.java:273)
	at org.apache.flink.table.types.logical.RowType.<init>(RowType.java:158)
	at org.apache.flink.table.types.logical.RowType.<init>(RowType.java:162)
	at org.apache.flink.table.store.file.KeyValue.schema(KeyValue.java:106)
	at org.apache.flink.table.store.file.io.KeyValueFileWriterFactory$Builder.build(KeyValueFileWriterFactory.java:142)
	at org.apache.flink.table.store.file.operation.KeyValueFileStoreWrite.createMergeTreeWriter(KeyValueFileStoreWrite.java:136)
	at org.apache.flink.table.store.file.operation.KeyValueFileStoreWrite.createWriter(KeyValueFileStoreWrite.java:112)
	at org.apache.flink.table.store.file.operation.AbstractFileStoreWrite.createWriter(AbstractFileStoreWrite.java:227)
	at org.apache.flink.table.store.file.operation.AbstractFileStoreWrite.lambda$getWriter$1(AbstractFileStoreWrite.java:217)
	at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1224)

This will confuse the user, and table store should check the column name in DDL
