### PR TITLE
[FLINK-30573] Fix bug that Table Store dedicated compact job may skip some records when checkpoint interval is long

### DIFF
--- a/flink-table-store-common/src/test/resources/log4j2-test.properties
+++ b/flink-table-store-common/src/test/resources/log4j2-test.properties
@@ -25,4 +25,4 @@ appender.testlogger.name = TestLogger
 appender.testlogger.type = CONSOLE
 appender.testlogger.target = SYSTEM_ERR
 appender.testlogger.layout.type = PatternLayout
-appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n
+appender.testlogger.layout.pattern = %-4r [%tid %t] %-5p %c %x - %m%n

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/CompactorSink.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/CompactorSink.java
@@ -24,7 +24,7 @@ import org.apache.flink.table.store.file.operation.Lock;
 import org.apache.flink.table.store.table.FileStoreTable;
 import org.apache.flink.util.function.SerializableFunction;
 
-/** {@link FlinkSink} for stand-alone compact jobs. */
+/** {@link FlinkSink} for dedicated compact jobs. */
 public class CompactorSink extends FlinkSink {
 
     private static final long serialVersionUID = 1L;

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/CompactorSinkBuilder.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/CompactorSinkBuilder.java
@@ -50,9 +50,11 @@ public class CompactorSinkBuilder {
     }
 
     public DataStreamSink<?> build() {
-        HashRowStreamPartitioner partitioner =
-                new HashRowStreamPartitioner(
-                        BucketsTable.rowType(table.schema().logicalPartitionType()));
+        OffsetRowDataHashStreamPartitioner partitioner =
+                new OffsetRowDataHashStreamPartitioner(
+                        BucketsTable.partitionWithBucketRowType(
+                                table.schema().logicalPartitionType()),
+                        1);
         PartitionTransformation<RowData> partitioned =
                 new PartitionTransformation<>(input.getTransformation(), partitioner);
 

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/FullChangelogStoreSinkWrite.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/FullChangelogStoreSinkWrite.java
@@ -34,7 +34,6 @@ import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.runtime.typeutils.BinaryRowDataSerializer;
 import org.apache.flink.table.store.CoreOptions;
 import org.apache.flink.table.store.file.Snapshot;
-import org.apache.flink.table.store.file.io.DataFileMeta;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
 import org.apache.flink.table.store.table.FileStoreTable;
 import org.apache.flink.table.store.table.sink.SinkRecord;
@@ -136,27 +135,6 @@ public class FullChangelogStoreSinkWrite extends StoreSinkWriteImpl {
     public void compact(BinaryRowData partition, int bucket, boolean fullCompaction)
             throws Exception {
         super.compact(partition, bucket, fullCompaction);
-        touchBucket(partition, bucket);
-    }
-
-    @Override
-    public void compact(
-            long snapshotId,
-            BinaryRowData partition,
-            int bucket,
-            boolean fullCompaction,
-            List<DataFileMeta> extraFiles)
-            throws Exception {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug(
-                    "Receive {} extra files from snapshot {}, partition {}, bucket {}",
-                    extraFiles.size(),
-                    snapshotId,
-                    partition,
-                    bucket);
-        }
-
-        super.compact(snapshotId, partition, bucket, fullCompaction, extraFiles);
         touchBucket(partition, bucket);
     }
 

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreCompactOperator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreCompactOperator.java
@@ -24,6 +24,8 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.store.CoreOptions;
+import org.apache.flink.table.store.file.io.DataFileMeta;
+import org.apache.flink.table.store.file.io.DataFileMetaSerializer;
 import org.apache.flink.table.store.file.utils.OffsetRowData;
 import org.apache.flink.table.store.table.FileStoreTable;
 import org.apache.flink.util.Preconditions;
@@ -47,6 +49,7 @@ public class StoreCompactOperator extends PrepareCommitOperator {
     private transient StoreSinkWrite write;
     private transient RowDataSerializer partitionSerializer;
     private transient OffsetRowData reusedPartition;
+    private transient DataFileMetaSerializer dataFileMetaSerializer;
 
     public StoreCompactOperator(
             FileStoreTable table,
@@ -73,17 +76,29 @@ public class StoreCompactOperator extends PrepareCommitOperator {
     public void open() throws Exception {
         super.open();
         partitionSerializer = new RowDataSerializer(table.schema().logicalPartitionType());
-        reusedPartition = new OffsetRowData(partitionSerializer.getArity(), 0);
+        reusedPartition = new OffsetRowData(partitionSerializer.getArity(), 1);
+        dataFileMetaSerializer = new DataFileMetaSerializer();
     }
 
     @Override
     public void processElement(StreamRecord<RowData> element) throws Exception {
-        RowData partitionAndBucket = element.getValue();
-        reusedPartition.replace(partitionAndBucket);
-        BinaryRowData partition = partitionSerializer.toBinaryRow(reusedPartition).copy();
-        int bucket = partitionAndBucket.getInt(partitionSerializer.getArity());
+        RowData record = element.getValue();
 
-        write.compact(partition, bucket, !isStreaming);
+        long snapshotId = record.getLong(0);
+
+        reusedPartition.replace(record);
+        BinaryRowData partition = partitionSerializer.toBinaryRow(reusedPartition).copy();
+
+        int bucket = record.getInt(partitionSerializer.getArity() + 1);
+
+        byte[] serializedFiles = record.getBinary(partitionSerializer.getArity() + 2);
+        List<DataFileMeta> files = dataFileMetaSerializer.deserializeList(serializedFiles);
+
+        if (isStreaming) {
+            write.compact(snapshotId, partition, bucket, false, files);
+        } else {
+            write.compact(partition, bucket, true);
+        }
     }
 
     @Override

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreCompactOperator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreCompactOperator.java
@@ -95,8 +95,13 @@ public class StoreCompactOperator extends PrepareCommitOperator {
         List<DataFileMeta> files = dataFileMetaSerializer.deserializeList(serializedFiles);
 
         if (isStreaming) {
-            write.compact(snapshotId, partition, bucket, false, files);
+            write.notifyNewFiles(snapshotId, partition, bucket, files);
+            write.compact(partition, bucket, false);
         } else {
+            Preconditions.checkArgument(
+                    files.isEmpty(),
+                    "Batch compact job does not concern what files are compacted. "
+                            + "They only need to know what buckets are compacted.");
             write.compact(partition, bucket, true);
         }
     }

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSinkWrite.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSinkWrite.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.store.file.io.DataFileMeta;
 import org.apache.flink.table.store.table.FileStoreTable;
 import org.apache.flink.table.store.table.sink.SinkRecord;
 
@@ -38,6 +39,14 @@ interface StoreSinkWrite {
     SinkRecord toLogRecord(SinkRecord record);
 
     void compact(BinaryRowData partition, int bucket, boolean fullCompaction) throws Exception;
+
+    void compact(
+            long snapshotId,
+            BinaryRowData partition,
+            int bucket,
+            boolean fullCompaction,
+            List<DataFileMeta> extraFiles)
+            throws Exception;
 
     List<Committable> prepareCommit(boolean doCompaction, long checkpointId) throws IOException;
 

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSinkWrite.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSinkWrite.java
@@ -40,13 +40,8 @@ interface StoreSinkWrite {
 
     void compact(BinaryRowData partition, int bucket, boolean fullCompaction) throws Exception;
 
-    void compact(
-            long snapshotId,
-            BinaryRowData partition,
-            int bucket,
-            boolean fullCompaction,
-            List<DataFileMeta> extraFiles)
-            throws Exception;
+    void notifyNewFiles(
+            long snapshotId, BinaryRowData partition, int bucket, List<DataFileMeta> files);
 
     List<Committable> prepareCommit(boolean doCompaction, long checkpointId) throws IOException;
 

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSinkWriteImpl.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSinkWriteImpl.java
@@ -23,6 +23,8 @@ import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.store.file.io.DataFileMeta;
+import org.apache.flink.table.store.file.operation.FileStoreWrite;
 import org.apache.flink.table.store.table.FileStoreTable;
 import org.apache.flink.table.store.table.sink.FileCommittable;
 import org.apache.flink.table.store.table.sink.SinkRecord;
@@ -82,6 +84,21 @@ public class StoreSinkWriteImpl implements StoreSinkWrite {
     public void compact(BinaryRowData partition, int bucket, boolean fullCompaction)
             throws Exception {
         write.compact(partition, bucket, fullCompaction);
+    }
+
+    @Override
+    public void compact(
+            long snapshotId,
+            BinaryRowData partition,
+            int bucket,
+            boolean fullCompaction,
+            List<DataFileMeta> extraFiles)
+            throws Exception {
+        write.compact(
+                partition,
+                bucket,
+                fullCompaction,
+                new FileStoreWrite.ExtraCompactFiles(snapshotId, extraFiles));
     }
 
     @Override

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSinkWriteImpl.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/sink/StoreSinkWriteImpl.java
@@ -24,11 +24,13 @@ import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.store.file.io.DataFileMeta;
-import org.apache.flink.table.store.file.operation.FileStoreWrite;
 import org.apache.flink.table.store.table.FileStoreTable;
 import org.apache.flink.table.store.table.sink.FileCommittable;
 import org.apache.flink.table.store.table.sink.SinkRecord;
 import org.apache.flink.table.store.table.sink.TableWrite;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -36,6 +38,8 @@ import java.util.List;
 
 /** Default implementation of {@link StoreSinkWrite}. This writer does not have states. */
 public class StoreSinkWriteImpl implements StoreSinkWrite {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StoreSinkWriteImpl.class);
 
     protected final FileStoreTable table;
     protected final String commitUser;
@@ -87,18 +91,17 @@ public class StoreSinkWriteImpl implements StoreSinkWrite {
     }
 
     @Override
-    public void compact(
-            long snapshotId,
-            BinaryRowData partition,
-            int bucket,
-            boolean fullCompaction,
-            List<DataFileMeta> extraFiles)
-            throws Exception {
-        write.compact(
-                partition,
-                bucket,
-                fullCompaction,
-                new FileStoreWrite.ExtraCompactFiles(snapshotId, extraFiles));
+    public void notifyNewFiles(
+            long snapshotId, BinaryRowData partition, int bucket, List<DataFileMeta> files) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(
+                    "Receive {} new files from snapshot {}, partition {}, bucket {}",
+                    files.size(),
+                    snapshotId,
+                    partition,
+                    bucket);
+        }
+        write.notifyNewFiles(snapshotId, partition, bucket, files);
     }
 
     @Override

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/CompactorSourceBuilder.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/CompactorSourceBuilder.java
@@ -82,10 +82,16 @@ public class CompactorSourceBuilder {
     private Source<RowData, ?, ?> buildSource() {
         Predicate partitionPredicate = null;
         if (specifiedPartitions != null) {
+            // This predicate is based on the row type of the original table, not bucket table.
+            // Because TableScan in BucketsTable is the same with FileStoreTable,
+            // and partition filter is done by scan.
             partitionPredicate =
                     PredicateBuilder.or(
                             specifiedPartitions.stream()
-                                    .map(p -> PredicateConverter.fromMap(p, bucketsTable.rowType()))
+                                    .map(
+                                            p ->
+                                                    PredicateConverter.fromMap(
+                                                            p, bucketsTable.wrapped().rowType()))
                                     .toArray(Predicate[]::new));
         }
 

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/CompactorSourceBuilder.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/CompactorSourceBuilder.java
@@ -44,12 +44,12 @@ import java.util.Map;
 
 /**
  * Source builder to build a Flink {@link StaticFileStoreSource} or {@link
- * ContinuousFileStoreSource}. This is for stand-alone compactor jobs.
+ * ContinuousFileStoreSource}. This is for dedicated compactor jobs.
  */
 public class CompactorSourceBuilder {
 
     private final String tableIdentifier;
-    private final BucketsTable bucketsTable;
+    private final FileStoreTable table;
 
     private boolean isContinuous = false;
     private StreamExecutionEnvironment env;
@@ -57,7 +57,7 @@ public class CompactorSourceBuilder {
 
     public CompactorSourceBuilder(String tableIdentifier, FileStoreTable table) {
         this.tableIdentifier = tableIdentifier;
-        this.bucketsTable = new BucketsTable(table);
+        this.table = table;
     }
 
     public CompactorSourceBuilder withContinuousMode(boolean isContinuous) {
@@ -79,7 +79,7 @@ public class CompactorSourceBuilder {
         return this;
     }
 
-    private Source<RowData, ?, ?> buildSource() {
+    private Source<RowData, ?, ?> buildSource(BucketsTable bucketsTable) {
         Predicate partitionPredicate = null;
         if (specifiedPartitions != null) {
             // This predicate is based on the row type of the original table, not bucket table.
@@ -88,10 +88,7 @@ public class CompactorSourceBuilder {
             partitionPredicate =
                     PredicateBuilder.or(
                             specifiedPartitions.stream()
-                                    .map(
-                                            p ->
-                                                    PredicateConverter.fromMap(
-                                                            p, bucketsTable.wrapped().rowType()))
+                                    .map(p -> PredicateConverter.fromMap(p, table.rowType()))
                                     .toArray(Predicate[]::new));
         }
 
@@ -128,9 +125,10 @@ public class CompactorSourceBuilder {
             throw new IllegalArgumentException("StreamExecutionEnvironment should not be null.");
         }
 
+        BucketsTable bucketsTable = new BucketsTable(table, isContinuous);
         LogicalType produceType = bucketsTable.rowType();
         return env.fromSource(
-                buildSource(),
+                buildSource(bucketsTable),
                 WatermarkStrategy.noWatermarks(),
                 tableIdentifier + "-compact-source",
                 InternalTypeInfo.of(produceType));

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ChangelogWithKeyFileStoreTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ChangelogWithKeyFileStoreTableITCase.java
@@ -360,7 +360,7 @@ public class ChangelogWithKeyFileStoreTableITCase extends TestBaseUtils {
                         + "'write.compaction-skip' = 'true'");
 
         // sleep for a random amount of time to check
-        // if stand-alone compactor job can find first snapshot to compact correctly
+        // if dedicated compactor job can find first snapshot to compact correctly
         Thread.sleep(random.nextInt(2500));
 
         for (int i = enableConflicts ? 2 : 1; i > 0; i--) {

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/CompactorSourceITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/CompactorSourceITCase.java
@@ -24,8 +24,10 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.data.writer.BinaryRowWriter;
+import org.apache.flink.table.store.file.io.DataFileMetaSerializer;
 import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.schema.UpdateSchema;
@@ -42,6 +44,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -60,10 +63,12 @@ public class CompactorSourceITCase extends AbstractTestBase {
                     new LogicalType[] {
                         DataTypes.INT().getLogicalType(),
                         DataTypes.INT().getLogicalType(),
-                        DataTypes.INT().getLogicalType(),
+                        DataTypes.STRING().getLogicalType(),
                         DataTypes.INT().getLogicalType()
                     },
-                    new String[] {"dt", "hh", "k", "v"});
+                    new String[] {"k", "v", "dt", "hh"});
+
+    private final DataFileMetaSerializer dataFileMetaSerializer = new DataFileMetaSerializer();
 
     private Path tablePath;
     private String commitUser;
@@ -80,12 +85,12 @@ public class CompactorSourceITCase extends AbstractTestBase {
         TableWrite write = table.newWrite(commitUser);
         TableCommit commit = table.newCommit(commitUser);
 
-        write.write(rowData(20221208, 15, 1, 1510));
-        write.write(rowData(20221208, 16, 2, 1620));
+        write.write(rowData(1, 1510, StringData.fromString("20221208"), 15));
+        write.write(rowData(2, 1620, StringData.fromString("20221208"), 16));
         commit.commit(0, write.prepareCommit(true, 0));
 
-        write.write(rowData(20221208, 15, 1, 1511));
-        write.write(rowData(20221209, 15, 1, 1510));
+        write.write(rowData(1, 1511, StringData.fromString("20221208"), 15));
+        write.write(rowData(1, 1510, StringData.fromString("20221209"), 15));
         commit.commit(1, write.prepareCommit(true, 1));
 
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -102,7 +107,10 @@ public class CompactorSourceITCase extends AbstractTestBase {
         }
         assertThat(actual)
                 .hasSameElementsAs(
-                        Arrays.asList("+I 20221208|15|0", "+I 20221208|16|0", "+I 20221209|15|0"));
+                        Arrays.asList(
+                                "+I 2|20221208|15|0|2",
+                                "+I 2|20221208|16|0|1",
+                                "+I 2|20221209|15|0|1"));
 
         write.close();
         commit.close();
@@ -115,22 +123,22 @@ public class CompactorSourceITCase extends AbstractTestBase {
         TableWrite write = table.newWrite(commitUser);
         TableCommit commit = table.newCommit(commitUser);
 
-        write.write(rowData(20221208, 15, 1, 1510));
-        write.write(rowData(20221208, 16, 2, 1620));
+        write.write(rowData(1, 1510, StringData.fromString("20221208"), 15));
+        write.write(rowData(2, 1620, StringData.fromString("20221208"), 16));
         commit.commit(0, write.prepareCommit(true, 0));
 
-        write.write(rowData(20221208, 15, 1, 1511));
-        write.write(rowData(20221209, 15, 1, 1510));
-        write.compact(binaryRow(20221208, 15), 0, true);
-        write.compact(binaryRow(20221209, 15), 0, true);
+        write.write(rowData(1, 1511, StringData.fromString("20221208"), 15));
+        write.write(rowData(1, 1510, StringData.fromString("20221209"), 15));
+        write.compact(binaryRow("20221208", 15), 0, true);
+        write.compact(binaryRow("20221209", 15), 0, true);
         commit.commit(1, write.prepareCommit(true, 1));
 
-        write.write(rowData(20221208, 15, 2, 1520));
-        write.write(rowData(20221208, 16, 2, 1621));
+        write.write(rowData(2, 1520, StringData.fromString("20221208"), 15));
+        write.write(rowData(2, 1621, StringData.fromString("20221208"), 16));
         commit.commit(2, write.prepareCommit(true, 2));
 
-        write.write(rowData(20221208, 15, 1, 1512));
-        write.write(rowData(20221209, 16, 2, 1620));
+        write.write(rowData(1, 1512, StringData.fromString("20221208"), 15));
+        write.write(rowData(2, 1620, StringData.fromString("20221209"), 16));
         commit.commit(3, write.prepareCommit(true, 3));
 
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -148,35 +156,22 @@ public class CompactorSourceITCase extends AbstractTestBase {
         assertThat(actual)
                 .hasSameElementsAs(
                         Arrays.asList(
-                                "+I 20221208|15|0",
-                                "+I 20221208|16|0",
-                                "+I 20221208|15|0",
-                                "+I 20221209|16|0"));
+                                "+I 4|20221208|15|0|1",
+                                "+I 4|20221208|16|0|1",
+                                "+I 5|20221208|15|0|1",
+                                "+I 5|20221209|16|0|1"));
 
-        write.write(rowData(20221209, 15, 2, 1520));
-        write.write(rowData(20221208, 16, 1, 1510));
-        write.write(rowData(20221209, 15, 1, 1511));
+        write.write(rowData(2, 1520, StringData.fromString("20221209"), 15));
+        write.write(rowData(1, 1510, StringData.fromString("20221208"), 16));
+        write.write(rowData(1, 1511, StringData.fromString("20221209"), 15));
         commit.commit(4, write.prepareCommit(true, 4));
 
         actual.clear();
         for (int i = 0; i < 2; i++) {
             actual.add(toString(it.next()));
         }
-        assertThat(actual).hasSameElementsAs(Arrays.asList("+I 20221208|16|0", "+I 20221209|15|0"));
-
-        write.close();
-        commit.close();
-
-        write = table.newWrite(commitUser).withOverwrite(true);
-        Map<String, String> partitionMap = new HashMap<>();
-        partitionMap.put("dt", "20221209");
-        partitionMap.put("hh", "16");
-        commit = table.newCommit(commitUser).withOverwritePartition(partitionMap);
-        write.write(rowData(20221209, 16, 1, 1512));
-        write.write(rowData(20221209, 16, 2, 1622));
-        commit.commit(5, write.prepareCommit(true, 5));
-
-        assertThat(toString(it.next())).isEqualTo("+I 20221209|16|0");
+        assertThat(actual)
+                .hasSameElementsAs(Arrays.asList("+I 6|20221208|16|0|1", "+I 6|20221209|15|0|1"));
 
         write.close();
         commit.close();
@@ -189,10 +184,10 @@ public class CompactorSourceITCase extends AbstractTestBase {
                 true,
                 getSpecifiedPartitions(),
                 Arrays.asList(
-                        "+I 20221208|16|0",
-                        "+I 20221209|15|0",
-                        "+I 20221208|16|0",
-                        "+I 20221209|15|0"));
+                        "+I 1|20221208|16|0|1",
+                        "+I 2|20221209|15|0|1",
+                        "+I 3|20221208|16|0|1",
+                        "+I 3|20221209|15|0|1"));
     }
 
     @Test
@@ -200,7 +195,7 @@ public class CompactorSourceITCase extends AbstractTestBase {
         testPartitionSpec(
                 false,
                 getSpecifiedPartitions(),
-                Arrays.asList("+I 20221208|16|0", "+I 20221209|15|0"));
+                Arrays.asList("+I 3|20221208|16|0|2", "+I 3|20221209|15|0|2"));
     }
 
     private List<Map<String, String>> getSpecifiedPartitions() {
@@ -224,17 +219,17 @@ public class CompactorSourceITCase extends AbstractTestBase {
         TableWrite write = table.newWrite(commitUser);
         TableCommit commit = table.newCommit(commitUser);
 
-        write.write(rowData(20221208, 15, 1, 1510));
-        write.write(rowData(20221208, 16, 2, 1620));
+        write.write(rowData(1, 1510, StringData.fromString("20221208"), 15));
+        write.write(rowData(2, 1620, StringData.fromString("20221208"), 16));
         commit.commit(0, write.prepareCommit(true, 0));
 
-        write.write(rowData(20221208, 15, 2, 1520));
-        write.write(rowData(20221209, 15, 2, 1520));
+        write.write(rowData(2, 1520, StringData.fromString("20221208"), 15));
+        write.write(rowData(2, 1520, StringData.fromString("20221209"), 15));
         commit.commit(1, write.prepareCommit(true, 1));
 
-        write.write(rowData(20221208, 15, 1, 1511));
-        write.write(rowData(20221208, 16, 1, 1610));
-        write.write(rowData(20221209, 15, 1, 1510));
+        write.write(rowData(1, 1511, StringData.fromString("20221208"), 15));
+        write.write(rowData(1, 1610, StringData.fromString("20221208"), 16));
+        write.write(rowData(1, 1510, StringData.fromString("20221209"), 15));
         commit.commit(2, write.prepareCommit(true, 2));
 
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -258,22 +253,31 @@ public class CompactorSourceITCase extends AbstractTestBase {
     }
 
     private String toString(RowData rowData) {
+        int numFiles;
+        try {
+            numFiles = dataFileMetaSerializer.deserializeList(rowData.getBinary(4)).size();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
         return String.format(
-                "%s %d|%d|%d",
+                "%s %d|%s|%d|%d|%d",
                 rowData.getRowKind().shortString(),
-                rowData.getInt(0),
-                rowData.getInt(1),
-                rowData.getInt(2));
+                rowData.getLong(0),
+                rowData.getString(1).toString(),
+                rowData.getInt(2),
+                rowData.getInt(3),
+                numFiles);
     }
 
     private GenericRowData rowData(Object... values) {
         return GenericRowData.of(values);
     }
 
-    private BinaryRowData binaryRow(int dt, int hh) {
+    private BinaryRowData binaryRow(String dt, int hh) {
         BinaryRowData b = new BinaryRowData(2);
         BinaryRowWriter writer = new BinaryRowWriter(b);
-        writer.writeInt(0, dt);
+        writer.writeString(0, StringData.fromString(dt));
         writer.writeInt(1, hh);
         writer.complete();
         return b;

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/CompactorSourceITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/CompactorSourceITCase.java
@@ -108,9 +108,9 @@ public class CompactorSourceITCase extends AbstractTestBase {
         assertThat(actual)
                 .hasSameElementsAs(
                         Arrays.asList(
-                                "+I 2|20221208|15|0|2",
-                                "+I 2|20221208|16|0|1",
-                                "+I 2|20221209|15|0|1"));
+                                "+I 2|20221208|15|0|0",
+                                "+I 2|20221208|16|0|0",
+                                "+I 2|20221209|15|0|0"));
 
         write.close();
         commit.close();
@@ -195,7 +195,7 @@ public class CompactorSourceITCase extends AbstractTestBase {
         testPartitionSpec(
                 false,
                 getSpecifiedPartitions(),
-                Arrays.asList("+I 3|20221208|16|0|2", "+I 3|20221209|15|0|2"));
+                Arrays.asList("+I 3|20221208|16|0|0", "+I 3|20221209|15|0|0"));
     }
 
     private List<Map<String, String>> getSpecifiedPartitions() {

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitGeneratorTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitGeneratorTest.java
@@ -78,6 +78,7 @@ public class FileStoreSourceSplitGeneratorTest {
                 };
         List<DataSplit> scanSplits =
                 AbstractDataTableScan.generateSplits(
+                        1L,
                         false,
                         Collections::singletonList,
                         plan.groupByPartFiles(plan.files(FileKind.ADD)));

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitSerializerTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitSerializerTest.java
@@ -118,7 +118,7 @@ public class FileStoreSourceSplitSerializerTest {
             boolean isIncremental,
             long recordsToSkip) {
         return new FileStoreSourceSplit(
-                id, new DataSplit(partition, bucket, files, isIncremental), recordsToSkip);
+                id, new DataSplit(1L, partition, bucket, files, isIncremental), recordsToSkip);
     }
 
     private static FileStoreSourceSplit serializeAndDeserialize(FileStoreSourceSplit split)

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/TestChangelogDataReadWrite.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/TestChangelogDataReadWrite.java
@@ -184,7 +184,8 @@ public class TestChangelogDataReadWrite {
                                 null, // not used, we only create an empty writer
                                 options,
                                 EXTRACTOR)
-                        .createEmptyWriter(partition, bucket, service);
+                        .createEmptyWriterWrapper(partition, bucket, service)
+                        .writer;
         ((MemoryOwner) writer)
                 .setMemoryPool(
                         new HeapMemorySegmentPool(options.writeBufferSize(), options.pageSize()));

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/TestChangelogDataReadWrite.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/TestChangelogDataReadWrite.java
@@ -184,7 +184,7 @@ public class TestChangelogDataReadWrite {
                                 null, // not used, we only create an empty writer
                                 options,
                                 EXTRACTOR)
-                        .createEmptyWriterWrapper(partition, bucket, service)
+                        .createEmptyWriterContainer(partition, bucket, service)
                         .writer;
         ((MemoryOwner) writer)
                 .setMemoryPool(

--- a/flink-table-store-connector/src/test/resources/log4j2-test.properties
+++ b/flink-table-store-connector/src/test/resources/log4j2-test.properties
@@ -25,4 +25,4 @@ appender.testlogger.name = TestLogger
 appender.testlogger.type = CONSOLE
 appender.testlogger.target = SYSTEM_ERR
 appender.testlogger.layout.type = PatternLayout
-appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n
+appender.testlogger.layout.pattern = %-4r [%tid %t] %-5p %c %x - %m%n

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/append/AppendOnlyWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/append/AppendOnlyWriter.java
@@ -94,9 +94,13 @@ public class AppendOnlyWriter implements RecordWriter<RowData> {
     }
 
     @Override
-    public void compact(boolean fullCompaction, List<DataFileMeta> extraFiles) throws Exception {
-        extraFiles.forEach(compactManager::addNewFile);
+    public void compact(boolean fullCompaction) throws Exception {
         flushWriter(true, fullCompaction);
+    }
+
+    @Override
+    public void addNewFiles(List<DataFileMeta> files) {
+        files.forEach(compactManager::addNewFile);
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/append/AppendOnlyWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/append/AppendOnlyWriter.java
@@ -94,7 +94,8 @@ public class AppendOnlyWriter implements RecordWriter<RowData> {
     }
 
     @Override
-    public void compact(boolean fullCompaction) throws Exception {
+    public void compact(boolean fullCompaction, List<DataFileMeta> extraFiles) throws Exception {
+        extraFiles.forEach(compactManager::addNewFile);
         flushWriter(true, fullCompaction);
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/compact/CompactFutureManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/compact/CompactFutureManager.java
@@ -51,11 +51,9 @@ public abstract class CompactFutureManager implements CompactManager {
                     result = taskFuture.get();
                 } catch (CancellationException e) {
                     LOG.info("Compaction future is cancelled", e);
-                    LOG.debug("OK task future " + taskFuture + " cancelled");
                     taskFuture = null;
                     return Optional.empty();
                 }
-                LOG.debug("OK task future " + taskFuture + " completed");
                 taskFuture = null;
                 return Optional.of(result);
             }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/compact/CompactFutureManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/compact/CompactFutureManager.java
@@ -51,9 +51,11 @@ public abstract class CompactFutureManager implements CompactManager {
                     result = taskFuture.get();
                 } catch (CancellationException e) {
                     LOG.info("Compaction future is cancelled", e);
+                    LOG.debug("OK task future " + taskFuture + " cancelled");
                     taskFuture = null;
                     return Optional.empty();
                 }
+                LOG.debug("OK task future " + taskFuture + " completed");
                 taskFuture = null;
                 return Optional.of(result);
             }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeWriter.java
@@ -139,7 +139,8 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
     }
 
     @Override
-    public void compact(boolean fullCompaction) throws Exception {
+    public void compact(boolean fullCompaction, List<DataFileMeta> extraFiles) throws Exception {
+        extraFiles.forEach(compactManager::addNewFile);
         flushWriteBuffer(true, fullCompaction);
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeWriter.java
@@ -139,9 +139,13 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
     }
 
     @Override
-    public void compact(boolean fullCompaction, List<DataFileMeta> extraFiles) throws Exception {
-        extraFiles.forEach(compactManager::addNewFile);
+    public void compact(boolean fullCompaction) throws Exception {
         flushWriteBuffer(true, fullCompaction);
+    }
+
+    @Override
+    public void addNewFiles(List<DataFileMeta> files) {
+        files.forEach(compactManager::addNewFile);
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/CompactStrategy.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/CompactStrategy.java
@@ -41,6 +41,11 @@ public interface CompactStrategy {
     /** Pick a compaction unit consisting of all existing files. */
     static Optional<CompactUnit> pickFullCompaction(int numLevels, List<LevelSortedRun> runs) {
         int maxLevel = numLevels - 1;
-        return Optional.of(CompactUnit.fromLevelRuns(maxLevel, runs));
+        if (runs.size() == 1 && runs.get(0).level() == maxLevel) {
+            // only 1 sorted run on the max level, nothing to compact
+            return Optional.empty();
+        } else {
+            return Optional.of(CompactUnit.fromLevelRuns(maxLevel, runs));
+        }
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/MergeTreeCompactManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/MergeTreeCompactManager.java
@@ -91,14 +91,20 @@ public class MergeTreeCompactManager extends CompactFutureManager {
                 LOG.debug(
                         "Trigger forced full compaciton. Picking from the following runs\n{}",
                         runs);
+                new RuntimeException().printStackTrace();
             }
             optionalUnit = CompactStrategy.pickFullCompaction(levels.numberOfLevels(), runs);
         } else {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("task future? = " + taskFuture);
+                new RuntimeException().printStackTrace();
+            }
             if (taskFuture != null) {
                 return;
             }
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Trigger normal compaciton. Picking from the following runs\n{}", runs);
+                new RuntimeException().printStackTrace();
             }
             optionalUnit =
                     strategy.pick(levels.numberOfLevels(), runs)
@@ -156,6 +162,7 @@ public class MergeTreeCompactManager extends CompactFutureManager {
                             .collect(Collectors.joining(", ")));
         }
         taskFuture = executor.submit(task);
+        LOG.debug("taskFuture = " + taskFuture);
     }
 
     /** Finish current task, and update result files to {@link Levels}. */

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/MergeTreeCompactManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/MergeTreeCompactManager.java
@@ -91,20 +91,14 @@ public class MergeTreeCompactManager extends CompactFutureManager {
                 LOG.debug(
                         "Trigger forced full compaciton. Picking from the following runs\n{}",
                         runs);
-                new RuntimeException().printStackTrace();
             }
             optionalUnit = CompactStrategy.pickFullCompaction(levels.numberOfLevels(), runs);
         } else {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("task future? = " + taskFuture);
-                new RuntimeException().printStackTrace();
-            }
             if (taskFuture != null) {
                 return;
             }
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Trigger normal compaciton. Picking from the following runs\n{}", runs);
-                new RuntimeException().printStackTrace();
             }
             optionalUnit =
                     strategy.pick(levels.numberOfLevels(), runs)
@@ -162,7 +156,6 @@ public class MergeTreeCompactManager extends CompactFutureManager {
                             .collect(Collectors.joining(", ")));
         }
         taskFuture = executor.submit(task);
-        LOG.debug("taskFuture = " + taskFuture);
     }
 
     /** Finish current task, and update result files to {@link Levels}. */

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AppendOnlyFileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AppendOnlyFileStoreWrite.java
@@ -81,28 +81,28 @@ public class AppendOnlyFileStoreWrite extends AbstractFileStoreWrite<RowData> {
     }
 
     @Override
-    public WriterWrapper<RowData> createWriterWrapper(
+    public WriterContainer<RowData> createWriterContainer(
             BinaryRowData partition, int bucket, ExecutorService compactExecutor) {
         Long latestSnapshotId = snapshotManager.latestSnapshotId();
         RecordWriter<RowData> writer =
-                createWriterWrapper(
+                createWriter(
                         partition,
                         bucket,
                         scanExistingFileMetas(latestSnapshotId, partition, bucket),
                         compactExecutor);
-        return new WriterWrapper<>(writer, latestSnapshotId);
+        return new WriterContainer<>(writer, latestSnapshotId);
     }
 
     @Override
-    public WriterWrapper<RowData> createEmptyWriterWrapper(
+    public WriterContainer<RowData> createEmptyWriterContainer(
             BinaryRowData partition, int bucket, ExecutorService compactExecutor) {
         Long latestSnapshotId = snapshotManager.latestSnapshotId();
         RecordWriter<RowData> writer =
-                createWriterWrapper(partition, bucket, Collections.emptyList(), compactExecutor);
-        return new WriterWrapper<>(writer, latestSnapshotId);
+                createWriter(partition, bucket, Collections.emptyList(), compactExecutor);
+        return new WriterContainer<>(writer, latestSnapshotId);
     }
 
-    private RecordWriter<RowData> createWriterWrapper(
+    private RecordWriter<RowData> createWriter(
             BinaryRowData partition,
             int bucket,
             List<DataFileMeta> restoredFiles,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreWrite.java
@@ -21,9 +21,12 @@ package org.apache.flink.table.store.file.operation;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.store.file.FileStore;
+import org.apache.flink.table.store.file.io.DataFileMeta;
 import org.apache.flink.table.store.file.utils.RecordWriter;
 import org.apache.flink.table.store.table.sink.FileCommittable;
 import org.apache.flink.table.store.table.sink.SinkRecord;
+
+import javax.annotation.Nullable;
 
 import java.util.List;
 
@@ -61,9 +64,15 @@ public interface FileStoreWrite<T> {
      * @param partition the partition to compact
      * @param bucket the bucket to compact
      * @param fullCompaction whether to trigger full compaction or just normal compaction
+     * @param extraCompactFiles extra level 0 files added to the writer before compaction
      * @throws Exception the thrown exception when compacting the records
      */
-    void compact(BinaryRowData partition, int bucket, boolean fullCompaction) throws Exception;
+    void compact(
+            BinaryRowData partition,
+            int bucket,
+            boolean fullCompaction,
+            @Nullable ExtraCompactFiles extraCompactFiles)
+            throws Exception;
 
     /**
      * Prepare commit in the write.
@@ -81,4 +90,23 @@ public interface FileStoreWrite<T> {
      * @throws Exception the thrown exception
      */
     void close() throws Exception;
+
+    /** Extra files added to the writer before compaction. */
+    class ExtraCompactFiles {
+        private final long snapshotId;
+        private final List<DataFileMeta> files;
+
+        public ExtraCompactFiles(long snapshotId, List<DataFileMeta> files) {
+            this.snapshotId = snapshotId;
+            this.files = files;
+        }
+
+        public long snapshotId() {
+            return snapshotId;
+        }
+
+        public List<DataFileMeta> files() {
+            return files;
+        }
+    }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreWrite.java
@@ -107,7 +107,7 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
     }
 
     @Override
-    public WriterWrapper<KeyValue> createWriterWrapper(
+    public WriterContainer<KeyValue> createWriterContainer(
             BinaryRowData partition, int bucket, ExecutorService compactExecutor) {
         Long latestSnapshotId = snapshotManager.latestSnapshotId();
         RecordWriter<KeyValue> writer =
@@ -116,16 +116,16 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                         bucket,
                         scanExistingFileMetas(latestSnapshotId, partition, bucket),
                         compactExecutor);
-        return new WriterWrapper<>(writer, latestSnapshotId);
+        return new WriterContainer<>(writer, latestSnapshotId);
     }
 
     @Override
-    public WriterWrapper<KeyValue> createEmptyWriterWrapper(
+    public WriterContainer<KeyValue> createEmptyWriterContainer(
             BinaryRowData partition, int bucket, ExecutorService compactExecutor) {
         Long latestSnapshotId = snapshotManager.latestSnapshotId();
         RecordWriter<KeyValue> writer =
                 createMergeTreeWriter(partition, bucket, Collections.emptyList(), compactExecutor);
-        return new WriterWrapper<>(writer, latestSnapshotId);
+        return new WriterContainer<>(writer, latestSnapshotId);
     }
 
     private MergeTreeWriter createMergeTreeWriter(

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/MemoryFileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/MemoryFileStoreWrite.java
@@ -51,7 +51,7 @@ public abstract class MemoryFileStoreWrite<T> extends AbstractFileStoreWrite<T> 
     }
 
     private Iterator<MemoryOwner> memoryOwners() {
-        Iterator<Map<Integer, WriterWithCommit<T>>> iterator = writers.values().iterator();
+        Iterator<Map<Integer, WriterWrapper<T>>> iterator = writers.values().iterator();
         return Iterators.concat(
                 new Iterator<Iterator<MemoryOwner>>() {
                     @Override
@@ -63,10 +63,10 @@ public abstract class MemoryFileStoreWrite<T> extends AbstractFileStoreWrite<T> 
                     public Iterator<MemoryOwner> next() {
                         return Iterators.transform(
                                 iterator.next().values().iterator(),
-                                writerWithCommit ->
-                                        writerWithCommit == null
+                                writerWrapper ->
+                                        writerWrapper == null
                                                 ? null
-                                                : (MemoryOwner) (writerWithCommit.writer));
+                                                : (MemoryOwner) (writerWrapper.writer));
                     }
                 });
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/MemoryFileStoreWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/MemoryFileStoreWrite.java
@@ -51,7 +51,7 @@ public abstract class MemoryFileStoreWrite<T> extends AbstractFileStoreWrite<T> 
     }
 
     private Iterator<MemoryOwner> memoryOwners() {
-        Iterator<Map<Integer, WriterWrapper<T>>> iterator = writers.values().iterator();
+        Iterator<Map<Integer, WriterContainer<T>>> iterator = writers.values().iterator();
         return Iterators.concat(
                 new Iterator<Iterator<MemoryOwner>>() {
                     @Override
@@ -63,10 +63,10 @@ public abstract class MemoryFileStoreWrite<T> extends AbstractFileStoreWrite<T> 
                     public Iterator<MemoryOwner> next() {
                         return Iterators.transform(
                                 iterator.next().values().iterator(),
-                                writerWrapper ->
-                                        writerWrapper == null
+                                writerContainer ->
+                                        writerContainer == null
                                                 ? null
-                                                : (MemoryOwner) (writerWrapper.writer));
+                                                : (MemoryOwner) (writerContainer.writer));
                     }
                 });
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/ObjectSerializer.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/ObjectSerializer.java
@@ -19,12 +19,16 @@
 package org.apache.flink.table.store.file.utils;
 
 import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.typeutils.InternalSerializers;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.types.logical.RowType;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -80,6 +84,13 @@ public abstract class ObjectSerializer<T> implements Serializable {
         }
     }
 
+    public final byte[] serializeList(List<T> records) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputViewStreamWrapper view = new DataOutputViewStreamWrapper(baos);
+        serializeList(records, view);
+        return baos.toByteArray();
+    }
+
     /** De-serializes a record list from the given source input view. */
     public final List<T> deserializeList(DataInputView source) throws IOException {
         int size = source.readInt();
@@ -88,6 +99,12 @@ public abstract class ObjectSerializer<T> implements Serializable {
             records.add(deserialize(source));
         }
         return records;
+    }
+
+    public final List<T> deserializeList(byte[] bytes) throws IOException {
+        ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+        DataInputViewStreamWrapper view = new DataInputViewStreamWrapper(bais);
+        return deserializeList(view);
     }
 
     /** Convert a {@link T} to {@link RowData}. */

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RecordWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RecordWriter.java
@@ -41,9 +41,15 @@ public interface RecordWriter<T> {
      * not be completed when the method returns.
      *
      * @param fullCompaction whether to trigger full compaction or just normal compaction
-     * @param extraFiles extra files added to the writer before compaction
      */
-    void compact(boolean fullCompaction, List<DataFileMeta> extraFiles) throws Exception;
+    void compact(boolean fullCompaction) throws Exception;
+
+    /**
+     * Add files to the internal {@link org.apache.flink.table.store.file.compact.CompactManager}.
+     *
+     * @param files files to add
+     */
+    void addNewFiles(List<DataFileMeta> files);
 
     /**
      * Prepare for a commit.

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RecordWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/RecordWriter.java
@@ -19,7 +19,10 @@
 package org.apache.flink.table.store.file.utils;
 
 import org.apache.flink.table.store.file.io.CompactIncrement;
+import org.apache.flink.table.store.file.io.DataFileMeta;
 import org.apache.flink.table.store.file.io.NewFilesIncrement;
+
+import java.util.List;
 
 /**
  * The {@code RecordWriter} is responsible for writing data and handling in-progress files used to
@@ -38,8 +41,9 @@ public interface RecordWriter<T> {
      * not be completed when the method returns.
      *
      * @param fullCompaction whether to trigger full compaction or just normal compaction
+     * @param extraFiles extra files added to the writer before compaction
      */
-    void compact(boolean fullCompaction) throws Exception;
+    void compact(boolean fullCompaction, List<DataFileMeta> extraFiles) throws Exception;
 
     /**
      * Prepare for a commit.

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWrite.java
@@ -18,12 +18,11 @@
 
 package org.apache.flink.table.store.table.sink;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
-import org.apache.flink.table.store.file.operation.FileStoreWrite;
-
-import javax.annotation.Nullable;
+import org.apache.flink.table.store.file.io.DataFileMeta;
 
 import java.util.List;
 
@@ -42,17 +41,17 @@ public interface TableWrite extends AutoCloseable {
     /** Log record need to preserve original pk (which includes partition fields). */
     SinkRecord toLogRecord(SinkRecord record);
 
-    default void compact(BinaryRowData partition, int bucket, boolean fullCompaction)
-            throws Exception {
-        compact(partition, bucket, fullCompaction, null);
-    }
+    void compact(BinaryRowData partition, int bucket, boolean fullCompaction) throws Exception;
 
-    void compact(
-            BinaryRowData partition,
-            int bucket,
-            boolean fullCompaction,
-            @Nullable FileStoreWrite.ExtraCompactFiles extraCompactFiles)
-            throws Exception;
+    /**
+     * Notify that some new files are created at given snapshot in given bucket.
+     *
+     * <p>Most probably, these files are created by another job. Currently this method is only used
+     * by the dedicated compact job to see files created by writer jobs.
+     */
+    @Internal
+    void notifyNewFiles(
+            long snapshotId, BinaryRowData partition, int bucket, List<DataFileMeta> files);
 
     List<FileCommittable> prepareCommit(boolean blocking, long commitIdentifier) throws Exception;
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWrite.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWrite.java
@@ -21,6 +21,9 @@ package org.apache.flink.table.store.table.sink;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.store.file.operation.FileStoreWrite;
+
+import javax.annotation.Nullable;
 
 import java.util.List;
 
@@ -39,7 +42,17 @@ public interface TableWrite extends AutoCloseable {
     /** Log record need to preserve original pk (which includes partition fields). */
     SinkRecord toLogRecord(SinkRecord record);
 
-    void compact(BinaryRowData partition, int bucket, boolean fullCompaction) throws Exception;
+    default void compact(BinaryRowData partition, int bucket, boolean fullCompaction)
+            throws Exception {
+        compact(partition, bucket, fullCompaction, null);
+    }
+
+    void compact(
+            BinaryRowData partition,
+            int bucket,
+            boolean fullCompaction,
+            @Nullable FileStoreWrite.ExtraCompactFiles extraCompactFiles)
+            throws Exception;
 
     List<FileCommittable> prepareCommit(boolean blocking, long commitIdentifier) throws Exception;
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWriteImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWriteImpl.java
@@ -23,6 +23,8 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.store.file.operation.FileStoreWrite;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
 
 /**
@@ -70,9 +72,13 @@ public class TableWriteImpl<T> implements TableWrite {
     }
 
     @Override
-    public void compact(BinaryRowData partition, int bucket, boolean fullCompaction)
+    public void compact(
+            BinaryRowData partition,
+            int bucket,
+            boolean fullCompaction,
+            @Nullable FileStoreWrite.ExtraCompactFiles extraCompactFiles)
             throws Exception {
-        write.compact(partition, bucket, fullCompaction);
+        write.compact(partition, bucket, fullCompaction, extraCompactFiles);
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWriteImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableWriteImpl.java
@@ -21,9 +21,8 @@ package org.apache.flink.table.store.table.sink;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.store.file.io.DataFileMeta;
 import org.apache.flink.table.store.file.operation.FileStoreWrite;
-
-import javax.annotation.Nullable;
 
 import java.util.List;
 
@@ -72,13 +71,15 @@ public class TableWriteImpl<T> implements TableWrite {
     }
 
     @Override
-    public void compact(
-            BinaryRowData partition,
-            int bucket,
-            boolean fullCompaction,
-            @Nullable FileStoreWrite.ExtraCompactFiles extraCompactFiles)
+    public void compact(BinaryRowData partition, int bucket, boolean fullCompaction)
             throws Exception {
-        write.compact(partition, bucket, fullCompaction, extraCompactFiles);
+        write.compact(partition, bucket, fullCompaction);
+    }
+
+    @Override
+    public void notifyNewFiles(
+            long snapshotId, BinaryRowData partition, int bucket, List<DataFileMeta> files) {
+        write.notifyNewFiles(snapshotId, partition, bucket, files);
     }
 
     @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/snapshot/ContinuousCompactorFollowUpScanner.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/snapshot/ContinuousCompactorFollowUpScanner.java
@@ -33,13 +33,12 @@ public class ContinuousCompactorFollowUpScanner implements FollowUpScanner {
 
     @Override
     public boolean shouldScanSnapshot(Snapshot snapshot) {
-        if (snapshot.commitKind() == Snapshot.CommitKind.APPEND
-                || snapshot.commitKind() == Snapshot.CommitKind.OVERWRITE) {
+        if (snapshot.commitKind() == Snapshot.CommitKind.APPEND) {
             return true;
         }
 
         LOG.debug(
-                "Next snapshot id {} is neither APPEND nor OVERWRITE, but is {}, check next one.",
+                "Next snapshot id {} is not APPEND, but is {}, check next one.",
                 snapshot.id(),
                 snapshot.commitKind());
         return false;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/system/BucketsTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/system/BucketsTable.java
@@ -61,6 +61,10 @@ public class BucketsTable implements DataTable {
         this.wrapped = wrapped;
     }
 
+    public FileStoreTable wrapped() {
+        return wrapped;
+    }
+
     @Override
     public Path location() {
         return wrapped.location();
@@ -122,6 +126,7 @@ public class BucketsTable implements DataTable {
 
         @Override
         public TableRead withFilter(Predicate predicate) {
+            // filter is done by scan
             return this;
         }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -193,10 +193,12 @@ public class TestFileStore extends KeyValueFileStore {
                                     ExecutorService service = Executors.newSingleThreadExecutor();
                                     RecordWriter<KeyValue> writer =
                                             emptyWriter
-                                                    ? write.createEmptyWriter(
-                                                            partition, bucket, service)
-                                                    : write.createWriter(
-                                                            partition, bucket, service);
+                                                    ? write.createEmptyWriterWrapper(
+                                                                    partition, bucket, service)
+                                                            .writer
+                                                    : write.createWriterWrapper(
+                                                                    partition, bucket, service)
+                                                            .writer;
                                     ((MemoryOwner) writer)
                                             .setMemoryPool(
                                                     new HeapMemorySegmentPool(
@@ -312,6 +314,7 @@ public class TestFileStore extends KeyValueFileStore {
                         new RecordReaderIterator<>(
                                 read.createReader(
                                         new DataSplit(
+                                                0L /* unused */,
                                                 entryWithPartition.getKey(),
                                                 entryWithBucket.getKey(),
                                                 entryWithBucket.getValue(),

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -193,10 +193,10 @@ public class TestFileStore extends KeyValueFileStore {
                                     ExecutorService service = Executors.newSingleThreadExecutor();
                                     RecordWriter<KeyValue> writer =
                                             emptyWriter
-                                                    ? write.createEmptyWriterWrapper(
+                                                    ? write.createEmptyWriterContainer(
                                                                     partition, bucket, service)
                                                             .writer
-                                                    : write.createWriterWrapper(
+                                                    : write.createWriterContainer(
                                                                     partition, bucket, service)
                                                             .writer;
                                     ((MemoryOwner) writer)

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreReadTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreReadTest.java
@@ -223,9 +223,9 @@ public class KeyValueFileStoreReadTest {
             throws Exception {
         store.commitData(data, partitionCalculator, kv -> 0);
         FileStoreScan scan = store.newScan();
+        Long snapshotId = store.snapshotManager().latestSnapshotId();
         Map<BinaryRowData, List<ManifestEntry>> filesGroupedByPartition =
-                scan.withSnapshot(store.snapshotManager().latestSnapshotId()).plan().files()
-                        .stream()
+                scan.withSnapshot(snapshotId).plan().files().stream()
                         .collect(Collectors.groupingBy(ManifestEntry::partition));
         KeyValueFileStoreRead read = store.newRead();
         if (keyProjection != null) {
@@ -241,6 +241,7 @@ public class KeyValueFileStoreReadTest {
             RecordReader<KeyValue> reader =
                     read.createReader(
                             new DataSplit(
+                                    snapshotId,
                                     entry.getKey(),
                                     0,
                                     entry.getValue().stream()

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
@@ -168,7 +168,7 @@ public class TestCommitThread extends Thread {
                 for (BinaryRowData partition : writtenPartitions) {
                     MergeTreeWriter writer =
                             writers.computeIfAbsent(partition, p -> createWriter(p, false));
-                    writer.compact(true);
+                    writer.compact(true, Collections.emptyList());
                     RecordWriter.CommitIncrement inc = writer.prepareCommit(true);
                     committable.addFileCommittable(
                             new FileCommittable(
@@ -279,8 +279,9 @@ public class TestCommitThread extends Thread {
                         });
         MergeTreeWriter writer =
                 empty
-                        ? (MergeTreeWriter) write.createEmptyWriter(partition, 0, service)
-                        : (MergeTreeWriter) write.createWriter(partition, 0, service);
+                        ? (MergeTreeWriter)
+                                write.createEmptyWriterWrapper(partition, 0, service).writer
+                        : (MergeTreeWriter) write.createWriterWrapper(partition, 0, service).writer;
         writer.setMemoryPool(
                 new HeapMemorySegmentPool(
                         WRITE_BUFFER_SIZE.getBytes(), (int) PAGE_SIZE.getBytes()));

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/TestCommitThread.java
@@ -168,7 +168,7 @@ public class TestCommitThread extends Thread {
                 for (BinaryRowData partition : writtenPartitions) {
                     MergeTreeWriter writer =
                             writers.computeIfAbsent(partition, p -> createWriter(p, false));
-                    writer.compact(true, Collections.emptyList());
+                    writer.compact(true);
                     RecordWriter.CommitIncrement inc = writer.prepareCommit(true);
                     committable.addFileCommittable(
                             new FileCommittable(
@@ -280,8 +280,9 @@ public class TestCommitThread extends Thread {
         MergeTreeWriter writer =
                 empty
                         ? (MergeTreeWriter)
-                                write.createEmptyWriterWrapper(partition, 0, service).writer
-                        : (MergeTreeWriter) write.createWriterWrapper(partition, 0, service).writer;
+                                write.createEmptyWriterContainer(partition, 0, service).writer
+                        : (MergeTreeWriter)
+                                write.createWriterContainer(partition, 0, service).writer;
         writer.setMemoryPool(
                 new HeapMemorySegmentPool(
                         WRITE_BUFFER_SIZE.getBytes(), (int) PAGE_SIZE.getBytes()));

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/source/SplitTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/source/SplitTest.java
@@ -44,7 +44,13 @@ public class SplitTest {
         for (int i = 0; i < ThreadLocalRandom.current().nextInt(10); i++) {
             files.add(gen.next().meta);
         }
-        DataSplit split = new DataSplit(data.partition, data.bucket, files, false);
+        DataSplit split =
+                new DataSplit(
+                        ThreadLocalRandom.current().nextLong(100),
+                        data.partition,
+                        data.bucket,
+                        files,
+                        false);
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         split.serialize(new DataOutputViewStreamWrapper(out));

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/source/snapshot/ContinuousCompactorFollowUpScannerTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/source/snapshot/ContinuousCompactorFollowUpScannerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.store.table.source.snapshot;
 
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.file.Snapshot;
+import org.apache.flink.table.store.file.io.DataFileMetaSerializer;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
 import org.apache.flink.table.store.table.FileStoreTable;
 import org.apache.flink.table.store.table.sink.TableCommit;
@@ -31,6 +32,8 @@ import org.apache.flink.types.RowKind;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -40,6 +43,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link ContinuousCompactorFollowUpScanner}. */
 public class ContinuousCompactorFollowUpScannerTest extends SnapshotEnumeratorTestBase {
+
+    private final DataFileMetaSerializer dataFileMetaSerializer = new DataFileMetaSerializer();
 
     @Test
     public void testGetPlan() throws Exception {
@@ -85,7 +90,7 @@ public class ContinuousCompactorFollowUpScannerTest extends SnapshotEnumeratorTe
         DataTableScan.DataFilePlan plan = scanner.getPlan(1, scan);
         assertThat(plan.snapshotId).isEqualTo(1);
         assertThat(getResult(read, plan.splits()))
-                .hasSameElementsAs(Arrays.asList("+I 1|0", "+I 2|0"));
+                .hasSameElementsAs(Arrays.asList("+I 1|1|0|1", "+I 1|2|0|1"));
 
         snapshot = snapshotManager.snapshot(2);
         assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.APPEND);
@@ -93,7 +98,7 @@ public class ContinuousCompactorFollowUpScannerTest extends SnapshotEnumeratorTe
         plan = scanner.getPlan(2, scan);
         assertThat(plan.snapshotId).isEqualTo(2);
         assertThat(getResult(read, plan.splits()))
-                .hasSameElementsAs(Collections.singletonList("+I 2|0"));
+                .hasSameElementsAs(Collections.singletonList("+I 2|2|0|1"));
 
         snapshot = snapshotManager.snapshot(3);
         assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.COMPACT);
@@ -101,17 +106,24 @@ public class ContinuousCompactorFollowUpScannerTest extends SnapshotEnumeratorTe
 
         snapshot = snapshotManager.snapshot(4);
         assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.OVERWRITE);
-        assertThat(scanner.shouldScanSnapshot(snapshot)).isTrue();
-        plan = scanner.getPlan(4, scan);
-        assertThat(plan.snapshotId).isEqualTo(4);
-        assertThat(getResult(read, plan.splits()))
-                .hasSameElementsAs(Collections.singletonList("+I 1|0"));
+        assertThat(scanner.shouldScanSnapshot(snapshot)).isFalse();
     }
 
     @Override
     protected String rowDataToString(RowData rowData) {
+        int numFiles;
+        try {
+            numFiles = dataFileMetaSerializer.deserializeList(rowData.getBinary(3)).size();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
         return String.format(
-                "%s %d|%d",
-                rowData.getRowKind().shortString(), rowData.getInt(0), rowData.getInt(1));
+                "%s %d|%d|%d|%d",
+                rowData.getRowKind().shortString(),
+                rowData.getLong(0),
+                rowData.getInt(1),
+                rowData.getInt(2),
+                numFiles);
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/source/snapshot/ContinuousCompactorFollowUpScannerTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/source/snapshot/ContinuousCompactorFollowUpScannerTest.java
@@ -79,7 +79,7 @@ public class ContinuousCompactorFollowUpScannerTest extends SnapshotEnumeratorTe
 
         assertThat(snapshotManager.latestSnapshotId()).isEqualTo(4);
 
-        BucketsTable bucketsTable = new BucketsTable(table);
+        BucketsTable bucketsTable = new BucketsTable(table, true);
         DataTableScan scan = bucketsTable.newScan();
         TableRead read = bucketsTable.newRead();
         ContinuousCompactorFollowUpScanner scanner = new ContinuousCompactorFollowUpScanner();

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/source/snapshot/ContinuousCompactorStartingScannerTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/source/snapshot/ContinuousCompactorStartingScannerTest.java
@@ -62,7 +62,7 @@ public class ContinuousCompactorStartingScannerTest extends SnapshotEnumeratorTe
 
         assertThat(snapshotManager.latestSnapshotId()).isEqualTo(5);
 
-        BucketsTable bucketsTable = new BucketsTable(table);
+        BucketsTable bucketsTable = new BucketsTable(table, true);
         ContinuousCompactorStartingScanner scanner = new ContinuousCompactorStartingScanner();
         DataTableScan.DataFilePlan plan = scanner.getPlan(snapshotManager, bucketsTable.newScan());
         assertThat(plan.snapshotId).isEqualTo(3);
@@ -76,7 +76,7 @@ public class ContinuousCompactorStartingScannerTest extends SnapshotEnumeratorTe
     public void testNoSnapshot() throws Exception {
         FileStoreTable table = createFileStoreTable();
         SnapshotManager snapshotManager = table.snapshotManager();
-        BucketsTable bucketsTable = new BucketsTable(table);
+        BucketsTable bucketsTable = new BucketsTable(table, true);
         ContinuousCompactorStartingScanner scanner = new ContinuousCompactorStartingScanner();
         assertThat(scanner.getPlan(snapshotManager, bucketsTable.newScan())).isNull();
     }

--- a/flink-table-store-core/src/test/resources/log4j2-test.properties
+++ b/flink-table-store-core/src/test/resources/log4j2-test.properties
@@ -25,4 +25,4 @@ appender.testlogger.name = TestLogger
 appender.testlogger.type = CONSOLE
 appender.testlogger.target = SYSTEM_ERR
 appender.testlogger.layout.type = PatternLayout
-appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n
+appender.testlogger.layout.pattern = %-4r [%tid %t] %-5p %c %x - %m%n

--- a/flink-table-store-e2e-tests/src/test/java/org/apache/flink/table/store/tests/FlinkActionsE2eTest.java
+++ b/flink-table-store-e2e-tests/src/test/java/org/apache/flink/table/store/tests/FlinkActionsE2eTest.java
@@ -89,7 +89,7 @@ public class FlinkActionsE2eTest extends E2eTestBase {
                 tableDdl,
                 testDataSourceDdl);
 
-        // run stand-alone compact job
+        // run dedicated compact job
         Container.ExecResult execResult =
                 jobManager.execInContainer(
                         "bin/flink",

--- a/flink-table-store-e2e-tests/src/test/resources/log4j2-test.properties
+++ b/flink-table-store-e2e-tests/src/test/resources/log4j2-test.properties
@@ -25,4 +25,4 @@ appender.testlogger.name = TestLogger
 appender.testlogger.type = CONSOLE
 appender.testlogger.target = SYSTEM_ERR
 appender.testlogger.layout.type = PatternLayout
-appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n
+appender.testlogger.layout.pattern = %-4r [%tid %t] %-5p %c %x - %m%n

--- a/flink-table-store-hive/flink-table-store-hive-connector/src/test/java/org/apache/flink/table/store/mapred/TableStoreInputSplitTest.java
+++ b/flink-table-store-hive/flink-table-store-hive-connector/src/test/java/org/apache/flink/table/store/mapred/TableStoreInputSplitTest.java
@@ -55,6 +55,7 @@ public class TableStoreInputSplitTest {
                 new TableStoreInputSplit(
                         tempDir.toString(),
                         new DataSplit(
+                                ThreadLocalRandom.current().nextLong(100),
                                 wantedPartition,
                                 0,
                                 generated.stream()

--- a/flink-table-store-hive/flink-table-store-hive-connector/src/test/resources/log4j2-test.properties
+++ b/flink-table-store-hive/flink-table-store-hive-connector/src/test/resources/log4j2-test.properties
@@ -25,4 +25,4 @@ appender.testlogger.name = TestLogger
 appender.testlogger.type = CONSOLE
 appender.testlogger.target = SYSTEM_ERR
 appender.testlogger.layout.type = PatternLayout
-appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n
+appender.testlogger.layout.pattern = %-4r [%tid %t] %-5p %c %x - %m%n

--- a/flink-table-store-kafka/src/test/resources/log4j2-test.properties
+++ b/flink-table-store-kafka/src/test/resources/log4j2-test.properties
@@ -25,7 +25,7 @@ appender.testlogger.name = TestLogger
 appender.testlogger.type = CONSOLE
 appender.testlogger.target = SYSTEM_ERR
 appender.testlogger.layout.type = PatternLayout
-appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n
+appender.testlogger.layout.pattern = %-4r [%tid %t] %-5p %c %x - %m%n
 
 logger.kafka.name = kafka
 logger.kafka.level = OFF

--- a/flink-table-store-spark/src/test/resources/log4j2-test.properties
+++ b/flink-table-store-spark/src/test/resources/log4j2-test.properties
@@ -25,7 +25,7 @@ appender.testlogger.name = TestLogger
 appender.testlogger.type = CONSOLE
 appender.testlogger.target = SYSTEM_ERR
 appender.testlogger.layout.type = PatternLayout
-appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n
+appender.testlogger.layout.pattern = %-4r [%tid %t] %-5p %c %x - %m%n
 
 logger.kafka.name = kafka
 logger.kafka.level = OFF

--- a/flink-table-store-spark2/src/test/resources/log4j2-test.properties
+++ b/flink-table-store-spark2/src/test/resources/log4j2-test.properties
@@ -25,7 +25,7 @@ appender.testlogger.name = TestLogger
 appender.testlogger.type = CONSOLE
 appender.testlogger.target = SYSTEM_ERR
 appender.testlogger.layout.type = PatternLayout
-appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n
+appender.testlogger.layout.pattern = %-4r [%tid %t] %-5p %c %x - %m%n
 
 logger.kafka.name = kafka
 logger.kafka.level = OFF


### PR DESCRIPTION
Currently the sink for Table Store dedicated compact job only receives records about what buckets are changed, instead of what files are changed. If the writer is kept open, new files of this bucket may be skipped.