### PR TITLE
[FLINK-30333] Supports lookup a partial-update table

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/lookup/FileStoreLookupFunction.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/lookup/FileStoreLookupFunction.java
@@ -30,7 +30,7 @@ import org.apache.flink.table.store.file.predicate.PredicateFilter;
 import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.table.FileStoreTable;
 import org.apache.flink.table.store.table.source.TableStreamingReader;
-import org.apache.flink.table.store.table.source.snapshot.SnapshotEnumerator;
+import org.apache.flink.table.store.table.source.snapshot.ContinuousDataFileSnapshotEnumerator;
 import org.apache.flink.table.store.utils.TypeUtils;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.FileUtils;
@@ -86,7 +86,7 @@ public class FileStoreLookupFunction extends TableFunction<RowData> {
         checkArgument(
                 schema.partitionKeys().isEmpty(), "Currently only support non-partitioned table.");
         checkArgument(schema.primaryKeys().size() > 0, "Currently only support primary key table.");
-        SnapshotEnumerator.validateContinuous(table.schema());
+        ContinuousDataFileSnapshotEnumerator.validate(table.schema());
 
         this.table = table;
 

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/lookup/FileStoreLookupFunction.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/lookup/FileStoreLookupFunction.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.store.file.predicate.PredicateFilter;
 import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.table.FileStoreTable;
 import org.apache.flink.table.store.table.source.TableStreamingReader;
+import org.apache.flink.table.store.table.source.snapshot.SnapshotEnumerator;
 import org.apache.flink.table.store.utils.TypeUtils;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.FileUtils;
@@ -85,6 +86,8 @@ public class FileStoreLookupFunction extends TableFunction<RowData> {
         checkArgument(
                 schema.partitionKeys().isEmpty(), "Currently only support non-partitioned table.");
         checkArgument(schema.primaryKeys().size() > 0, "Currently only support primary key table.");
+        SnapshotEnumerator.validateContinuous(table.schema());
+
         this.table = table;
 
         // join keys are based on projection fields

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FlinkSourceBuilder.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FlinkSourceBuilder.java
@@ -33,7 +33,7 @@ import org.apache.flink.table.store.CoreOptions.StartupMode;
 import org.apache.flink.table.store.file.predicate.Predicate;
 import org.apache.flink.table.store.log.LogSourceProvider;
 import org.apache.flink.table.store.table.FileStoreTable;
-import org.apache.flink.table.store.table.source.snapshot.SnapshotEnumerator;
+import org.apache.flink.table.store.table.source.snapshot.ContinuousDataFileSnapshotEnumerator;
 import org.apache.flink.table.store.utils.Projection;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
@@ -123,7 +123,7 @@ public class FlinkSourceBuilder {
 
     private Source<RowData, ?, ?> buildSource() {
         if (isContinuous) {
-            SnapshotEnumerator.validateContinuous(table.schema());
+            ContinuousDataFileSnapshotEnumerator.validate(table.schema());
 
             // TODO visit all options through CoreOptions
             StartupMode startupMode = CoreOptions.startupMode(conf);

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
@@ -446,6 +446,10 @@ public class CoreOptions implements Serializable {
         return options.get(MANIFEST_MERGE_MIN_COUNT);
     }
 
+    public MergeEngine mergeEngine() {
+        return options.get(MERGE_ENGINE);
+    }
+
     public long splitTargetSize() {
         return options.get(SOURCE_SPLIT_TARGET_SIZE).getBytes();
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/TableStreamingReader.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/TableStreamingReader.java
@@ -25,8 +25,6 @@ import org.apache.flink.table.store.file.predicate.PredicateFilter;
 import org.apache.flink.table.store.file.utils.RecordReaderIterator;
 import org.apache.flink.table.store.table.FileStoreTable;
 import org.apache.flink.table.store.table.source.snapshot.ContinuousDataFileSnapshotEnumerator;
-import org.apache.flink.table.store.table.source.snapshot.DeltaFollowUpScanner;
-import org.apache.flink.table.store.table.source.snapshot.FullStartingScanner;
 import org.apache.flink.table.store.table.source.snapshot.SnapshotEnumerator;
 import org.apache.flink.table.store.utils.TypeUtils;
 
@@ -88,13 +86,7 @@ public class TableStreamingReader {
         if (predicate != null) {
             scan.withFilter(predicate);
         }
-        enumerator =
-                new ContinuousDataFileSnapshotEnumerator(
-                        table.location(),
-                        scan,
-                        new FullStartingScanner(),
-                        new DeltaFollowUpScanner(),
-                        null);
+        enumerator = ContinuousDataFileSnapshotEnumerator.create(table, scan, null);
     }
 
     @Nullable

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/TableStreamingReader.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/TableStreamingReader.java
@@ -86,7 +86,7 @@ public class TableStreamingReader {
         if (predicate != null) {
             scan.withFilter(predicate);
         }
-        enumerator = ContinuousDataFileSnapshotEnumerator.create(table, scan, null);
+        enumerator = ContinuousDataFileSnapshotEnumerator.createWithSnapshotStarting(table, scan);
     }
 
     @Nullable

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/snapshot/ContinuousDataFileSnapshotEnumerator.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/snapshot/ContinuousDataFileSnapshotEnumerator.java
@@ -102,17 +102,35 @@ public class ContinuousDataFileSnapshotEnumerator implements SnapshotEnumerator 
     //  static create methods
     // ------------------------------------------------------------------------
 
+    public static ContinuousDataFileSnapshotEnumerator createWithSnapshotStarting(
+            FileStoreTable table, DataTableScan scan) {
+        StartingScanner startingScanner =
+                table.options().startupMode() == CoreOptions.StartupMode.COMPACTED
+                        ? new CompactedStartingScanner()
+                        : new FullStartingScanner();
+        return new ContinuousDataFileSnapshotEnumerator(
+                table.location(), scan, startingScanner, createFollowUpScanner(table, scan), null);
+    }
+
     public static ContinuousDataFileSnapshotEnumerator create(
-            FileStoreTable table, DataTableScan scan, Long nextSnapshotId) {
+            FileStoreTable table, DataTableScan scan, @Nullable Long nextSnapshotId) {
+        return new ContinuousDataFileSnapshotEnumerator(
+                table.location(),
+                scan,
+                createStartingScanner(table),
+                createFollowUpScanner(table, scan),
+                nextSnapshotId);
+    }
+
+    private static StartingScanner createStartingScanner(FileStoreTable table) {
         CoreOptions.StartupMode startupMode = table.options().startupMode();
         Long startupMillis = table.options().logScanTimestampMills();
-        StartingScanner startingScanner;
         if (startupMode == CoreOptions.StartupMode.FULL) {
-            startingScanner = new FullStartingScanner();
+            return new FullStartingScanner();
         } else if (startupMode == CoreOptions.StartupMode.LATEST) {
-            startingScanner = new ContinuousLatestStartingScanner();
+            return new ContinuousLatestStartingScanner();
         } else if (startupMode == CoreOptions.StartupMode.COMPACTED) {
-            startingScanner = new CompactedStartingScanner();
+            return new CompactedStartingScanner();
         } else if (startupMode == CoreOptions.StartupMode.FROM_TIMESTAMP) {
             Preconditions.checkNotNull(
                     startupMillis,
@@ -121,27 +139,25 @@ public class ContinuousDataFileSnapshotEnumerator implements SnapshotEnumerator 
                             CoreOptions.SCAN_TIMESTAMP_MILLIS.key(),
                             CoreOptions.StartupMode.FROM_TIMESTAMP,
                             CoreOptions.SCAN_MODE.key()));
-            startingScanner = new ContinuousFromTimestampStartingScanner(startupMillis);
+            return new ContinuousFromTimestampStartingScanner(startupMillis);
         } else {
             throw new UnsupportedOperationException("Unknown startup mode " + startupMode.name());
         }
+    }
 
+    private static FollowUpScanner createFollowUpScanner(FileStoreTable table, DataTableScan scan) {
         CoreOptions.ChangelogProducer changelogProducer = table.options().changelogProducer();
-        FollowUpScanner followUpScanner;
         if (changelogProducer == CoreOptions.ChangelogProducer.NONE) {
-            followUpScanner = new DeltaFollowUpScanner();
+            return new DeltaFollowUpScanner();
         } else if (changelogProducer == CoreOptions.ChangelogProducer.INPUT) {
-            followUpScanner = new InputChangelogFollowUpScanner();
+            return new InputChangelogFollowUpScanner();
         } else if (changelogProducer == CoreOptions.ChangelogProducer.FULL_COMPACTION) {
             // this change in scan will affect both starting scanner and follow-up scanner
             scan.withLevel(table.options().numLevels() - 1);
-            followUpScanner = new CompactionChangelogFollowUpScanner();
+            return new CompactionChangelogFollowUpScanner();
         } else {
             throw new UnsupportedOperationException(
                     "Unknown changelog producer " + changelogProducer.name());
         }
-
-        return new ContinuousDataFileSnapshotEnumerator(
-                table.location(), scan, startingScanner, followUpScanner, nextSnapshotId);
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/snapshot/SnapshotEnumerator.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/snapshot/SnapshotEnumerator.java
@@ -18,17 +18,9 @@
 
 package org.apache.flink.table.store.table.source.snapshot;
 
-import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.store.CoreOptions;
-import org.apache.flink.table.store.CoreOptions.MergeEngine;
-import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.table.source.DataTableScan;
 
 import javax.annotation.Nullable;
-
-import java.util.HashMap;
-
-import static org.apache.flink.table.store.CoreOptions.ChangelogProducer.FULL_COMPACTION;
 
 /** Enumerate incremental changes from newly created snapshots. */
 public interface SnapshotEnumerator {
@@ -44,24 +36,4 @@ public interface SnapshotEnumerator {
      */
     @Nullable
     DataTableScan.DataFilePlan enumerate();
-
-    static void validateContinuous(TableSchema schema) {
-        CoreOptions options = new CoreOptions(schema.options());
-        MergeEngine mergeEngine = options.mergeEngine();
-        HashMap<MergeEngine, String> mergeEngineDesc =
-                new HashMap<MergeEngine, String>() {
-                    {
-                        put(MergeEngine.PARTIAL_UPDATE, "Partial update");
-                        put(MergeEngine.AGGREGATE, "Pre-aggregate");
-                    }
-                };
-        if (schema.primaryKeys().size() > 0
-                && mergeEngineDesc.containsKey(mergeEngine)
-                && options.changelogProducer() != FULL_COMPACTION) {
-            throw new ValidationException(
-                    mergeEngineDesc.get(mergeEngine)
-                            + " continuous reading is not supported. "
-                            + "You can use full compaction changelog producer to support streaming reading.");
-        }
-    }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/snapshot/SnapshotEnumerator.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/snapshot/SnapshotEnumerator.java
@@ -18,9 +18,17 @@
 
 package org.apache.flink.table.store.table.source.snapshot;
 
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.store.CoreOptions;
+import org.apache.flink.table.store.CoreOptions.MergeEngine;
+import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.table.source.DataTableScan;
 
 import javax.annotation.Nullable;
+
+import java.util.HashMap;
+
+import static org.apache.flink.table.store.CoreOptions.ChangelogProducer.FULL_COMPACTION;
 
 /** Enumerate incremental changes from newly created snapshots. */
 public interface SnapshotEnumerator {
@@ -36,4 +44,24 @@ public interface SnapshotEnumerator {
      */
     @Nullable
     DataTableScan.DataFilePlan enumerate();
+
+    static void validateContinuous(TableSchema schema) {
+        CoreOptions options = new CoreOptions(schema.options());
+        MergeEngine mergeEngine = options.mergeEngine();
+        HashMap<MergeEngine, String> mergeEngineDesc =
+                new HashMap<MergeEngine, String>() {
+                    {
+                        put(MergeEngine.PARTIAL_UPDATE, "Partial update");
+                        put(MergeEngine.AGGREGATE, "Pre-aggregate");
+                    }
+                };
+        if (schema.primaryKeys().size() > 0
+                && mergeEngineDesc.containsKey(mergeEngine)
+                && options.changelogProducer() != FULL_COMPACTION) {
+            throw new ValidationException(
+                    mergeEngineDesc.get(mergeEngine)
+                            + " continuous reading is not supported. "
+                            + "You can use full compaction changelog producer to support streaming reading.");
+        }
+    }
 }


### PR DESCRIPTION
The lookup uses streaming read for reading table. (In TableStreamingReader)
- We should support lookup a partial-update table with full compaction.
- But partial-update table without full compaction, we should throw exception.