### PR TITLE
[FLINK-30555] Hive cluster can not read oss/s3 tables

### DIFF
--- a/docs/content/docs/filesystems/oss.md
+++ b/docs/content/docs/filesystems/oss.md
@@ -72,16 +72,20 @@ spark-sql \
 
 {{< tab "Hive" >}}
 
+NOTE: You need to ensure that Hive metastore can access `oss`.
+
 Place `flink-table-store-oss-{{< version >}}.jar` together with `flink-table-store-hive-connector-{{< version >}}.jar` under Hive's auxlib directory, and start like
 
 ```sql
 SET tablestore.fs.oss.endpoint=oss-cn-hangzhou.aliyuncs.com;
 SET tablestore.fs.oss.accessKeyId=xxx;
 SET tablestore.fs.oss.accessKeySecret=yyy;
+```
 
-CREATE EXTERNAL TABLE external_test_table
-STORED BY 'org.apache.flink.table.store.hive.TableStoreHiveStorageHandler'
-LOCATION 'oss://<bucket-name>/<db-name>.db/<table-name>';
+And read table from hive metastore, table can be created by Flink or Spark, see [Catalog with Hive Metastore]({{< ref "docs/how-to/creating-catalogs" >}})
+```sql
+SELECT * FROM test_table;
+SELECT COUNT(1) FROM test_table;
 ```
 
 {{< /tab >}}

--- a/docs/content/docs/filesystems/s3.md
+++ b/docs/content/docs/filesystems/s3.md
@@ -72,16 +72,20 @@ spark-sql \
 
 {{< tab "Hive" >}}
 
+NOTE: You need to ensure that Hive metastore can access `s3`.
+
 Place `flink-table-store-s3-{{< version >}}.jar` together with `flink-table-store-hive-connector-{{< version >}}.jar` under Hive's auxlib directory, and start like
 
 ```sql
 SET tablestore.s3.endpoint=your-endpoint-hostname;
 SET tablestore.s3.access-key=xxx;
 SET tablestore.s3.secret-key=yyy;
+```
 
-CREATE EXTERNAL TABLE external_test_table
-STORED BY 'org.apache.flink.table.store.hive.TableStoreHiveStorageHandler'
-LOCATION 's3://<bucket>/<endpoint>';
+And read table from hive metastore, table can be created by Flink or Spark, see [Catalog with Hive Metastore]({{< ref "docs/how-to/creating-catalogs" >}})
+```sql
+SELECT * FROM test_table;
+SELECT COUNT(1) FROM test_table;
 ```
 
 {{< /tab >}}

