### PR TITLE
[FLINK-30581] Deprecate FileStoreTableITCase and use CatalogITCaseBase

### DIFF
--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/CatalogITCaseBase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/CatalogITCaseBase.java
@@ -37,6 +37,7 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 
 import static org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL;
@@ -64,6 +65,10 @@ public abstract class CatalogITCaseBase extends AbstractTestBase {
 
         prepareConfiguration(tEnv);
         prepareConfiguration(sEnv);
+
+        for (String ddl : ddl()) {
+            tEnv.executeSql(ddl);
+        }
     }
 
     private void prepareConfiguration(TableEnvironment env) {
@@ -77,9 +82,19 @@ public abstract class CatalogITCaseBase extends AbstractTestBase {
         return 2;
     }
 
-    protected List<Row> sql(String query, Object... args) throws Exception {
+    protected List<String> ddl() {
+        return Collections.emptyList();
+    }
+
+    protected List<Row> batchSql(String query, Object... args) {
+        return sql(query, args);
+    }
+
+    protected List<Row> sql(String query, Object... args) {
         try (CloseableIterator<Row> iter = tEnv.executeSql(String.format(query, args)).collect()) {
             return ImmutableList.copyOf(iter);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileStoreTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileStoreTableITCase.java
@@ -57,6 +57,7 @@ import static org.apache.flink.table.store.connector.FlinkConnectorOptions.relat
 import static org.junit.jupiter.api.Assertions.fail;
 
 /** ITCase for file store table api. */
+@Deprecated
 public abstract class FileStoreTableITCase extends AbstractTestBase {
 
     protected TableEnvironment bEnv;

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/PartialUpdateITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/PartialUpdateITCase.java
@@ -36,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** ITCase for partial update. */
-public class PartialUpdateITCase extends FileStoreTableITCase {
+public class PartialUpdateITCase extends CatalogITCaseBase {
 
     @Override
     protected List<String> ddl() {


### PR DESCRIPTION
We recommend users to use Catalog tables instead managed tables.
Managed tables should be deprecated. Now we already did not expose managed in documentation. We can remove it.
Before removing, tests should be refactored.

FileStoreTableITCase with managed tables should be changed to CatalogITCaseBase.