### PR TITLE
Speed up FTS  build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,7 +360,7 @@ under the License.
             <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
-                <version>0.13</version>
+                <version>0.15</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>
@@ -679,7 +679,7 @@ under the License.
             <plugin>
                 <groupId>org.commonjava.maven.plugins</groupId>
                 <artifactId>directory-maven-plugin</artifactId>
-                <version>0.1</version>
+                <version>1.0</version>
                 <executions>
                     <execution>
                         <id>directories</id>

--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,13 @@ under the License.
                 <version>${flink.version}</version>
                 <scope>test</scope>
             </dependency>
+
+            <dependency>
+                <!-- pin transitive dependency of org.apache.hadoop:hadoop-common:2.8.5 -->
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>2.3</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
With this patch the maven build takes around 1 minute instead of 20 on my laptop. 

There are 2 changes - pinning a dependency in 1b6f8012328522b945dc5e36eda7ee946159c6c9 and updating 2 plugins to their thread-safe versions in 60f661a60f2d1ac2b09b8448bee91f7f4b18c98b.

Without these changes `mvn clean install -DskipTests` takes 15-20 minutes on my laptop. After pinning `json-smart` the build time went to around 2-2.5 minutes. After switching to the latest plugin versions and using -`-T 4` the build runs in 1-1.5 minutes.

