### PR TITLE
[FLINK-30504] Fix UnsupportedFileSystemSchemeException when writing Table Store on OSS with Spark

### DIFF
--- a/docs/content/docs/filesystems/oss.md
+++ b/docs/content/docs/filesystems/oss.md
@@ -48,9 +48,9 @@ You can find the shaded jars under
 [Prepare OSS jar](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/filesystems/oss/#shaded-hadoop-oss-file-system), then configure `flink-conf.yaml` like
 
 ```yaml
-fs.oss.endpoint: oss-cn-hangzhou.aliyun.cs.com
-fs.oss.accessKey: xxx
-fs.oss.accessSecret: yyy
+fs.oss.endpoint: oss-cn-hangzhou.aliyuncs.com
+fs.oss.accessKeyId: xxx
+fs.oss.accessKeySecret: yyy
 ```
 
 {{< /tab >}}
@@ -63,9 +63,9 @@ Place `flink-table-store-oss-{{< version >}}.jar` together with `flink-table-sto
 spark-sql \ 
   --conf spark.sql.catalog.tablestore=org.apache.flink.table.store.spark.SparkCatalog \
   --conf spark.sql.catalog.tablestore.warehouse=oss://<bucket-name>/ \
-  --conf spark.sql.catalog.tablestore.fs.oss.endpoint=oss-cn-hangzhou.aliyun.cs.com \
-  --conf spark.sql.catalog.tablestore.fs.oss.accessKey=xxx \
-  --conf spark.sql.catalog.tablestore.fs.oss.accessSecret=yyy
+  --conf spark.sql.catalog.tablestore.fs.oss.endpoint=oss-cn-hangzhou.aliyuncs.com \
+  --conf spark.sql.catalog.tablestore.fs.oss.accessKeyId=xxx \
+  --conf spark.sql.catalog.tablestore.fs.oss.accessKeySecret=yyy
 ```
 
 {{< /tab >}}
@@ -75,9 +75,9 @@ spark-sql \
 Place `flink-table-store-oss-{{< version >}}.jar` together with `flink-table-store-hive-connector-{{< version >}}.jar` under Hive's auxlib directory, and start like
 
 ```sql
-SET tablestore.fs.oss.endpoint=oss-cn-hangzhou.aliyun.cs.com;
-SET tablestore.fs.oss.accessKey=xxx;
-SET tablestore.fs.oss.accessSecret=yyy;
+SET tablestore.fs.oss.endpoint=oss-cn-hangzhou.aliyuncs.com;
+SET tablestore.fs.oss.accessKeyId=xxx;
+SET tablestore.fs.oss.accessKeySecret=yyy;
 
 CREATE EXTERNAL TABLE external_test_table
 STORED BY 'org.apache.flink.table.store.hive.TableStoreHiveStorageHandler'

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/DataTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/DataTable.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.store.table;
 
-import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.store.CoreOptions;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
 import org.apache.flink.table.store.table.source.DataTableScan;
@@ -30,8 +29,6 @@ public interface DataTable extends Table {
     DataTableScan newScan();
 
     CoreOptions options();
-
-    Path location();
 
     SnapshotManager snapshotManager();
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/Table.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/Table.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.store.table;
 
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.store.table.source.TableRead;
 import org.apache.flink.table.store.table.source.TableScan;
 import org.apache.flink.table.types.logical.RowType;
@@ -31,6 +32,8 @@ public interface Table extends Serializable {
     String name();
 
     RowType rowType();
+
+    Path location();
 
     TableScan newScan();
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/system/OptionsTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/system/OptionsTable.java
@@ -75,6 +75,11 @@ public class OptionsTable implements Table {
     }
 
     @Override
+    public Path location() {
+        return location;
+    }
+
+    @Override
     public TableScan newScan() {
         return new OptionsScan();
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/system/SchemasTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/system/SchemasTable.java
@@ -86,6 +86,11 @@ public class SchemasTable implements Table {
     }
 
     @Override
+    public Path location() {
+        return location;
+    }
+
+    @Override
     public TableScan newScan() {
         return new SchemasScan();
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/system/SnapshotsTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/system/SnapshotsTable.java
@@ -88,6 +88,11 @@ public class SnapshotsTable implements Table {
     }
 
     @Override
+    public Path location() {
+        return location;
+    }
+
+    @Override
     public TableScan newScan() {
         return new SnapshotsScan();
     }

--- a/flink-table-store-spark/src/main/java/org/apache/flink/table/store/spark/SparkCatalog.java
+++ b/flink-table-store-spark/src/main/java/org/apache/flink/table/store/spark/SparkCatalog.java
@@ -69,14 +69,14 @@ public class SparkCatalog implements TableCatalog, SupportsNamespaces {
 
     private String name = null;
     private Catalog catalog = null;
+    private Configuration conf = null;
 
     @Override
     public void initialize(String name, CaseInsensitiveStringMap options) {
         this.name = name;
-        Configuration configuration =
-                Configuration.fromMap(SparkCaseSensitiveConverter.convert(options));
-        FileSystems.initialize(CatalogFactory.warehouse(configuration), configuration);
-        this.catalog = CatalogFactory.createCatalog(configuration);
+        conf = Configuration.fromMap(SparkCaseSensitiveConverter.convert(options));
+        FileSystems.initialize(CatalogFactory.warehouse(conf), conf);
+        this.catalog = CatalogFactory.createCatalog(conf);
     }
 
     @Override
@@ -204,7 +204,9 @@ public class SparkCatalog implements TableCatalog, SupportsNamespaces {
         try {
             ObjectPath path = objectPath(ident);
             return new SparkTable(
-                    catalog.getTable(path), Lock.factory(catalog.lockFactory().orElse(null), path));
+                    catalog.getTable(path),
+                    Lock.factory(catalog.lockFactory().orElse(null), path),
+                    conf);
         } catch (Catalog.TableNotExistException e) {
             throw new NoSuchTableException(ident);
         }

--- a/flink-table-store-spark/src/main/java/org/apache/flink/table/store/spark/SparkReaderFactory.java
+++ b/flink-table-store-spark/src/main/java/org/apache/flink/table/store/spark/SparkReaderFactory.java
@@ -17,10 +17,12 @@
 
 package org.apache.flink.table.store.spark;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.file.predicate.Predicate;
 import org.apache.flink.table.store.file.utils.RecordReader;
 import org.apache.flink.table.store.file.utils.RecordReaderIterator;
+import org.apache.flink.table.store.filesystem.FileSystems;
 import org.apache.flink.table.store.table.Table;
 import org.apache.flink.table.store.table.source.TableRead;
 import org.apache.flink.table.store.utils.TypeUtils;
@@ -45,11 +47,14 @@ public class SparkReaderFactory implements PartitionReaderFactory {
     private final Table table;
     private final int[] projectedFields;
     private final List<Predicate> predicates;
+    private final Configuration conf;
 
-    public SparkReaderFactory(Table table, int[] projectedFields, List<Predicate> predicates) {
+    public SparkReaderFactory(
+            Table table, int[] projectedFields, List<Predicate> predicates, Configuration conf) {
         this.table = table;
         this.projectedFields = projectedFields;
         this.predicates = predicates;
+        this.conf = conf;
     }
 
     private RowType readRowType() {
@@ -95,5 +100,12 @@ public class SparkReaderFactory implements PartitionReaderFactory {
                 }
             }
         };
+    }
+
+    private void readObject(java.io.ObjectInputStream in)
+            throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        // TODO move file system initialization into common modules
+        FileSystems.initialize(table.location(), conf);
     }
 }

--- a/flink-table-store-spark/src/main/java/org/apache/flink/table/store/spark/SparkScan.java
+++ b/flink-table-store-spark/src/main/java/org/apache/flink/table/store/spark/SparkScan.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.store.spark;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.store.file.predicate.Predicate;
 import org.apache.flink.table.store.table.Table;
 import org.apache.flink.table.store.table.source.Split;
@@ -45,13 +46,16 @@ public class SparkScan implements Scan, SupportsReportStatistics {
     protected final Table table;
     private final List<Predicate> predicates;
     private final int[] projectedFields;
+    private final Configuration conf;
 
     private List<Split> splits;
 
-    public SparkScan(Table table, List<Predicate> predicates, int[] projectedFields) {
+    public SparkScan(
+            Table table, List<Predicate> predicates, int[] projectedFields, Configuration conf) {
         this.table = table;
         this.predicates = predicates;
         this.projectedFields = projectedFields;
+        this.conf = conf;
     }
 
     @Override
@@ -77,7 +81,7 @@ public class SparkScan implements Scan, SupportsReportStatistics {
 
             @Override
             public PartitionReaderFactory createReaderFactory() {
-                return new SparkReaderFactory(table, projectedFields, predicates);
+                return new SparkReaderFactory(table, projectedFields, predicates, conf);
             }
         };
     }

--- a/flink-table-store-spark/src/main/java/org/apache/flink/table/store/spark/SparkScanBuilder.java
+++ b/flink-table-store-spark/src/main/java/org/apache/flink/table/store/spark/SparkScanBuilder.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.store.spark;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.store.file.predicate.Predicate;
 import org.apache.flink.table.store.table.Table;
 
@@ -36,13 +37,15 @@ public class SparkScanBuilder
         implements ScanBuilder, SupportsPushDownFilters, SupportsPushDownRequiredColumns {
 
     private final Table table;
+    private final Configuration conf;
 
     private List<Predicate> predicates = new ArrayList<>();
     private Filter[] pushedFilters;
     private int[] projectedFields;
 
-    public SparkScanBuilder(Table table) {
+    public SparkScanBuilder(Table table, Configuration conf) {
         this.table = table;
+        this.conf = conf;
     }
 
     @Override
@@ -80,6 +83,6 @@ public class SparkScanBuilder
 
     @Override
     public Scan build() {
-        return new SparkScan(table, predicates, projectedFields);
+        return new SparkScan(table, predicates, projectedFields, conf);
     }
 }

--- a/flink-table-store-spark/src/main/java/org/apache/flink/table/store/spark/SparkSource.java
+++ b/flink-table-store-spark/src/main/java/org/apache/flink/table/store/spark/SparkSource.java
@@ -70,7 +70,9 @@ public class SparkSource implements DataSourceRegister, SessionConfigSupport {
                 Configuration.fromMap(SparkCaseSensitiveConverter.convert(options));
         FileSystems.initialize(CoreOptions.path(options), configuration);
         return new SparkTable(
-                FileStoreTableFactory.create(Configuration.fromMap(options)), Lock.emptyFactory());
+                FileStoreTableFactory.create(Configuration.fromMap(options)),
+                Lock.emptyFactory(),
+                configuration);
     }
 
     @Override

--- a/flink-table-store-spark/src/main/java/org/apache/flink/table/store/spark/SparkTable.java
+++ b/flink-table-store-spark/src/main/java/org/apache/flink/table/store/spark/SparkTable.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.store.spark;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.store.file.operation.Lock;
 import org.apache.flink.table.store.file.predicate.Predicate;
 import org.apache.flink.table.store.table.SupportsPartition;
@@ -52,16 +53,18 @@ public class SparkTable
 
     private final Table table;
     private final Lock.Factory lockFactory;
+    private final Configuration conf;
 
-    public SparkTable(Table table, Lock.Factory lockFactory) {
+    public SparkTable(Table table, Lock.Factory lockFactory, Configuration conf) {
         this.table = table;
         this.lockFactory = lockFactory;
+        this.conf = conf;
     }
 
     @Override
     public ScanBuilder newScanBuilder(CaseInsensitiveStringMap options) {
         // options is already merged into table
-        return new SparkScanBuilder(table);
+        return new SparkScanBuilder(table, conf);
     }
 
     @Override
@@ -96,7 +99,7 @@ public class SparkTable
 
     @Override
     public WriteBuilder newWriteBuilder(LogicalWriteInfo info) {
-        return new SparkWriteBuilder(castToWritable(table), info.queryId(), lockFactory);
+        return new SparkWriteBuilder(castToWritable(table), info.queryId(), lockFactory, conf);
     }
 
     @Override

--- a/flink-table-store-spark/src/main/java/org/apache/flink/table/store/spark/SparkWriteBuilder.java
+++ b/flink-table-store-spark/src/main/java/org/apache/flink/table/store/spark/SparkWriteBuilder.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.store.spark;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.store.file.operation.Lock;
 import org.apache.flink.table.store.table.SupportsWrite;
 
@@ -34,15 +35,18 @@ public class SparkWriteBuilder implements WriteBuilder {
     private final SupportsWrite table;
     private final String queryId;
     private final Lock.Factory lockFactory;
+    private final Configuration conf;
 
-    public SparkWriteBuilder(SupportsWrite table, String queryId, Lock.Factory lockFactory) {
+    public SparkWriteBuilder(
+            SupportsWrite table, String queryId, Lock.Factory lockFactory, Configuration conf) {
         this.table = table;
         this.queryId = queryId;
         this.lockFactory = lockFactory;
+        this.conf = conf;
     }
 
     @Override
     public Write build() {
-        return new SparkWrite(table, queryId, lockFactory);
+        return new SparkWrite(table, queryId, lockFactory, conf);
     }
 }


### PR DESCRIPTION
Currently when writing Table Store tables on OSS with other engines (for example Spark), the following exception will occur.

```
22/12/23 17:54:12 WARN TaskSetManager: Lost task 0.0 in stage 3.0 (TID 3) (core-1-1.c-c9f1b761c8946269.cn-huhehaote.emr.aliyuncs.com executor 2): java.lang.RuntimeException: Failed to find latest snapshot id
  at org.apache.flink.table.store.file.utils.SnapshotManager.latestSnapshotId(SnapshotManager.java:81)
  at org.apache.flink.table.store.file.operation.AbstractFileStoreWrite.scanExistingFileMetas(AbstractFileStoreWrite.java:87)
  at org.apache.flink.table.store.file.operation.KeyValueFileStoreWrite.createWriter(KeyValueFileStoreWrite.java:113)
  at org.apache.flink.table.store.file.operation.AbstractFileStoreWrite.createWriter(AbstractFileStoreWrite.java:227)
  at org.apache.flink.table.store.file.operation.AbstractFileStoreWrite.lambda$getWriter$1(AbstractFileStoreWrite.java:217)
  at java.util.HashMap.computeIfAbsent(HashMap.java:1128)
  at org.apache.flink.table.store.file.operation.AbstractFileStoreWrite.getWriter(AbstractFileStoreWrite.java:217)
  at org.apache.flink.table.store.file.operation.AbstractFileStoreWrite.write(AbstractFileStoreWrite.java:106)
  at org.apache.flink.table.store.table.sink.TableWriteImpl.write(TableWriteImpl.java:63)
  at org.apache.flink.table.store.spark.SparkWrite$WriteRecords.call(SparkWrite.java:124)
  at org.apache.flink.table.store.spark.SparkWrite$WriteRecords.call(SparkWrite.java:105)
  at org.apache.spark.api.java.JavaPairRDD$.$anonfun$toScalaFunction$1(JavaPairRDD.scala:1070)
  at org.apache.spark.rdd.PairRDDFunctions.$anonfun$mapValues$3(PairRDDFunctions.scala:752)
  at scala.collection.Iterator$$anon$10.next(Iterator.scala:461)
  at scala.collection.Iterator$$anon$10.next(Iterator.scala:461)
  at scala.collection.Iterator.foreach(Iterator.scala:943)
  at scala.collection.Iterator.foreach$(Iterator.scala:943)
  at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
  at scala.collection.TraversableOnce.reduceLeft(TraversableOnce.scala:237)
  at scala.collection.TraversableOnce.reduceLeft$(TraversableOnce.scala:220)
  at scala.collection.AbstractIterator.reduceLeft(Iterator.scala:1431)
  at org.apache.spark.rdd.RDD.$anonfun$reduce$2(RDD.scala:1097)
  at org.apache.spark.SparkContext.$anonfun$runJob$6(SparkContext.scala:2322)
  at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
  at org.apache.spark.scheduler.Task.run(Task.scala:136)
  at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:548)
  at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1504)
  at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:551)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
  at java.lang.Thread.run(Thread.java:750)
Caused by: org.apache.flink.core.fs.UnsupportedFileSystemSchemeException: Could not find a file system implementation for scheme 'oss'. The scheme is directly supported by Flink through the following plugin(s): flink-oss-fs-hadoop. Please ensure that each plugin resides within its own subfolder within the plugins directory. See https://nightlies.apache.org/flink/flink-docs-stable/docs/deployment/filesystems/plugins/ for more information. If you want to use a Hadoop file system for that scheme, please add the scheme to the configuration fs.allowed-fallback-filesystems. For a full list of supported file systems, please see https://nightlies.apache.org/flink/flink-docs-stable/ops/filesystems/.
  at org.apache.flink.core.fs.FileSystem.getUnguardedFileSystem(FileSystem.java:515)
  at org.apache.flink.core.fs.FileSystem.get(FileSystem.java:409)
  at org.apache.flink.core.fs.Path.getFileSystem(Path.java:274)
  at org.apache.flink.table.store.file.utils.SnapshotManager.findLatest(SnapshotManager.java:164)
  at org.apache.flink.table.store.file.utils.SnapshotManager.latestSnapshotId(SnapshotManager.java:79)
  ... 30 more
```