### PR TITLE
Speedup build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -679,7 +679,7 @@ under the License.
             <plugin>
                 <groupId>org.commonjava.maven.plugins</groupId>
                 <artifactId>directory-maven-plugin</artifactId>
-                <version>1.0</version>
+                <version>0.1</version>
                 <executions>
                     <execution>
                         <id>directories</id>

--- a/pom.xml
+++ b/pom.xml
@@ -360,7 +360,7 @@ under the License.
             <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
-                <version>0.13</version>
+                <version>0.15</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>
@@ -679,7 +679,7 @@ under the License.
             <plugin>
                 <groupId>org.commonjava.maven.plugins</groupId>
                 <artifactId>directory-maven-plugin</artifactId>
-                <version>0.1</version>
+                <version>1.0</version>
                 <executions>
                     <execution>
                         <id>directories</id>

--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,13 @@ under the License.
                 <version>${flink.version}</version>
                 <scope>test</scope>
             </dependency>
+
+            <dependency>
+                <!-- pin transitive dependency of org.apache.hadoop:hadoop-common:2.8.5 -->
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>2.3</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -265,7 +265,7 @@ under the License.
                 <!-- pin transitive dependency of org.apache.hadoop:hadoop-common:2.8.5 -->
                 <groupId>net.minidev</groupId>
                 <artifactId>json-smart</artifactId>
-                <version>2.3</version>
+                <version>2.3.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This is a follow-up PR for https://github.com/apache/flink-table-store/pull/447. 

The original PR was reverted because it broke builds with maven 3.2.5. Build failures were due to `directory-maven-plugin` upgrade to version 1.0.

This PR reverts the `directory-maven-plugin` version change, but still upgrades rat and pins json-smart. As a result, we still get the build speedup from 20 minutes to ca. ~2 minutes without the multithreaded build.

I tested this PR by building the project with this patch using maven 3.2.5.