--- a/flink-table-store-hive/flink-table-store-hive-connector/src/main/java/org/apache/flink/table/store/hive/HiveSchema.java
+++ b/flink-table-store-hive/flink-table-store-hive-connector/src/main/java/org/apache/flink/table/store/hive/HiveSchema.java
@@ -36,17 +36,15 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.table.store.TableStoreJobConf.extractCatalogConfig;
+
 /** Column names, types and comments of a Hive table. */
 public class HiveSchema {
-
-    private static final String TABLE_STORE_PREFIX = "tablestore.";
 
     private final TableSchema tableSchema;
 
@@ -81,10 +79,7 @@ public class HiveSchema {
         }
         Path path = new Path(location);
         if (configuration != null) {
-            org.apache.flink.configuration.Configuration flinkConf =
-                    org.apache.flink.configuration.Configuration.fromMap(
-                            getPropsWithPrefix(configuration, TABLE_STORE_PREFIX));
-            FileSystems.initialize(path, flinkConf);
+            FileSystems.initialize(path, extractCatalogConfig(configuration));
         }
         TableSchema tableSchema =
                 new SchemaManager(path)
@@ -115,30 +110,6 @@ public class HiveSchema {
         }
 
         return new HiveSchema(tableSchema);
-    }
-
-    /**
-     * Constructs a mapping of configuration and includes all properties that start with the
-     * specified configuration prefix. Property names in the mapping are trimmed to remove the
-     * configuration prefix.
-     *
-     * <p>Note: this is directly copied from {@link Configuration} to make E2E test happy, since
-     * this method is introduced since 2.8 but we are using a hive container with hadoop-2.7.4.
-     *
-     * @param confPrefix configuration prefix
-     * @return mapping of configuration properties with prefix stripped
-     */
-    private static Map<String, String> getPropsWithPrefix(Configuration conf, String confPrefix) {
-        Map<String, String> configMap = new HashMap<>();
-        for (Map.Entry<String, String> entry : conf) {
-            String name = entry.getKey();
-            if (name.startsWith(confPrefix)) {
-                String value = conf.get(name);
-                name = name.substring(confPrefix.length());
-                configMap.put(name, value);
-            }
-        }
-        return configMap;
     }
 
     private static void checkSchemaMatched(

--- a/flink-table-store-hive/flink-table-store-hive-connector/src/main/java/org/apache/flink/table/store/hive/TableStoreHiveStorageHandler.java
+++ b/flink-table-store-hive/flink-table-store-hive-connector/src/main/java/org/apache/flink/table/store/hive/TableStoreHiveStorageHandler.java
@@ -74,7 +74,7 @@ public class TableStoreHiveStorageHandler
     @Override
     public void configureInputJobProperties(TableDesc tableDesc, Map<String, String> map) {
         Properties properties = tableDesc.getProperties();
-        TableStoreJobConf.configureInputJobProperties(properties, map);
+        TableStoreJobConf.configureInputJobProperties(conf, properties, map);
     }
 
     public void configureInputJobCredentials(TableDesc tableDesc, Map<String, String> map) {}

--- a/flink-table-store-hive/flink-table-store-hive-connector/src/main/java/org/apache/flink/table/store/mapred/TableStoreInputFormat.java
+++ b/flink-table-store-hive/flink-table-store-hive-connector/src/main/java/org/apache/flink/table/store/mapred/TableStoreInputFormat.java
@@ -19,12 +19,14 @@
 package org.apache.flink.table.store.mapred;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.store.CoreOptions;
 import org.apache.flink.table.store.RowDataContainer;
 import org.apache.flink.table.store.SearchArgumentToPredicateConverter;
 import org.apache.flink.table.store.TableStoreJobConf;
 import org.apache.flink.table.store.file.predicate.Predicate;
 import org.apache.flink.table.store.file.schema.TableSchema;
+import org.apache.flink.table.store.filesystem.FileSystems;
 import org.apache.flink.table.store.table.FileStoreTable;
 import org.apache.flink.table.store.table.FileStoreTableFactory;
 import org.apache.flink.table.store.table.source.DataTableScan;
@@ -77,6 +79,7 @@ public class TableStoreInputFormat implements InputFormat<Void, RowDataContainer
         TableStoreJobConf wrapper = new TableStoreJobConf(jobConf);
         Configuration conf = new Configuration();
         conf.set(CoreOptions.PATH, wrapper.getLocation());
+        FileSystems.initialize(new Path(wrapper.getLocation()), wrapper.getCatalogConfig());
         return FileStoreTableFactory.create(conf);
     }
 

--- a/flink-table-store-hive/flink-table-store-hive-connector/src/test/java/org/apache/flink/table/store/hive/TableStoreHiveStorageHandlerITCase.java
+++ b/flink-table-store-hive/flink-table-store-hive-connector/src/test/java/org/apache/flink/table/store/hive/TableStoreHiveStorageHandlerITCase.java
@@ -98,6 +98,7 @@ public class TableStoreHiveStorageHandlerITCase {
         } else {
             throw new UnsupportedOperationException("Unsupported engine " + engine);
         }
+
         hiveShell.execute("CREATE DATABASE IF NOT EXISTS test_db");
         hiveShell.execute("USE test_db");
 

--- a/flink-table-store-hive/flink-table-store-hive-connector/src/test/java/org/apache/flink/table/store/hive/TableStoreHiveStorageHandlerITCase.java
+++ b/flink-table-store-hive/flink-table-store-hive-connector/src/test/java/org/apache/flink/table/store/hive/TableStoreHiveStorageHandlerITCase.java
@@ -98,7 +98,6 @@ public class TableStoreHiveStorageHandlerITCase {
         } else {
             throw new UnsupportedOperationException("Unsupported engine " + engine);
         }
-        hiveShell.execute("SET tablestore.hahaha=you");
         hiveShell.execute("CREATE DATABASE IF NOT EXISTS test_db");
         hiveShell.execute("USE test_db");
 

--- a/flink-table-store-hive/flink-table-store-hive-connector/src/test/java/org/apache/flink/table/store/hive/TableStoreHiveStorageHandlerITCase.java
+++ b/flink-table-store-hive/flink-table-store-hive-connector/src/test/java/org/apache/flink/table/store/hive/TableStoreHiveStorageHandlerITCase.java
@@ -98,7 +98,7 @@ public class TableStoreHiveStorageHandlerITCase {
         } else {
             throw new UnsupportedOperationException("Unsupported engine " + engine);
         }
-
+        hiveShell.execute("SET tablestore.hahaha=you");
         hiveShell.execute("CREATE DATABASE IF NOT EXISTS test_db");
         hiveShell.execute("USE test_db");
 


### PR DESCRIPTION
[FLINK-29964](https://issues.apache.org/jira/browse/FLINK-29964) add oss support for Hive, but only valid in the case of standalone Hive, the distributed Hive compute engine cannot access.
We should add more FileSystems.initialize to Hive connector.

Manually tests cover, there is no way to test distributed Hive compute engine.