### PR TITLE
[FLINK-30506] Add documentation for writing Table Store with Spark3

### DIFF
--- a/docs/content/docs/engines/overview.md
+++ b/docs/content/docs/engines/overview.md
@@ -34,8 +34,8 @@ Apache Spark and Apache Hive.
 
 | Engine | Version | Feature | Read Pushdown |
 |---|---|---|---|
-| Flink | 1.16/1.15/1.14 | read, write, create/drop table, create/drop database | Projection, Filter |
-| Hive      | 3.1/2.3/2.2/2.1/2.1 CDH 6.3 | read | Projection, Filter |
-| Spark     | 3.3/3.2/3.1/3.0 | read, create/drop table, create/drop database | Projection, Filter |
-| Spark     | 2.4 | read | Projection, Filter |
-| Trino     | 388/358 | read | Projection, Filter |
+| Flink | 1.16/1.15/1.14 | batch/streaming read, batch/streaming write, create/drop table, create/drop database | Projection, Filter |
+| Hive      | 3.1/2.3/2.2/2.1/2.1 CDH 6.3 | batch read | Projection, Filter |
+| Spark     | 3.3/3.2/3.1/3.0 | batch read, batch write, create/drop table, create/drop database | Projection, Filter |
+| Spark     | 2.4 | batch read | Projection, Filter |
+| Trino     | 388/358 | batch read | Projection, Filter |

--- a/docs/content/docs/engines/spark2.md
+++ b/docs/content/docs/engines/spark2.md
@@ -68,7 +68,7 @@ If you are using HDFS, make sure that the environment variable `HADOOP_HOME` or 
 
 **Step 1: Prepare Test Data**
 
-Table Store currently only supports reading tables through Spark. To create a Table Store table with records, please follow our [Flink quick start guide]({{< ref "docs/engines/flink#quick-start" >}}).
+Table Store currently only supports reading tables through Spark2. To create a Table Store table with records, please follow our [Flink quick start guide]({{< ref "docs/engines/flink#quick-start" >}}).
 
 After the guide, all table files should be stored under the path `/tmp/table_store`, or the warehouse path you've specified.
 

--- a/docs/content/docs/how-to/writing-tables.md
+++ b/docs/content/docs/how-to/writing-tables.md
@@ -40,6 +40,16 @@ INSERT INTO MyTable SELECT ...
 
 {{< /tab >}}
 
+{{< tab "Spark3" >}}
+
+Use `INSERT INTO` to apply records and changes to tables.
+
+```sql
+INSERT INTO MyTable SELECT ...
+```
+
+{{< /tab >}}
+
 {{< /tabs >}}
 
 ## Overwriting the Whole Table


### PR DESCRIPTION
Table Store 0.3 supports writing with Spark3. We need to add documentation.