### PR TITLE
[FLINK-30611] Expiration can be performed with missing files

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestFile.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestFile.java
@@ -35,13 +35,8 @@ import org.apache.flink.table.store.format.FieldStatsCollector;
 import org.apache.flink.table.store.format.FileFormat;
 import org.apache.flink.table.types.logical.RowType;
 
-import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
-
 import java.io.IOException;
-import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Queue;
 
 /**
  * This file includes several {@link ManifestEntry}s, representing the additional changes since last
@@ -89,24 +84,6 @@ public class ManifestFile {
         } catch (IOException e) {
             throw new RuntimeException("Failed to read manifest file " + fileName, e);
         }
-    }
-
-    public Iterable<ManifestEntry> readManifestFiles(List<String> manifestFiles) {
-        Queue<String> files = new LinkedList<>(manifestFiles);
-        return Iterables.concat(
-                (Iterable<Iterable<ManifestEntry>>)
-                        () ->
-                                new Iterator<Iterable<ManifestEntry>>() {
-                                    @Override
-                                    public boolean hasNext() {
-                                        return files.size() > 0;
-                                    }
-
-                                    @Override
-                                    public Iterable<ManifestEntry> next() {
-                                        return read(files.poll());
-                                    }
-                                });
     }
 
     /**

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -404,9 +404,6 @@ public class TestFileStore extends KeyValueFileStore {
 
     private Set<Path> getFilesInUse() {
         Set<Path> result = new HashSet<>();
-        FileStorePathFactory pathFactory = pathFactory();
-        ManifestList manifestList = manifestListFactory().create();
-        FileStoreScan scan = newScan();
 
         SchemaManager schemaManager = new SchemaManager(options.path());
         schemaManager.listAllIds().forEach(id -> result.add(schemaManager.toSchemaPath(id)));
@@ -427,35 +424,48 @@ public class TestFileStore extends KeyValueFileStore {
         }
 
         for (long id = firstInUseSnapshotId; id <= latestSnapshotId; id++) {
-            Path snapshotPath = snapshotManager.snapshotPath(id);
-            Snapshot snapshot = Snapshot.fromPath(snapshotPath);
-
-            // snapshot file
-            result.add(snapshotPath);
-
-            // manifest lists
-            result.add(pathFactory.toManifestListPath(snapshot.baseManifestList()));
-            result.add(pathFactory.toManifestListPath(snapshot.deltaManifestList()));
-            if (snapshot.changelogManifestList() != null) {
-                result.add(pathFactory.toManifestListPath(snapshot.changelogManifestList()));
-            }
-
-            // manifests
-            List<ManifestFileMeta> manifests = snapshot.readAllDataManifests(manifestList);
-            if (snapshot.changelogManifestList() != null) {
-                manifests.addAll(manifestList.read(snapshot.changelogManifestList()));
-            }
-            manifests.forEach(m -> result.add(pathFactory.toManifestFilePath(m.fileName())));
-
-            // data file
-            List<ManifestEntry> entries = scan.withManifestList(manifests).plan().files();
-            for (ManifestEntry entry : entries) {
-                result.add(
-                        new Path(
-                                pathFactory.bucketPath(entry.partition(), entry.bucket()),
-                                entry.file().fileName()));
-            }
+            result.addAll(getFilesInUse(id));
         }
+        return result;
+    }
+
+    public Set<Path> getFilesInUse(long snapshotId) {
+        Set<Path> result = new HashSet<>();
+
+        SnapshotManager snapshotManager = snapshotManager();
+        FileStorePathFactory pathFactory = pathFactory();
+        ManifestList manifestList = manifestListFactory().create();
+        FileStoreScan scan = newScan();
+
+        Path snapshotPath = snapshotManager.snapshotPath(snapshotId);
+        Snapshot snapshot = Snapshot.fromPath(snapshotPath);
+
+        // snapshot file
+        result.add(snapshotPath);
+
+        // manifest lists
+        result.add(pathFactory.toManifestListPath(snapshot.baseManifestList()));
+        result.add(pathFactory.toManifestListPath(snapshot.deltaManifestList()));
+        if (snapshot.changelogManifestList() != null) {
+            result.add(pathFactory.toManifestListPath(snapshot.changelogManifestList()));
+        }
+
+        // manifests
+        List<ManifestFileMeta> manifests = snapshot.readAllDataManifests(manifestList);
+        if (snapshot.changelogManifestList() != null) {
+            manifests.addAll(manifestList.read(snapshot.changelogManifestList()));
+        }
+        manifests.forEach(m -> result.add(pathFactory.toManifestFilePath(m.fileName())));
+
+        // data file
+        List<ManifestEntry> entries = scan.withManifestList(manifests).plan().files();
+        for (ManifestEntry entry : entries) {
+            result.add(
+                    new Path(
+                            pathFactory.bucketPath(entry.partition(), entry.bucket()),
+                            entry.file().fileName()));
+        }
+
         return result;
     }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/UncleanedFileStoreExpireTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/UncleanedFileStoreExpireTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.file.operation;
+
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.store.file.KeyValue;
+import org.apache.flink.table.store.file.utils.FileUtils;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link FileStoreExpireImpl}. Some files not in use may still remain after the test due
+ * to the testing methods.
+ */
+public class UncleanedFileStoreExpireTest extends FileStoreExpireTestBase {
+
+    @Test
+    public void testExpireWithMissingFiles() throws Exception {
+        FileStoreExpire expire = store.newExpire(1, 1, 1);
+
+        List<KeyValue> allData = new ArrayList<>();
+        List<Integer> snapshotPositions = new ArrayList<>();
+        commit(5, allData, snapshotPositions);
+
+        int latestSnapshotId = snapshotManager.latestSnapshotId().intValue();
+        Set<Path> filesInUse = store.getFilesInUse(latestSnapshotId);
+        List<Path> unusedFileList =
+                Files.walk(Paths.get(tempDir.toString()))
+                        .filter(Files::isRegularFile)
+                        .filter(p -> !p.getFileName().toString().startsWith("snapshot"))
+                        .filter(p -> !p.getFileName().toString().startsWith("schema"))
+                        .map(p -> new Path(p.toString()))
+                        .filter(p -> !filesInUse.contains(p))
+                        .collect(Collectors.toList());
+
+        // shuffle list
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        for (int i = unusedFileList.size() - 1; i > 0; i--) {
+            int j = random.nextInt(i + 1);
+            Collections.swap(unusedFileList, i, j);
+        }
+
+        // delete some unused files
+        int numFilesToDelete = random.nextInt(unusedFileList.size());
+        for (int i = 0; i < numFilesToDelete; i++) {
+            FileUtils.deleteOrWarn(unusedFileList.get(i));
+        }
+
+        expire.expire();
+
+        for (int i = 1; i < latestSnapshotId; i++) {
+            assertThat(snapshotManager.snapshotExists(i)).isFalse();
+        }
+        assertThat(snapshotManager.snapshotExists(latestSnapshotId)).isTrue();
+        assertSnapshot(latestSnapshotId, allData, snapshotPositions);
+    }
+}


### PR DESCRIPTION
If user kills the job when expiration is in progress, the files for some snapshots will become incomplete. We should support expiration with missing files so that when the job restarts, the expiration process can work normally.