### PR TITLE
[FLINK-30615] Refactor ReadWriteTableITCase to get rid of Managed Table and introduce new AbstractTestBase

### DIFF
--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ReadWriteTableITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ReadWriteTableITCase.java
@@ -19,13 +19,11 @@
 package org.apache.flink.table.store.connector;
 
 import org.apache.flink.api.dag.Transformation;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.transformations.PartitionTransformation;
-import org.apache.flink.table.api.EnvironmentSettings;
-import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.catalog.ObjectIdentifier;
@@ -36,49 +34,68 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.DynamicTableFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
+import org.apache.flink.table.store.CoreOptions;
 import org.apache.flink.table.store.connector.sink.TableStoreSink;
+import org.apache.flink.table.store.connector.util.AbstractTestBase;
+import org.apache.flink.table.store.file.schema.SchemaManager;
+import org.apache.flink.table.store.file.schema.UpdateSchema;
 import org.apache.flink.table.store.file.utils.BlockingIterator;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.types.Row;
-import org.apache.flink.util.CollectionUtil;
 
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nullable;
-
-import java.io.File;
-import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.table.planner.factories.TestValuesTableFactory.changelogRow;
-import static org.apache.flink.table.planner.factories.TestValuesTableFactory.registerData;
-import static org.apache.flink.table.store.connector.FlinkConnectorOptions.ROOT_PATH;
+import static org.apache.flink.table.store.connector.AbstractTableStoreFactory.buildFileStoreTable;
 import static org.apache.flink.table.store.connector.FlinkConnectorOptions.SCAN_PARALLELISM;
 import static org.apache.flink.table.store.connector.FlinkConnectorOptions.SINK_PARALLELISM;
-import static org.apache.flink.table.store.connector.ReadWriteTableTestUtil.dailyRates;
-import static org.apache.flink.table.store.connector.ReadWriteTableTestUtil.dailyRatesChangelogWithUB;
-import static org.apache.flink.table.store.connector.ReadWriteTableTestUtil.dailyRatesChangelogWithoutUB;
-import static org.apache.flink.table.store.connector.ReadWriteTableTestUtil.rates;
-import static org.apache.flink.table.store.connector.ShowCreateUtil.buildSimpleSelectQuery;
+import static org.apache.flink.table.store.connector.ReadWriteTableTestBase.assertNoMoreRecords;
 import static org.apache.flink.table.store.connector.TableStoreTestBase.createResolvedTable;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.bEnv;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.bExeEnv;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.buildQuery;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.buildQueryWithTableOptions;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.buildSimpleQuery;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.checkFileStorePath;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.createTable;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.createTemporaryTable;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.init;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.insertInto;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.insertIntoFromTable;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.insertOverwrite;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.insertOverwritePartition;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.sEnv;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.testBatchRead;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.testStreamingRead;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/** IT cases for managed table dml. */
-public class ReadWriteTableITCase extends ReadWriteTableTestBase {
+/** Table Store reading and writing IT cases. */
+public class ReadWriteTableITCase extends AbstractTestBase {
+
+    @BeforeEach
+    public void setUp() {
+        init(getTempDirPath());
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // Batch Read & Write
+    // ----------------------------------------------------------------------------------------------------------------
 
     @Test
-    public void testBatchWriteWithPartitionedRecordsWithPk() throws Exception {
-        // input is dailyRates()
-        List<Row> expectedRecords =
+    public void testBatchReadWriteWithPartitionedRecordsWithPk() throws Exception {
+        List<Row> initialRecords =
                 Arrays.asList(
                         // part = 2022-01-01
                         changelogRow("+I", "US Dollar", 114L, "2022-01-01"),
@@ -86,177 +103,165 @@ public class ReadWriteTableITCase extends ReadWriteTableTestBase {
                         changelogRow("+I", "Euro", 114L, "2022-01-01"),
                         // part = 2022-01-02
                         changelogRow("+I", "Euro", 119L, "2022-01-02"));
-        // test batch read
-        String managedTable =
-                collectAndCheckBatchReadWrite(
-                        true, true, null, Collections.emptyList(), expectedRecords);
-        checkFileStorePath(tEnv, managedTable, dailyRates().f1);
 
-        // test streaming read
-        final StreamTableEnvironment streamTableEnv =
-                StreamTableEnvironment.create(buildStreamEnv());
-        registerTable(streamTableEnv, managedTable);
-        BlockingIterator<Row, Row> streamIter =
-                collectAndCheck(
-                        streamTableEnv,
-                        managedTable,
-                        Collections.emptyMap(),
-                        null,
-                        expectedRecords);
+        String table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt String"),
+                        Arrays.asList("currency", "dt"),
+                        Collections.singletonList("dt"));
 
-        // overwrite static partition 2022-01-02
-        prepareEnvAndOverwrite(
-                managedTable,
-                Collections.singletonMap("dt", "'2022-01-02'"),
-                Arrays.asList(new String[] {"'Euro'", "100"}, new String[] {"'Yen'", "1"}));
+        insertInto(
+                table,
+                "('US Dollar', 114, '2022-01-01')",
+                "('Yen', 1, '2022-01-01')",
+                "('Euro', 114, '2022-01-01')",
+                "('Euro', 119, '2022-01-02')");
 
-        // streaming iter will not receive any changelog
-        assertNoMoreRecords(streamIter);
+        checkFileStorePath(table, Arrays.asList("dt=2022-01-01", "dt=2022-01-02"));
+
+        testBatchRead(buildSimpleQuery(table), initialRecords);
+
+        BlockingIterator<Row, Row> streamItr =
+                testStreamingRead(buildSimpleQuery(table), initialRecords);
+
+        // test refresh after overwriting
+        insertOverwritePartition(
+                table, "PARTITION (dt = '2022-01-02')", "('Euro', 100)", "('Yen', 1)");
+
+        // streaming iterator will not receive any changelog
+        assertNoMoreRecords(streamItr);
+        streamItr.close();
 
         // batch read to check partition refresh
-        collectAndCheck(
-                        tEnv,
-                        managedTable,
-                        Collections.emptyMap(),
-                        "dt IN ('2022-01-02')",
-                        Arrays.asList(
-                                // part = 2022-01-01
-                                changelogRow("+I", "Euro", 100L, "2022-01-02"),
-                                changelogRow("+I", "Yen", 1L, "2022-01-02")))
-                .close();
+        testBatchRead(
+                buildQuery(table, "*", "WHERE dt IN ('2022-01-02')"),
+                Arrays.asList(
+                        // part = 2022-01-02
+                        changelogRow("+I", "Euro", 100L, "2022-01-02"),
+                        changelogRow("+I", "Yen", 1L, "2022-01-02")));
 
         // test partition filter
-        List<Row> expected =
+        List<Row> expectedPartitionRecords =
                 Arrays.asList(
                         changelogRow("+I", "Yen", 1L, "2022-01-01"),
                         changelogRow("+I", "Euro", 114L, "2022-01-01"),
                         changelogRow("+I", "US Dollar", 114L, "2022-01-01"));
-        collectAndCheckBatchReadWrite(
-                true, true, "dt <> '2022-01-02'", Collections.emptyList(), expected);
 
-        collectAndCheckBatchReadWrite(
-                true, true, "dt IN ('2022-01-01')", Collections.emptyList(), expected);
+        testBatchRead(buildQuery(table, "*", "WHERE dt <> '2022-01-02'"), expectedPartitionRecords);
+
+        testBatchRead(
+                buildQuery(table, "*", "WHERE dt IN ('2022-01-01')"), expectedPartitionRecords);
 
         // test field filter
-        collectAndCheckBatchReadWrite(
-                true,
-                true,
-                "rate >= 100",
-                Collections.emptyList(),
+        testBatchRead(
+                buildQuery(table, "*", "WHERE rate >= 100"),
                 Arrays.asList(
-                        // part = 2022-01-01
                         changelogRow("+I", "US Dollar", 114L, "2022-01-01"),
                         changelogRow("+I", "Euro", 114L, "2022-01-01"),
-                        // part = 2022-01-02
-                        changelogRow("+I", "Euro", 119L, "2022-01-02")));
+                        changelogRow("+I", "Euro", 100L, "2022-01-02")));
 
         // test partition and field filter
-        collectAndCheckBatchReadWrite(
-                true,
-                true,
-                "rate >= 100 AND dt = '2022-01-02'",
-                Collections.emptyList(),
-                Collections.singletonList(changelogRow("+I", "Euro", 119L, "2022-01-02")));
+        testBatchRead(
+                buildQuery(table, "*", "WHERE dt = '2022-01-02' AND rate >= 100"),
+                Collections.singletonList(changelogRow("+I", "Euro", 100L, "2022-01-02")));
 
         // test projection
-        collectAndCheckBatchReadWrite(
-                true,
-                true,
-                null,
-                Collections.singletonList("dt"),
+        testBatchRead(
+                buildQuery(table, "dt", ""),
                 Arrays.asList(
-                        changelogRow("+I", "2022-01-01"), // US Dollar
-                        changelogRow("+I", "2022-01-01"), // Yen
-                        changelogRow("+I", "2022-01-01"), // Euro
-                        changelogRow("+I", "2022-01-02"))); // Euro
+                        changelogRow("+I", "2022-01-01"),
+                        changelogRow("+I", "2022-01-01"),
+                        changelogRow("+I", "2022-01-01"),
+                        changelogRow("+I", "2022-01-02"),
+                        changelogRow("+I", "2022-01-02")));
 
-        collectAndCheckBatchReadWrite(
-                true,
-                true,
-                null,
-                Collections.singletonList("dt, currency, rate"),
+        testBatchRead(
+                buildQuery(table, "dt, currency, rate", ""),
                 Arrays.asList(
-                        changelogRow("+I", "2022-01-01", "US Dollar", 114L), // US Dollar
-                        changelogRow("+I", "2022-01-01", "Yen", 1L), // Yen
-                        changelogRow("+I", "2022-01-01", "Euro", 114L), // Euro
-                        changelogRow("+I", "2022-01-02", "Euro", 119L))); // Euro
+                        changelogRow("+I", "2022-01-01", "US Dollar", 114L),
+                        changelogRow("+I", "2022-01-01", "Yen", 1L),
+                        changelogRow("+I", "2022-01-01", "Euro", 114L),
+                        changelogRow("+I", "2022-01-02", "Euro", 100L),
+                        changelogRow("+I", "2022-01-02", "Yen", 1L)));
 
         // test projection and filter
-        collectAndCheckBatchReadWrite(
-                true,
-                true,
-                "rate = 114",
-                Collections.singletonList("rate"),
+        testBatchRead(
+                buildQuery(table, "currency, dt", "WHERE rate = 114"),
                 Arrays.asList(
-                        changelogRow("+I", 114L), // US Dollar
-                        changelogRow("+I", 114L) // Euro
-                        ));
+                        changelogRow("+I", "US Dollar", "2022-01-01"),
+                        changelogRow("+I", "Euro", "2022-01-01")));
     }
 
     @Test
-    public void testBatchWriteWithPartitionedRecordsWithoutPk() throws Exception {
-        // input is dailyRates()
-
-        // test batch read
-        String managedTable =
-                collectAndCheckBatchReadWrite(
-                        true, false, null, Collections.emptyList(), dailyRates().f0);
-        checkFileStorePath(tEnv, managedTable, dailyRates().f1);
-
-        // overwrite dynamic partition
-        prepareEnvAndOverwrite(
-                managedTable,
-                Collections.emptyMap(),
+    public void testBatchReadWriteWithPartitionedRecordsWithoutPk() throws Exception {
+        List<Row> initialRecords =
                 Arrays.asList(
-                        new String[] {"'Euro'", "90", "'2022-01-01'"},
-                        new String[] {"'Yen'", "2", "'2022-01-02'"}));
+                        // dt = 2022-01-01
+                        changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                        changelogRow("+I", "Euro", 114L, "2022-01-01"),
+                        changelogRow("+I", "Yen", 1L, "2022-01-01"),
+                        changelogRow("+I", "Euro", 114L, "2022-01-01"),
+                        changelogRow("+I", "US Dollar", 114L, "2022-01-01"),
+                        // dt = 2022-01-02
+                        changelogRow("+I", "Euro", 119L, "2022-01-02"));
+
+        String table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt String"),
+                        Collections.emptyList(),
+                        Collections.singletonList("dt"));
+
+        insertInto(
+                table,
+                "('US Dollar', 102, '2022-01-01')",
+                "('Euro', 114, '2022-01-01')",
+                "('Yen', 1, '2022-01-01')",
+                "('Euro', 114, '2022-01-01')",
+                "('US Dollar', 114, '2022-01-01')",
+                "('Euro', 119, '2022-01-02')");
+
+        checkFileStorePath(table, Arrays.asList("dt=2022-01-01", "dt=2022-01-02"));
+
+        testBatchRead(buildSimpleQuery(table), initialRecords);
+
+        // overwrite
+        insertOverwrite(table, "('Euro', 90, '2022-01-01')", "('Yen', 2, '2022-01-02')");
 
         // test streaming read
-        final StreamTableEnvironment streamTableEnv =
-                StreamTableEnvironment.create(buildStreamEnv());
-        registerTable(streamTableEnv, managedTable);
-        collectAndCheck(
-                        streamTableEnv,
-                        managedTable,
-                        Collections.emptyMap(),
-                        "dt IN ('2022-01-01', '2022-01-02')",
+        testStreamingRead(
+                        buildSimpleQuery(table),
                         Arrays.asList(
-                                // part = 2022-01-01
                                 changelogRow("+I", "Euro", 90L, "2022-01-01"),
-                                // part = 2022-01-02
                                 changelogRow("+I", "Yen", 2L, "2022-01-02")))
                 .close();
 
+        // overwrite with initial data
+        insertOverwrite(
+                table,
+                "('US Dollar', 102, '2022-01-01')",
+                "('Euro', 114, '2022-01-01')",
+                "('Yen', 1, '2022-01-01')",
+                "('Euro', 114, '2022-01-01')",
+                "('US Dollar', 114, '2022-01-01')",
+                "('Euro', 119, '2022-01-02')");
+
         // test partition filter
-        collectAndCheckBatchReadWrite(
-                true, false, "dt >= '2022-01-01'", Collections.emptyList(), dailyRates().f0);
+        testBatchRead(buildQuery(table, "*", "WHERE dt >= '2022-01-01'"), initialRecords);
 
         // test field filter
-        collectAndCheckBatchReadWrite(
-                true,
-                false,
-                "currency = 'US Dollar'",
-                Collections.emptyList(),
+        testBatchRead(
+                buildQuery(table, "*", "WHERE currency = 'US Dollar'"),
                 Arrays.asList(
-                        // part = 2022-01-01
                         changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
-                        // part = 2022-01-01
                         changelogRow("+I", "US Dollar", 114L, "2022-01-01")));
 
         // test partition and field filter
-        collectAndCheckBatchReadWrite(
-                true,
-                false,
-                "dt = '2022-01-01' OR rate > 115",
-                Collections.emptyList(),
-                dailyRates().f0);
+        testBatchRead(
+                buildQuery(table, "*", "WHERE dt = '2022-01-01' OR rate > 115"), initialRecords);
 
         // test projection
-        collectAndCheckBatchReadWrite(
-                true,
-                false,
-                null,
-                Collections.singletonList("currency"),
+        testBatchRead(
+                buildQuery(table, "currency", ""),
                 Arrays.asList(
                         changelogRow("+I", "US Dollar"),
                         changelogRow("+I", "US Dollar"),
@@ -266,102 +271,105 @@ public class ReadWriteTableITCase extends ReadWriteTableTestBase {
                         changelogRow("+I", "Euro")));
 
         // test projection and filter
-        collectAndCheckBatchReadWrite(
-                true,
-                false,
-                "rate = 119",
-                Arrays.asList("currency", "dt"),
+        testBatchRead(
+                buildQuery(table, "currency, dt", "WHERE rate = 119"),
                 Collections.singletonList(changelogRow("+I", "Euro", "2022-01-02")));
     }
 
     @Test
-    public void testBatchWriteWithNonPartitionedRecordsWithPk() throws Exception {
-        // input is rates()
-        String managedTable =
-                collectAndCheckBatchReadWrite(
-                        false,
-                        true,
-                        null,
-                        Collections.emptyList(),
-                        Arrays.asList(
-                                changelogRow("+I", "US Dollar", 102L),
-                                changelogRow("+I", "Yen", 1L),
-                                changelogRow("+I", "Euro", 119L)));
-        checkFileStorePath(tEnv, managedTable, null);
+    public void testBatchReadWriteWithNonPartitionedRecordsWithPk() throws Exception {
+        List<Row> initialRecords =
+                Arrays.asList(
+                        changelogRow("+I", "US Dollar", 102L),
+                        changelogRow("+I", "Yen", 1L),
+                        changelogRow("+I", "Euro", 119L));
 
-        // overwrite the whole table
-        prepareEnvAndOverwrite(
-                managedTable,
-                Collections.emptyMap(),
-                Collections.singletonList(new String[] {"'Euro'", "100"}));
-        collectAndCheck(
-                tEnv,
-                managedTable,
-                Collections.emptyMap(),
-                null,
+        String table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.singletonList("currency"),
+                        Collections.emptyList());
+
+        insertInto(table, "('US Dollar', 102)", "('Yen', 1)", "('Euro', 119)");
+
+        checkFileStorePath(table, Collections.emptyList());
+
+        testBatchRead(buildQuery(table, "*", ""), initialRecords);
+
+        // overwrite
+        insertOverwrite(table, "('Euro', 100)");
+
+        testBatchRead(
+                buildSimpleQuery(table),
                 Collections.singletonList(changelogRow("+I", "Euro", 100L)));
 
-        // test field filter
-        collectAndCheckBatchReadWrite(
-                false,
-                true,
-                "currency = 'Euro'",
-                Collections.emptyList(),
-                Collections.singletonList(changelogRow("+I", "Euro", 119L)));
+        // overwrite with initial data
+        insertOverwrite(table, "('US Dollar', 102)", "('Yen', 1)", "('Euro', 119)");
 
-        collectAndCheckBatchReadWrite(
-                false,
-                true,
-                "119 >= rate AND 102 < rate",
-                Collections.emptyList(),
-                Collections.singletonList(changelogRow("+I", "Euro", 119L)));
+        // test field filter
+        List<Row> expectedFieldRecords =
+                Collections.singletonList(changelogRow("+I", "Euro", 119L));
+
+        testBatchRead(buildQuery(table, "*", "WHERE currency = 'Euro'"), expectedFieldRecords);
+
+        testBatchRead(
+                buildQuery(table, "*", "WHERE rate > 102 AND rate <= 119"), expectedFieldRecords);
 
         // test projection
-        collectAndCheckBatchReadWrite(
-                false,
-                true,
-                null,
-                Arrays.asList("rate", "currency"),
+        testBatchRead(
+                buildQuery(table, "currency", ""),
                 Arrays.asList(
-                        changelogRow("+I", 102L, "US Dollar"),
-                        changelogRow("+I", 1L, "Yen"),
-                        changelogRow("+I", 119L, "Euro")));
+                        changelogRow("+I", "US Dollar"),
+                        changelogRow("+I", "Yen"),
+                        changelogRow("+I", "Euro")));
 
         // test projection and filter
-        collectAndCheckBatchReadWrite(
-                false,
-                true,
-                "currency IN ('Yen')",
-                Collections.singletonList("rate"),
+        testBatchRead(
+                buildQuery(table, "rate", "WHERE currency IN ('Yen')"),
                 Collections.singletonList(changelogRow("+I", 1L)));
     }
 
     @Test
-    public void testBatchWriteNonPartitionedRecordsWithoutPk() throws Exception {
-        // input is rates()
-        String managedTable =
-                collectAndCheckBatchReadWrite(false, false, null, Collections.emptyList(), rates());
-        checkFileStorePath(tEnv, managedTable, null);
+    public void testBatchReadWriteWithNonPartitionedRecordsWithoutPk() throws Exception {
+        List<Row> initialRecords =
+                Arrays.asList(
+                        changelogRow("+I", "US Dollar", 102L),
+                        changelogRow("+I", "Euro", 114L),
+                        changelogRow("+I", "Yen", 1L),
+                        changelogRow("+I", "Euro", 114L),
+                        changelogRow("+I", "Euro", 119L));
+
+        String table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.emptyList(),
+                        Collections.emptyList());
+
+        insertInto(
+                table,
+                "('US Dollar', 102)",
+                "('Euro', 114)",
+                "('Yen', 1)",
+                "('Euro', 114)",
+                "('Euro', 119)");
+
+        checkFileStorePath(table, Collections.emptyList());
+
+        testBatchRead(buildSimpleQuery(table), initialRecords);
 
         // test field filter
-        collectAndCheckBatchReadWrite(
-                false,
-                false,
-                "currency = 'Euro'",
-                Collections.emptyList(),
+        testBatchRead(buildQuery(table, "*", "WHERE rate >= 1"), initialRecords);
+
+        testBatchRead(
+                buildQuery(table, "*", "WHERE currency = 'Euro'"),
                 Arrays.asList(
                         changelogRow("+I", "Euro", 114L),
                         changelogRow("+I", "Euro", 114L),
                         changelogRow("+I", "Euro", 119L)));
 
-        collectAndCheckBatchReadWrite(false, false, "rate >= 1", Collections.emptyList(), rates());
-
         // test projection
-        collectAndCheckBatchReadWrite(
-                false,
-                false,
-                null,
-                Collections.singletonList("currency"),
+        testBatchRead(
+                buildQuery(table, "currency", ""),
                 Arrays.asList(
                         changelogRow("+I", "Euro"),
                         changelogRow("+I", "Euro"),
@@ -370,11 +378,8 @@ public class ReadWriteTableITCase extends ReadWriteTableTestBase {
                         changelogRow("+I", "US Dollar")));
 
         // test projection and filter
-        collectAndCheckBatchReadWrite(
-                false,
-                false,
-                "rate > 100 OR currency = 'Yen'",
-                Collections.singletonList("currency"),
+        testBatchRead(
+                buildQuery(table, "currency", "WHERE rate > 100 OR currency = 'Yen'"),
                 Arrays.asList(
                         changelogRow("+I", "Euro"),
                         changelogRow("+I", "Euro"),
@@ -383,68 +388,352 @@ public class ReadWriteTableITCase extends ReadWriteTableTestBase {
                         changelogRow("+I", "US Dollar")));
     }
 
+    // ----------------------------------------------------------------------------------------------------------------
+    // Streaming Read & Write
+    // ----------------------------------------------------------------------------------------------------------------
+
+    @Test
+    public void testStreamingReadWriteWithPartitionedRecordsWithPk() throws Exception {
+        // file store continuous read
+        // will not merge, at least collect two records
+        List<Row> initialRecords =
+                Arrays.asList(
+                        // dt = 2022-01-01
+                        changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                        changelogRow("+I", "Euro", 114L, "2022-01-01"),
+                        changelogRow("+I", "Yen", 1L, "2022-01-01"),
+                        changelogRow("+U", "Euro", 116L, "2022-01-01"),
+                        changelogRow("-D", "Yen", 1L, "2022-01-01"),
+                        changelogRow("-D", "Euro", 116L, "2022-01-01"),
+                        // dt = 2022-01-02
+                        changelogRow("+I", "Euro", 119L, "2022-01-02"),
+                        changelogRow("+U", "Euro", 119L, "2022-01-02"));
+
+        String temporaryTable =
+                createTemporaryTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Arrays.asList("currency", "dt"),
+                        Collections.singletonList("dt"),
+                        initialRecords,
+                        "dt:2022-01-01;dt:2022-01-02",
+                        false,
+                        "I,UA,D");
+
+        String table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Arrays.asList("currency", "dt"),
+                        Collections.singletonList("dt"));
+
+        insertIntoFromTable(temporaryTable, table);
+
+        sEnv.executeSql(String.format("INSERT INTO `%s` SELECT * FROM `%s`", table, temporaryTable))
+                .await();
+
+        checkFileStorePath(table, Arrays.asList("dt=2022-01-01", "dt=2022-01-02"));
+
+        testStreamingRead(
+                        buildSimpleQuery(table),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                                changelogRow("+I", "Euro", 119L, "2022-01-02")))
+                .close();
+
+        // test partition filter
+        testStreamingRead(
+                        buildQuery(table, "*", "WHERE dt < '2022-01-02'"),
+                        Collections.singletonList(
+                                changelogRow("+I", "US Dollar", 102L, "2022-01-01")))
+                .close();
+
+        // test field filter
+        testStreamingRead(
+                        buildQuery(table, "*", "WHERE rate = 102"),
+                        Collections.singletonList(
+                                changelogRow("+I", "US Dollar", 102L, "2022-01-01")))
+                .close();
+
+        // test partition and field filter
+        testStreamingRead(
+                        buildQuery(table, "*", "WHERE rate = 102 OR dt < '2022-01-02'"),
+                        Collections.singletonList(
+                                // part = 2022-01-01
+                                changelogRow("+I", "US Dollar", 102L, "2022-01-01")))
+                .close();
+
+        // test projection and filter
+        testStreamingRead(
+                        buildQuery(table, "currency", "WHERE rate = 102 OR dt < '2022-01-02'"),
+                        Collections.singletonList(changelogRow("+I", "US Dollar")))
+                .close();
+    }
+
+    @Test
+    public void testStreamingReadWriteWithPartitionedRecordsWithoutPk() throws Exception {
+        // file store bounded read with merge
+        List<Row> initialRecords =
+                Arrays.asList(
+                        // dt = 2022-01-01
+                        changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                        changelogRow("+I", "Euro", 116L, "2022-01-01"),
+                        changelogRow("-D", "Euro", 116L, "2022-01-01"),
+                        changelogRow("+I", "Yen", 1L, "2022-01-01"),
+                        changelogRow("-D", "Yen", 1L, "2022-01-01"),
+                        // dt = 2022-01-02
+                        changelogRow("+I", "Euro", 114L, "2022-01-02"),
+                        changelogRow("-U", "Euro", 114L, "2022-01-02"),
+                        changelogRow("+U", "Euro", 119L, "2022-01-02"),
+                        changelogRow("-D", "Euro", 119L, "2022-01-02"),
+                        changelogRow("+I", "Euro", 115L, "2022-01-02"));
+
+        String temporaryTable =
+                createTemporaryTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Collections.emptyList(),
+                        Collections.singletonList("dt"),
+                        initialRecords,
+                        "dt:2022-01-01;dt:2022-01-02",
+                        false,
+                        "I,UA,UB,D");
+
+        String table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Collections.emptyList(),
+                        Collections.singletonList("dt"));
+
+        insertIntoFromTable(temporaryTable, table);
+
+        checkFileStorePath(table, Arrays.asList("dt=2022-01-01", "dt=2022-01-02"));
+
+        testStreamingRead(
+                        buildSimpleQuery(table),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                                changelogRow("+I", "Euro", 115L, "2022-01-02")))
+                .close();
+
+        // test partition filter
+        testStreamingRead(
+                        buildQuery(table, "*", "WHERE dt IS NOT NULL"),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                                changelogRow("+I", "Euro", 115L, "2022-01-02")))
+                .close();
+
+        testStreamingRead(buildQuery(table, "*", "WHERE dt IS NULL"), Collections.emptyList())
+                .close();
+
+        // test field filter
+        testStreamingRead(
+                        buildQuery(table, "*", "WHERE currency = 'US Dollar' OR rate = 115"),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                                changelogRow("+I", "Euro", 115L, "2022-01-02")))
+                .close();
+
+        // test partition and field filter
+        testStreamingRead(
+                        buildQuery(
+                                table,
+                                "*",
+                                "WHERE (dt = '2022-01-02' AND currency = 'US Dollar') OR (dt = '2022-01-01' AND rate = 115)"),
+                        Collections.emptyList())
+                .close();
+
+        // test projection
+        testStreamingRead(
+                        buildQuery(table, "rate", ""),
+                        Arrays.asList(changelogRow("+I", 102L), changelogRow("+I", 115L)))
+                .close();
+
+        // test projection and filter
+        testStreamingRead(
+                        buildQuery(table, "rate", "WHERE dt <> '2022-01-01'"),
+                        Collections.singletonList(changelogRow("+I", 115L)))
+                .close();
+    }
+
+    @Test
+    void testStreamingReadWriteWithNonPartitionedRecordsWithPk() throws Exception {
+        // file store bounded read with merge
+        List<Row> initialRecords =
+                Arrays.asList(
+                        changelogRow("+I", "US Dollar", 102L),
+                        changelogRow("+I", "Euro", 114L),
+                        changelogRow("+I", "Yen", 1L),
+                        changelogRow("+U", "Euro", 116L),
+                        changelogRow("-D", "Euro", 116L),
+                        changelogRow("+I", "Euro", 119L),
+                        changelogRow("+U", "Euro", 119L),
+                        changelogRow("-D", "Yen", 1L));
+
+        String temporaryTable =
+                createTemporaryTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.singletonList("currency"),
+                        Collections.emptyList(),
+                        initialRecords,
+                        null,
+                        false,
+                        "I,UA,D");
+
+        String table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.singletonList("currency"),
+                        Collections.emptyList());
+
+        insertIntoFromTable(temporaryTable, table);
+
+        checkFileStorePath(table, Collections.emptyList());
+
+        testStreamingRead(
+                        buildSimpleQuery(table),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L),
+                                changelogRow("+I", "Euro", 119L)))
+                .close();
+
+        // test field filter
+        testStreamingRead(buildQuery(table, "*", "WHERE currency = 'Yen'"), Collections.emptyList())
+                .close();
+
+        // test projection
+        testStreamingRead(
+                        buildQuery(table, "currency", ""),
+                        Arrays.asList(changelogRow("+I", "US Dollar"), changelogRow("+I", "Euro")))
+                .close();
+
+        // test projection and filter
+        testStreamingRead(
+                        buildQuery(table, "currency", "WHERE rate = 102"),
+                        Collections.singletonList(changelogRow("+I", "US Dollar")))
+                .close();
+    }
+
+    @Test
+    public void testStreamingReadWriteWithNonPartitionedRecordsWithoutPk() throws Exception {
+        // default full scan mode, will merge
+        List<Row> initialRecords =
+                Arrays.asList(
+                        changelogRow("+I", "US Dollar", 102L),
+                        changelogRow("+I", "Euro", 114L),
+                        changelogRow("+I", "Yen", 1L),
+                        changelogRow("-U", "Euro", 114L),
+                        changelogRow("+U", "Euro", 116L),
+                        changelogRow("-D", "Euro", 116L),
+                        changelogRow("+I", "Euro", 119L),
+                        changelogRow("-U", "Euro", 119L),
+                        changelogRow("+U", "Euro", 119L),
+                        changelogRow("-D", "Yen", 1L),
+                        changelogRow("+I", null, 100L),
+                        changelogRow("+I", "HK Dollar", null));
+
+        String temporaryTable =
+                createTemporaryTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        initialRecords,
+                        null,
+                        false,
+                        "I,UA,UB,D");
+
+        String table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.emptyList(),
+                        Collections.emptyList());
+
+        insertIntoFromTable(temporaryTable, table);
+
+        checkFileStorePath(table, Collections.emptyList());
+
+        testStreamingRead(
+                        buildSimpleQuery(table),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L),
+                                changelogRow("+I", "Euro", 119L),
+                                changelogRow("+I", null, 100L),
+                                changelogRow("+I", "HK Dollar", null)))
+                .close();
+
+        // test field filter
+        testStreamingRead(
+                        buildQuery(table, "*", "WHERE currency IS NOT NULL"),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L),
+                                changelogRow("+I", "Euro", 119L),
+                                changelogRow("+I", "HK Dollar", null)))
+                .close();
+
+        testStreamingRead(
+                        buildQuery(table, "*", "WHERE rate IS NOT NULL"),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L),
+                                changelogRow("+I", "Euro", 119L),
+                                changelogRow("+I", null, 100L)))
+                .close();
+
+        // test projection and filter
+        testStreamingRead(
+                        buildQuery(
+                                table, "rate", "WHERE currency IS NOT NULL AND rate IS NOT NULL"),
+                        Arrays.asList(changelogRow("+I", 102L), changelogRow("+I", 119L)))
+                .close();
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // Purge data using overwrite
+    // ----------------------------------------------------------------------------------------------------------------
+
     @Test
     public void testPurgeTableUsingBatchOverWrite() throws Exception {
-        TableEnvironment tEnv =
-                TableEnvironment.create(EnvironmentSettings.newInstance().inBatchMode().build());
-        tEnv.executeSql(
-                String.format(
-                        "CREATE CATALOG test_catalog WITH ("
-                                + "'type'='table-store', 'warehouse'='%s')",
-                        TEMPORARY_FOLDER.newFolder().toURI()));
-        tEnv.useCatalog("test_catalog");
-        tEnv.executeSql("CREATE TABLE test (k1 INT, k2 STRING, v STRING)");
+        String table =
+                createTable(
+                        Arrays.asList("k0 INT", "k1 STRING", "v STRING"),
+                        Collections.emptyList(),
+                        Collections.emptyList());
 
-        validateOverwriteResult(tEnv, "test", "", "*", Collections.emptyList());
+        validateOverwriteResult(table, "", "*", Collections.emptyList());
     }
 
     @Test
     public void testPurgePartitionUsingBatchOverWrite() throws Exception {
-        TableEnvironment tEnv =
-                TableEnvironment.create(EnvironmentSettings.newInstance().inBatchMode().build());
-        tEnv.executeSql(
-                String.format(
-                        "CREATE CATALOG test_catalog WITH ("
-                                + "'type'='table-store', 'warehouse'='%s')",
-                        TEMPORARY_FOLDER.newFolder().toURI()));
-        tEnv.useCatalog("test_catalog");
+        List<String> fieldsSpec = Arrays.asList("k0 INT", "k1 STRING", "v STRING");
 
         // single partition key
-        tEnv.executeSql(
-                "CREATE TABLE test_single (k1 INT, k2 STRING, v STRING) PARTITIONED BY (k1)");
+        String table =
+                createTable(fieldsSpec, Collections.emptyList(), Collections.singletonList("k0"));
 
         validateOverwriteResult(
-                tEnv,
-                "test_single",
-                "PARTITION (k1 = 0)",
-                "k2, v",
+                table,
+                "PARTITION (k0 = 0)",
+                "k1, v",
                 Arrays.asList(
                         changelogRow("+I", 1, "2023-01-01", "flink"),
                         changelogRow("+I", 1, "2023-01-02", "table"),
                         changelogRow("+I", 1, "2023-01-02", "store")));
 
         // multiple partition keys and overwrite one partition key
-        tEnv.executeSql(
-                "CREATE TABLE test_multiple0 (k1 INT, k2 STRING, v STRING) PARTITIONED BY (k1, k2)");
+        table = createTable(fieldsSpec, Collections.emptyList(), Arrays.asList("k0", "k1"));
 
         validateOverwriteResult(
-                tEnv,
-                "test_multiple0",
-                "PARTITION (k1 = 0)",
-                "k2, v",
+                table,
+                "PARTITION (k0 = 0)",
+                "k1, v",
                 Arrays.asList(
                         changelogRow("+I", 1, "2023-01-01", "flink"),
                         changelogRow("+I", 1, "2023-01-02", "table"),
                         changelogRow("+I", 1, "2023-01-02", "store")));
 
         // multiple partition keys and overwrite all partition keys
-        tEnv.executeSql(
-                "CREATE TABLE test_multiple1 (k1 INT, k2 STRING, v STRING) PARTITIONED BY (k1, k2)");
+        table = createTable(fieldsSpec, Collections.emptyList(), Arrays.asList("k0", "k1"));
 
         validateOverwriteResult(
-                tEnv,
-                "test_multiple1",
-                "PARTITION (k1 = 0, k2 = '2023-01-01')",
+                table,
+                "PARTITION (k0 = 0, k1 = '2023-01-01')",
                 "v",
                 Arrays.asList(
                         changelogRow("+I", 0, "2023-01-02", "world"),
@@ -453,911 +742,40 @@ public class ReadWriteTableITCase extends ReadWriteTableTestBase {
                         changelogRow("+I", 1, "2023-01-02", "store")));
     }
 
-    @Test
-    public void testEnableLogAndStreamingReadWritePartitionedRecordsWithPk() throws Exception {
-        // input is dailyRatesChangelogWithoutUB()
-        // test hybrid read
-        Tuple2<String, BlockingIterator<Row, Row>> tuple =
-                collectAndCheckStreamingReadWriteWithoutClose(
-                        Collections.emptyMap(),
-                        "dt >= '2022-01-01' AND dt <= '2022-01-03' OR currency = 'HK Dollar'",
-                        Collections.emptyList(),
-                        Arrays.asList(
-                                // part = 2022-01-01
-                                changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
-                                // part = 2022-01-02
-                                changelogRow("+I", "Euro", 119L, "2022-01-02")));
-        String managedTable = tuple.f0;
-        checkFileStorePath(tEnv, managedTable, dailyRatesChangelogWithoutUB().f1);
-        BlockingIterator<Row, Row> streamIter = tuple.f1;
-
-        // test log store in hybrid mode accepts all filters
-        tEnv.executeSql(
-                        String.format(
-                                "INSERT INTO `%s` PARTITION (dt = '2022-01-03')\n"
-                                        + "VALUES('HK Dollar', 100), ('Yen', 20)\n",
-                                managedTable))
-                .await();
-
-        tEnv.executeSql(
-                        String.format(
-                                "INSERT INTO `%s` PARTITION (dt = '2022-01-04')\n"
-                                        + "VALUES('Yen', 20)\n",
-                                managedTable))
-                .await();
-
-        assertThat(streamIter.collect(2, 10, TimeUnit.SECONDS))
-                .containsExactlyInAnyOrderElementsOf(
-                        Arrays.asList(
-                                changelogRow("+I", "HK Dollar", 100L, "2022-01-03"),
-                                changelogRow("+I", "Yen", 20L, "2022-01-03")));
-
-        // overwrite partition 2022-01-02
-        prepareEnvAndOverwrite(
-                managedTable,
-                Collections.singletonMap("dt", "'2022-01-02'"),
-                Arrays.asList(new String[] {"'Euro'", "100"}, new String[] {"'Yen'", "1"}));
-
-        // batch read to check data refresh
-        final StreamTableEnvironment batchTableEnv =
-                StreamTableEnvironment.create(buildBatchEnv(), EnvironmentSettings.inBatchMode());
-        registerTable(batchTableEnv, managedTable);
-        collectAndCheck(
-                batchTableEnv,
-                managedTable,
-                Collections.emptyMap(),
-                null,
-                Arrays.asList(
-                        // part = 2022-01-01
-                        changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
-                        // part = 2022-01-02
-                        changelogRow("+I", "Euro", 100L, "2022-01-02"),
-                        changelogRow("+I", "Yen", 1L, "2022-01-02"),
-                        // part = 2022-01-03
-                        changelogRow("+I", "HK Dollar", 100L, "2022-01-03"),
-                        changelogRow("+I", "Yen", 20L, "2022-01-03"),
-                        // part = 2022-01-04
-                        changelogRow("+I", "Yen", 20L, "2022-01-04")));
-
-        // check no changelog generated for streaming read
-        assertNoMoreRecords(streamIter);
-
-        // filter on partition
-        collectAndCheckStreamingReadWriteWithClose(
-                true,
-                true,
-                true,
-                Collections.emptyMap(),
-                "dt = '2022-01-01'",
-                Collections.emptyList(),
-                Collections.singletonList(changelogRow("+I", "US Dollar", 102L, "2022-01-01")));
-
-        // test field filter
-        collectAndCheckStreamingReadWriteWithClose(
-                true,
-                true,
-                true,
-                Collections.emptyMap(),
-                "currency = 'US Dollar'",
-                Collections.emptyList(),
-                Collections.singletonList(changelogRow("+I", "US Dollar", 102L, "2022-01-01")));
-
-        // test partition and field filter
-        collectAndCheckStreamingReadWriteWithClose(
-                true,
-                true,
-                true,
-                Collections.emptyMap(),
-                "dt = '2022-01-01' AND rate = 1",
-                Collections.emptyList(),
-                Collections.emptyList());
-
-        // test projection and filter
-        collectAndCheckStreamingReadWriteWithClose(
-                true,
-                true,
-                true,
-                Collections.emptyMap(),
-                "dt = '2022-01-02' AND currency = 'Euro'",
-                Arrays.asList("rate", "dt", "currency"),
-                Collections.singletonList(changelogRow("+I", 119L, "2022-01-02", "Euro")));
-    }
-
-    @Test
-    public void testDisableLogAndStreamingReadWritePartitionedRecordsWithPk() throws Exception {
-        // input is dailyRatesChangelogWithoutUB()
-        // file store continuous read
-        // will not merge, at least collect two records
-        checkFileStorePath(
-                tEnv,
-                collectAndCheckStreamingReadWriteWithClose(
-                        false,
-                        true,
-                        true,
-                        Collections.emptyMap(),
-                        null,
-                        Collections.emptyList(),
-                        Arrays.asList(
-                                // part = 2022-01-01
-                                changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
-                                // part = 2022-01-02
-                                changelogRow("+I", "Euro", 119L, "2022-01-02"))),
-                dailyRatesChangelogWithoutUB().f1);
-
-        // test partition filter
-        collectAndCheckStreamingReadWriteWithClose(
-                false,
-                true,
-                true,
-                Collections.emptyMap(),
-                "dt < '2022-01-02'",
-                Collections.emptyList(),
-                Collections.singletonList(
-                        // part = 2022-01-01
-                        changelogRow("+I", "US Dollar", 102L, "2022-01-01")));
-
-        // test field filter
-        collectAndCheckStreamingReadWriteWithClose(
-                false,
-                true,
-                true,
-                Collections.emptyMap(),
-                "rate = 102",
-                Collections.emptyList(),
-                Collections.singletonList(
-                        // part = 2022-01-01
-                        changelogRow("+I", "US Dollar", 102L, "2022-01-01")));
-
-        // test partition and field filter
-        collectAndCheckStreamingReadWriteWithClose(
-                false,
-                true,
-                true,
-                Collections.emptyMap(),
-                "rate = 102 or dt < '2022-01-02'",
-                Collections.emptyList(),
-                Collections.singletonList(
-                        // part = 2022-01-01
-                        changelogRow("+I", "US Dollar", 102L, "2022-01-01")));
-
-        // test projection and filter
-        collectAndCheckStreamingReadWriteWithClose(
-                false,
-                true,
-                true,
-                Collections.emptyMap(),
-                "rate = 102 or dt < '2022-01-02'",
-                Collections.singletonList("currency"),
-                Collections.singletonList(
-                        // part = 2022-01-01
-                        changelogRow("+I", "US Dollar")));
-    }
-
-    @Test
-    public void testStreamingReadWritePartitionedRecordsWithoutPk() throws Exception {
-        // input is dailyRatesChangelogWithUB()
-        // enable log store, file store bounded read with merge
-        checkFileStorePath(
-                tEnv,
-                collectAndCheckStreamingReadWriteWithClose(
-                        true,
-                        true,
-                        false,
-                        Collections.emptyMap(),
-                        null,
-                        Collections.emptyList(),
-                        Arrays.asList(
-                                // part = 2022-01-01
-                                changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
-                                // part = 2022-01-02
-                                changelogRow("+I", "Euro", 115L, "2022-01-02"))),
-                dailyRatesChangelogWithUB().f1);
-
-        // test partition filter
-        collectAndCheckStreamingReadWriteWithClose(
-                true,
-                true,
-                false,
-                Collections.emptyMap(),
-                "dt IS NOT NULL",
-                Collections.emptyList(),
-                Arrays.asList(
-                        // part = 2022-01-01
-                        changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
-                        // part = 2022-01-02
-                        changelogRow("+I", "Euro", 115L, "2022-01-02")));
-
-        collectAndCheckStreamingReadWriteWithClose(
-                true,
-                true,
-                false,
-                Collections.emptyMap(),
-                "dt IS NULL",
-                Collections.emptyList(),
-                Collections.emptyList());
-
-        // test field filter
-        collectAndCheckStreamingReadWriteWithClose(
-                true,
-                true,
-                false,
-                Collections.emptyMap(),
-                "currency = 'US Dollar' OR rate = 115",
-                Collections.emptyList(),
-                Arrays.asList(
-                        // part = 2022-01-01
-                        changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
-                        // part = 2022-01-02
-                        changelogRow("+I", "Euro", 115L, "2022-01-02")));
-
-        // test partition and field filter
-        collectAndCheckStreamingReadWriteWithClose(
-                true,
-                true,
-                false,
-                Collections.emptyMap(),
-                "(dt = '2022-01-02' AND currency = 'US Dollar') OR (dt = '2022-01-01' AND rate = 115)",
-                Collections.emptyList(),
-                Collections.emptyList());
-
-        // test projection
-        collectAndCheckStreamingReadWriteWithClose(
-                true,
-                true,
-                false,
-                Collections.emptyMap(),
-                null,
-                Collections.singletonList("rate"),
-                Arrays.asList(
-                        // part = 2022-01-01
-                        changelogRow("+I", 102L),
-                        // part = 2022-01-02
-                        changelogRow("+I", 115L)));
-
-        // test projection and filter
-        collectAndCheckStreamingReadWriteWithClose(
-                true,
-                true,
-                false,
-                Collections.emptyMap(),
-                "dt <> '2022-01-01'",
-                Collections.singletonList("rate"),
-                Collections.singletonList(
-                        // part = 2022-01-02, Euro
-                        changelogRow("+I", 115L)));
-    }
-
-    @Test
-    public void testStreamingReadWriteNonPartitionedRecordsWithPk() throws Exception {
-        // input is ratesChangelogWithoutUB()
-        // enable log store, file store bounded read with merge
-        checkFileStorePath(
-                tEnv,
-                collectAndCheckStreamingReadWriteWithClose(
-                        true,
-                        false,
-                        true,
-                        Collections.emptyMap(),
-                        null,
-                        Collections.emptyList(),
-                        Arrays.asList(
-                                changelogRow("+I", "US Dollar", 102L),
-                                changelogRow("+I", "Euro", 119L))),
-                null);
-
-        // test field filter
-        collectAndCheckStreamingReadWriteWithClose(
-                true,
-                false,
-                true,
-                Collections.emptyMap(),
-                "currency = 'Yen'",
-                Collections.emptyList(),
-                Collections.emptyList());
-
-        // test projection
-        collectAndCheckStreamingReadWriteWithClose(
-                true,
-                false,
-                true,
-                Collections.emptyMap(),
-                null,
-                Collections.singletonList("currency"),
-                Arrays.asList(changelogRow("+I", "US Dollar"), changelogRow("+I", "Euro")));
-
-        // test projection and filter
-        collectAndCheckStreamingReadWriteWithClose(
-                true,
-                false,
-                true,
-                Collections.emptyMap(),
-                "rate = 102",
-                Collections.singletonList("currency"),
-                Collections.singletonList(changelogRow("+I", "US Dollar")));
-    }
-
-    @Test
-    public void testStreamingReadWriteNonPartitionedRecordsWithoutPk() throws Exception {
-        // input is ratesChangelogWithUB()
-        // enable log store, with default full scan mode, will merge
-        checkFileStorePath(
-                tEnv,
-                collectAndCheckStreamingReadWriteWithClose(
-                        true,
-                        false,
-                        false,
-                        Collections.emptyMap(),
-                        null,
-                        Collections.emptyList(),
-                        Arrays.asList(
-                                changelogRow("+I", "US Dollar", 102L),
-                                changelogRow("+I", "Euro", 119L),
-                                changelogRow("+I", null, 100L),
-                                changelogRow("+I", "HK Dollar", null))),
-                null);
-
-        // test field filter
-        collectAndCheckStreamingReadWriteWithClose(
-                true,
-                false,
-                false,
-                Collections.emptyMap(),
-                "currency IS NOT NULL",
-                Collections.emptyList(),
-                Arrays.asList(
-                        changelogRow("+I", "US Dollar", 102L),
-                        changelogRow("+I", "Euro", 119L),
-                        changelogRow("+I", "HK Dollar", null)));
-
-        collectAndCheckStreamingReadWriteWithClose(
-                true,
-                false,
-                false,
-                Collections.emptyMap(),
-                "rate IS NOT NULL",
-                Collections.emptyList(),
-                Arrays.asList(
-                        changelogRow("+I", "US Dollar", 102L),
-                        changelogRow("+I", "Euro", 119L),
-                        changelogRow("+I", null, 100L)));
-
-        // test projection and filter
-        collectAndCheckStreamingReadWriteWithClose(
-                true,
-                false,
-                false,
-                Collections.emptyMap(),
-                "currency IS NOT NULL AND rate is NOT NULL",
-                Collections.singletonList("rate"),
-                Arrays.asList(
-                        changelogRow("+I", 102L), // US Dollar
-                        changelogRow("+I", 119L)) // Euro
-                );
-    }
-
-    @Test
-    public void testReadLatestChangelogOfPartitionedRecordsWithPk() throws Exception {
-        // input is dailyRatesChangelogWithoutUB()
-        collectLatestLogAndCheck(
-                false,
-                true,
-                true,
-                null,
-                Collections.emptyList(),
-                Arrays.asList(
-                        // part = 2022-01-01
-                        changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
-                        changelogRow("+I", "Euro", 114L, "2022-01-01"),
-                        changelogRow("+I", "Yen", 1L, "2022-01-01"),
-                        changelogRow("-U", "Euro", 114L, "2022-01-01"),
-                        changelogRow("+U", "Euro", 116L, "2022-01-01"),
-                        changelogRow("-D", "Yen", 1L, "2022-01-01"),
-                        changelogRow("-D", "Euro", 116L, "2022-01-01"),
-                        // part = 2022-01-02
-                        changelogRow("+I", "Euro", 119L, "2022-01-02")));
-
-        // test partition filter
-        collectLatestLogAndCheck(
-                false,
-                true,
-                true,
-                "dt = '2022-01-01'",
-                Collections.emptyList(),
-                Arrays.asList(
-                        // part = 2022-01-01
-                        changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
-                        changelogRow("+I", "Euro", 114L, "2022-01-01"),
-                        changelogRow("+I", "Yen", 1L, "2022-01-01"),
-                        changelogRow("-U", "Euro", 114L, "2022-01-01"),
-                        changelogRow("+U", "Euro", 116L, "2022-01-01"),
-                        changelogRow("-D", "Yen", 1L, "2022-01-01"),
-                        changelogRow("-D", "Euro", 116L, "2022-01-01")));
-
-        // test field filter
-        collectLatestLogAndCheck(
-                false,
-                true,
-                true,
-                "currency = 'Yen'",
-                Collections.emptyList(),
-                Arrays.asList(
-                        // part = 2022-01-01
-                        changelogRow("+I", "Yen", 1L, "2022-01-01"),
-                        changelogRow("-D", "Yen", 1L, "2022-01-01")));
-
-        collectLatestLogAndCheck(
-                false,
-                true,
-                true,
-                "rate = 114",
-                Collections.emptyList(),
-                Arrays.asList(
-                        // part = 2022-01-01
-                        changelogRow("+I", "Euro", 114L, "2022-01-01"),
-                        changelogRow("-U", "Euro", 114L, "2022-01-01")));
-
-        // test partition and field filter
-        collectLatestLogAndCheck(
-                false,
-                true,
-                true,
-                "rate = 114 AND dt = '2022-01-02'",
-                Collections.emptyList(),
-                Collections.emptyList());
-
-        // test projection
-        collectLatestLogAndCheck(
-                false,
-                true,
-                true,
-                null,
-                Collections.singletonList("rate"),
-                Arrays.asList(
-                        // part = 2022-01-01
-                        changelogRow("+I", 102L), // US Dollar
-                        changelogRow("+I", 114L), // Euro
-                        changelogRow("+I", 1L), // Yen
-                        changelogRow("-U", 114L), // Euro
-                        changelogRow("+U", 116L), // Euro
-                        changelogRow("-D", 1L), // Yen
-                        changelogRow("-D", 116L), // Euro
-                        // part = 2022-01-02
-                        changelogRow("+I", 119L) // Euro
-                        ));
-
-        // test projection and filter
-        collectLatestLogAndCheck(
-                false,
-                true,
-                true,
-                "dt = '2022-01-02'",
-                Collections.singletonList("rate"),
-                Collections.singletonList(
-                        // part = 2022-01-02, Euro
-                        changelogRow("+I", 119L)));
-    }
-
-    @Test
-    public void testReadLatestChangelogOfPartitionedRecordsWithoutPk() throws Exception {
-        // input is dailyRatesChangelogWithUB()
-        collectLatestLogAndCheck(
-                false,
-                true,
-                false,
-                null,
-                Collections.emptyList(),
-                Arrays.asList(
-                        // part = 2022-01-01
-                        changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
-                        changelogRow("+I", "Euro", 116L, "2022-01-01"),
-                        changelogRow("-D", "Euro", 116L, "2022-01-01"),
-                        changelogRow("+I", "Yen", 1L, "2022-01-01"),
-                        changelogRow("-D", "Yen", 1L, "2022-01-01"),
-                        // part = 2022-01-02
-                        changelogRow("+I", "Euro", 114L, "2022-01-02"),
-                        changelogRow("-D", "Euro", 114L, "2022-01-02"),
-                        changelogRow("+I", "Euro", 119L, "2022-01-02"),
-                        changelogRow("-D", "Euro", 119L, "2022-01-02"),
-                        changelogRow("+I", "Euro", 115L, "2022-01-02")));
-    }
-
-    @Test
-    public void testReadLatestChangelogOfNonPartitionedRecordsWithPk() throws Exception {
-        // input is ratesChangelogWithoutUB()
-        collectLatestLogAndCheck(
-                false,
-                false,
-                true,
-                null,
-                Collections.emptyList(),
-                Arrays.asList(
-                        changelogRow("+I", "US Dollar", 102L),
-                        changelogRow("+I", "Euro", 114L),
-                        changelogRow("+I", "Yen", 1L),
-                        changelogRow("-U", "Euro", 114L),
-                        changelogRow("+U", "Euro", 116L),
-                        changelogRow("-D", "Euro", 116L),
-                        changelogRow("+I", "Euro", 119L),
-                        changelogRow("-D", "Yen", 1L)));
-
-        // test field filter
-        collectLatestLogAndCheck(
-                false,
-                false,
-                true,
-                "currency = 'Euro'",
-                Collections.emptyList(),
-                Arrays.asList(
-                        changelogRow("+I", "Euro", 114L),
-                        changelogRow("-U", "Euro", 114L),
-                        changelogRow("+U", "Euro", 116L),
-                        changelogRow("-D", "Euro", 116L),
-                        changelogRow("+I", "Euro", 119L)));
-
-        // test projection
-        collectLatestLogAndCheck(
-                false,
-                false,
-                true,
-                null,
-                Collections.singletonList("currency"),
-                Arrays.asList(
-                        changelogRow("+I", "US Dollar"),
-                        changelogRow("+I", "Euro"),
-                        changelogRow("+I", "Yen"),
-                        changelogRow("-D", "Euro"),
-                        changelogRow("+I", "Euro"),
-                        changelogRow("-D", "Yen")));
-
-        // test projection and filter
-        collectLatestLogAndCheck(
-                false,
-                false,
-                true,
-                "currency = 'Euro'",
-                Collections.singletonList("rate"),
-                Arrays.asList(
-                        changelogRow("+I", 114L),
-                        changelogRow("-U", 114L),
-                        changelogRow("+U", 116L),
-                        changelogRow("-D", 116L),
-                        changelogRow("+I", 119L)));
-    }
-
-    @Test
-    public void testReadLatestChangelogOfNonPartitionedRecordsWithoutPk() throws Exception {
-        // input is ratesChangelogWithUB()
-        collectLatestLogAndCheck(
-                false,
-                false,
-                false,
-                null,
-                Collections.emptyList(),
-                Arrays.asList(
-                        changelogRow("+I", "US Dollar", 102L),
-                        changelogRow("+I", "Euro", 114L),
-                        changelogRow("+I", "Yen", 1L),
-                        changelogRow("-D", "Euro", 114L),
-                        changelogRow("+I", "Euro", 116L),
-                        changelogRow("-D", "Euro", 116L),
-                        changelogRow("+I", "Euro", 119L),
-                        changelogRow("-D", "Euro", 119L),
-                        changelogRow("+I", "Euro", 119L),
-                        changelogRow("-D", "Yen", 1L),
-                        changelogRow("+I", null, 100L),
-                        changelogRow("+I", "HK Dollar", null)));
-
-        // test field filter
-        collectLatestLogAndCheck(
-                false,
-                false,
-                false,
-                "currency = 'Euro'",
-                Collections.emptyList(),
-                Arrays.asList(
-                        changelogRow("+I", "Euro", 114L),
-                        changelogRow("-D", "Euro", 114L),
-                        changelogRow("+I", "Euro", 116L),
-                        changelogRow("-D", "Euro", 116L),
-                        changelogRow("+I", "Euro", 119L),
-                        changelogRow("-D", "Euro", 119L),
-                        changelogRow("+I", "Euro", 119L)));
-
-        // test projection
-        collectLatestLogAndCheck(
-                false,
-                false,
-                false,
-                null,
-                Arrays.asList("currency", "rate"),
-                Arrays.asList(
-                        changelogRow("+I", "US Dollar", 102L),
-                        changelogRow("+I", "Euro", 114L),
-                        changelogRow("+I", "Yen", 1L),
-                        changelogRow("-D", "Euro", 114L),
-                        changelogRow("+I", "Euro", 116L),
-                        changelogRow("-D", "Euro", 116L),
-                        changelogRow("+I", "Euro", 119L),
-                        changelogRow("-D", "Euro", 119L),
-                        changelogRow("+I", "Euro", 119L),
-                        changelogRow("-D", "Yen", 1L),
-                        changelogRow("+I", null, 100L),
-                        changelogRow("+I", "HK Dollar", null)));
-
-        // test projection and filter
-        collectLatestLogAndCheck(
-                false,
-                false,
-                false,
-                "currency IS NOT NULL",
-                Collections.singletonList("currency"),
-                Arrays.asList(
-                        changelogRow("+I", "US Dollar"),
-                        changelogRow("+I", "Euro"),
-                        changelogRow("+I", "Yen"),
-                        changelogRow("-D", "Euro"),
-                        changelogRow("+I", "Euro"),
-                        changelogRow("-D", "Euro"),
-                        changelogRow("+I", "Euro"),
-                        changelogRow("-D", "Euro"),
-                        changelogRow("+I", "Euro"),
-                        changelogRow("-D", "Yen"),
-                        changelogRow("+I", "HK Dollar")));
-
-        collectLatestLogAndCheck(
-                false,
-                false,
-                false,
-                "rate = 119",
-                Collections.singletonList("currency"),
-                Arrays.asList(
-                        changelogRow("+I", "Euro"),
-                        changelogRow("-D", "Euro"),
-                        changelogRow("+I", "Euro")));
-    }
-
-    @Test
-    public void testReadLatestChangelogOfInsertOnlyRecords() throws Exception {
-        // input is rates()
-        List<Row> expected =
-                Arrays.asList(
-                        changelogRow("+I", "US Dollar", 102L),
-                        changelogRow("+I", "Euro", 114L),
-                        changelogRow("+I", "Yen", 1L),
-                        changelogRow("-U", "Euro", 114L),
-                        changelogRow("+U", "Euro", 119L));
-
-        // currency as pk
-        collectLatestLogAndCheck(true, false, true, null, Collections.emptyList(), expected);
-
-        // without pk
-        collectLatestLogAndCheck(true, false, true, null, Collections.emptyList(), expected);
-
-        // test field filter
-        collectLatestLogAndCheck(
-                true,
-                false,
-                true,
-                "rate = 114",
-                Collections.emptyList(),
-                Arrays.asList(changelogRow("+I", "Euro", 114L), changelogRow("-U", "Euro", 114L)));
-
-        // test projection
-        collectLatestLogAndCheck(
-                true,
-                false,
-                true,
-                null,
-                Collections.singletonList("rate"),
-                Arrays.asList(
-                        changelogRow("+I", 102L),
-                        changelogRow("+I", 114L),
-                        changelogRow("+I", 1L),
-                        changelogRow("-U", 114L),
-                        changelogRow("+U", 119L)));
-
-        // test projection and filter
-        collectLatestLogAndCheck(
-                true,
-                false,
-                true,
-                "rate = 114",
-                Collections.singletonList("currency"),
-                Arrays.asList(changelogRow("+I", "Euro"), changelogRow("-U", "Euro")));
-    }
-
-    @Test
-    public void testReadInsertOnlyChangelogFromTimestamp() throws Exception {
-        // input is dailyRates()
-        collectChangelogFromTimestampAndCheck(
-                true,
-                true,
-                true,
-                0,
-                Arrays.asList(
-                        // part = 2022-01-01
-                        changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
-                        changelogRow("+I", "Yen", 1L, "2022-01-01"),
-                        changelogRow("+I", "Euro", 114L, "2022-01-01"),
-                        changelogRow("-U", "US Dollar", 102L, "2022-01-01"),
-                        changelogRow("+U", "US Dollar", 114L, "2022-01-01"),
-                        // part = 2022-01-02
-                        changelogRow("+I", "Euro", 119L, "2022-01-02")));
-
-        collectChangelogFromTimestampAndCheck(true, true, false, 0, dailyRates().f0);
-
-        // input is rates()
-        collectChangelogFromTimestampAndCheck(
-                true,
-                false,
-                true,
-                0,
-                Arrays.asList(
-                        changelogRow("+I", "US Dollar", 102L),
-                        changelogRow("+I", "Euro", 114L),
-                        changelogRow("+I", "Yen", 1L),
-                        changelogRow("-U", "Euro", 114L),
-                        changelogRow("+U", "Euro", 119L)));
-
-        collectChangelogFromTimestampAndCheck(true, false, false, 0, rates());
-
-        collectChangelogFromTimestampAndCheck(
-                true, false, false, Long.MAX_VALUE - 1, Collections.emptyList());
-    }
-
-    @Test
-    public void testReadRetractChangelogFromTimestamp() throws Exception {
-        // input is dailyRatesChangelogWithUB()
-        collectChangelogFromTimestampAndCheck(
-                false,
-                true,
-                false,
-                0,
-                Arrays.asList(
-                        // part = 2022-01-01
-                        changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
-                        changelogRow("+I", "Euro", 116L, "2022-01-01"),
-                        changelogRow("-D", "Euro", 116L, "2022-01-01"),
-                        changelogRow("+I", "Yen", 1L, "2022-01-01"),
-                        changelogRow("-D", "Yen", 1L, "2022-01-01"),
-                        // part = 2022-01-02
-                        changelogRow("+I", "Euro", 114L, "2022-01-02"),
-                        changelogRow("-D", "Euro", 114L, "2022-01-02"),
-                        changelogRow("+I", "Euro", 119L, "2022-01-02"),
-                        changelogRow("-D", "Euro", 119L, "2022-01-02"),
-                        changelogRow("+I", "Euro", 115L, "2022-01-02")));
-
-        // input is dailyRatesChangelogWithoutUB()
-        collectChangelogFromTimestampAndCheck(
-                false,
-                true,
-                true,
-                0,
-                Arrays.asList(
-                        // part = 2022-01-01
-                        changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
-                        changelogRow("+I", "Euro", 114L, "2022-01-01"),
-                        changelogRow("+I", "Yen", 1L, "2022-01-01"),
-                        changelogRow("-U", "Euro", 114L, "2022-01-01"),
-                        changelogRow("+U", "Euro", 116L, "2022-01-01"),
-                        changelogRow("-D", "Yen", 1L, "2022-01-01"),
-                        changelogRow("-D", "Euro", 116L, "2022-01-01"),
-                        // part = 2022-01-02
-                        changelogRow("+I", "Euro", 119L, "2022-01-02")));
-    }
-
-    @Test
-    public void testSourceParallelism() throws Exception {
-        String managedTable =
-                createSourceAndManagedTable(
-                                false,
-                                false,
-                                false,
-                                Collections.emptyList(),
-                                Collections.emptyList(),
-                                Collections.emptyList(),
-                                null)
-                        .f1;
-
-        // without hint
-        String query = buildSimpleSelectQuery(managedTable, Collections.emptyMap());
-        assertThat(sourceParallelism(query)).isEqualTo(env.getParallelism());
-
-        // with hint
-        query =
-                buildSimpleSelectQuery(
-                        managedTable, Collections.singletonMap(SCAN_PARALLELISM.key(), "66"));
-        assertThat(sourceParallelism(query)).isEqualTo(66);
-    }
-
-    @Test
-    public void testSinkParallelism() throws IOException {
-        testSinkParallelism(null, env.getParallelism());
-        testSinkParallelism(23, 23);
-    }
-
-    @Test
-    public void testQueryContainsDefaultFieldName() throws Exception {
-        rootPath = TEMPORARY_FOLDER.newFolder().getPath();
-        tEnv = StreamTableEnvironment.create(buildBatchEnv(), EnvironmentSettings.inBatchMode());
-        String id = registerData(Collections.singletonList(changelogRow("+I", 1, "abc")));
-        tEnv.executeSql(
-                String.format(
-                        "create table dummy_source ("
-                                + "f0 int, "
-                                + "f1 string) with ("
-                                + "'connector' = 'values', "
-                                + "'bounded' = 'true', "
-                                + "'data-id' = '%s')",
-                        id));
-        tEnv.executeSql(
-                String.format(
-                        "create table managed_table with ('root-path' = '%s') "
-                                + "like dummy_source (excluding options)",
-                        rootPath));
-        tEnv.executeSql("insert into managed_table select * from dummy_source").await();
-        BlockingIterator<Row, Row> iterator =
-                BlockingIterator.of(tEnv.executeSql("select * from managed_table").collect());
-        assertThat(iterator.collect(1, 5, TimeUnit.SECONDS))
-                .containsOnly(changelogRow("+I", 1, "abc"));
-    }
+    // ----------------------------------------------------------------------------------------------------------------
+    // Keyword
+    // ----------------------------------------------------------------------------------------------------------------
 
     @Test
     public void testLike() throws Exception {
-        rootPath = TEMPORARY_FOLDER.newFolder().getPath();
-        tEnv = StreamTableEnvironment.create(buildBatchEnv(), EnvironmentSettings.inBatchMode());
-        List<Row> input =
-                Arrays.asList(
-                        changelogRow("+I", 1, "test_1"),
-                        changelogRow("+I", 2, "test_2"),
-                        changelogRow("+I", 1, "test_%"),
-                        changelogRow("+I", 2, "test%2"),
-                        changelogRow("+I", 3, "university"),
-                        changelogRow("+I", 4, "very"),
-                        changelogRow("+I", 5, "yield"));
-        String id = registerData(input);
-        UUID randomSourceId = UUID.randomUUID();
-        tEnv.executeSql(
-                String.format(
-                        "create table `helper_source_%s` (f0 int, f1 string) with ("
-                                + "'connector' = 'values', "
-                                + "'bounded' = 'true', "
-                                + "'data-id' = '%s')",
-                        randomSourceId, id));
-
-        UUID randomSinkId = UUID.randomUUID();
-        tEnv.executeSql(
-                String.format(
-                        "create table `managed_table_%s` with ("
-                                + "'%s' = '%s'"
-                                + ") like `helper_source_%s` "
-                                + "(excluding options)",
-                        randomSinkId, ROOT_PATH.key(), rootPath, randomSourceId));
+        String table =
+                createTable(
+                        Arrays.asList("f0 INT", "f1 STRING"),
+                        Collections.emptyList(),
+                        Collections.emptyList());
 
         // insert multiple times
-        tEnv.executeSql(
-                        String.format(
-                                "insert into `managed_table_%s` select * from `helper_source_%s`",
-                                randomSinkId, randomSourceId))
-                .await();
+        insertInto(
+                table,
+                "(1, 'test_1')",
+                "(2, 'test_2')",
+                "(1, 'test_%')",
+                "(2, 'test%2')",
+                "(3, 'university')",
+                "(4, 'very')",
+                "(5, 'yield')");
 
-        tEnv.executeSql(
-                        String.format(
-                                "insert into `managed_table_%s` values (7, 'villa'), (8, 'tests'), (20, 'test_123')",
-                                randomSinkId))
-                .await();
+        insertInto(
+                table,
+                "(7, 'villa')",
+                "(8, 'tests')",
+                "(20, 'test_123')",
+                "(9, 'valley')",
+                "(10, 'tested')",
+                "(100, 'test%fff')");
 
-        tEnv.executeSql(
-                        "insert into `managed_table_"
-                                + randomSinkId
-                                + "` values (9, 'valley'), (10, 'tested'), (100, 'test%fff')")
-                .await();
-
-        collectAndCheck(
-                tEnv,
-                "managed_table_" + randomSinkId,
-                Collections.emptyMap(),
-                "f1 like 'test%'",
+        testBatchRead(
+                buildQuery(table, "*", "WHERE f1 LIKE 'test%'"),
                 Arrays.asList(
                         changelogRow("+I", 1, "test_1"),
                         changelogRow("+I", 2, "test_2"),
@@ -1366,48 +784,38 @@ public class ReadWriteTableITCase extends ReadWriteTableTestBase {
                         changelogRow("+I", 8, "tests"),
                         changelogRow("+I", 10, "tested"),
                         changelogRow("+I", 20, "test_123")));
-        collectAndCheck(
-                tEnv,
-                "managed_table_" + randomSinkId,
-                Collections.emptyMap(),
-                "f1 like 'v%'",
+
+        testBatchRead(
+                buildQuery(table, "*", "WHERE f1 LIKE 'v%'"),
                 Arrays.asList(
                         changelogRow("+I", 4, "very"),
                         changelogRow("+I", 7, "villa"),
                         changelogRow("+I", 9, "valley")));
-        collectAndCheck(
-                tEnv,
-                "managed_table_" + randomSinkId,
-                Collections.emptyMap(),
-                "f1 like 'test=_%' escape '='",
+
+        testBatchRead(
+                buildQuery(table, "*", "WHERE f1 LIKE 'test=_%' ESCAPE '='"),
                 Arrays.asList(
                         changelogRow("+I", 1, "test_1"),
                         changelogRow("+I", 2, "test_2"),
                         changelogRow("+I", 1, "test_%"),
                         changelogRow("+I", 20, "test_123")));
-        collectAndCheck(
-                tEnv,
-                "managed_table_" + randomSinkId,
-                Collections.emptyMap(),
-                "f1 like 'test=__' escape '='",
+
+        testBatchRead(
+                buildQuery(table, "*", "WHERE f1 LIKE 'test=__' ESCAPE '='"),
                 Arrays.asList(
                         changelogRow("+I", 1, "test_1"),
                         changelogRow("+I", 2, "test_2"),
                         changelogRow("+I", 1, "test_%")));
-        collectAndCheck(
-                tEnv,
-                "managed_table_" + randomSinkId,
-                Collections.emptyMap(),
-                "f1 like 'test$%%' escape '$'",
+
+        testBatchRead(
+                buildQuery(table, "*", "WHERE f1 LIKE 'test$%%' ESCAPE '$'"),
                 Arrays.asList(
                         changelogRow("+I", 2, "test%2"), changelogRow("+I", 100, "test%fff")));
     }
 
     @Test
     public void testIn() throws Exception {
-        rootPath = TEMPORARY_FOLDER.newFolder().getPath();
-        tEnv = StreamTableEnvironment.create(buildBatchEnv(), EnvironmentSettings.inBatchMode());
-        List<Row> input =
+        List<Row> initialRecords =
                 Arrays.asList(
                         changelogRow("+I", 1, "aaa"),
                         changelogRow("+I", 2, "bbb"),
@@ -1431,310 +839,220 @@ public class ReadWriteTableITCase extends ReadWriteTableTestBase {
                         changelogRow("+I", 20, "eee"),
                         changelogRow("+I", 21, "fff"));
 
-        String id = registerData(input);
-        UUID randomSourceId = UUID.randomUUID();
-        tEnv.executeSql(
-                String.format(
-                        "create table `helper_source_%s` (f0 int, f1 string) with ("
-                                + "'connector' = 'values', "
-                                + "'bounded' = 'true', "
-                                + "'data-id' = '%s')",
-                        randomSourceId, id));
+        String table =
+                createTable(
+                        Arrays.asList("f0 INT", "f1 STRING"),
+                        Collections.emptyList(),
+                        Collections.emptyList());
 
-        UUID randomSinkId = UUID.randomUUID();
-        tEnv.executeSql(
-                String.format(
-                        "create table `managed_table_%s` with ("
-                                + "'%s' = '%s'"
-                                + ") like `helper_source_%s` "
-                                + "(excluding options)",
-                        randomSinkId, ROOT_PATH.key(), rootPath, randomSourceId));
-        tEnv.executeSql(
-                        String.format(
-                                "insert into `managed_table_%s` select * from `helper_source_%s`",
-                                randomSinkId, randomSourceId))
-                .await();
+        insertInto(
+                table,
+                "(1, 'aaa')",
+                "(2, 'bbb')",
+                "(3, 'ccc')",
+                "(4, 'ddd')",
+                "(5, 'eee')",
+                "(6, 'aaa')",
+                "(7, 'bbb')",
+                "(8, 'ccc')",
+                "(9, 'ddd')",
+                "(10, 'eee')",
+                "(11, 'aaa')",
+                "(12, 'bbb')",
+                "(13, 'ccc')",
+                "(14, 'ddd')",
+                "(15, 'eee')",
+                "(16, 'aaa')",
+                "(17, 'bbb')",
+                "(18, 'ccc')",
+                "(19, 'ddd')",
+                "(20, 'eee')",
+                "(21, 'fff')");
 
-        collectAndCheck(
-                tEnv,
-                "managed_table_" + randomSinkId,
-                Collections.emptyMap(),
-                "f0 in (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, "
-                        + "11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)",
-                input);
+        testBatchRead(
+                buildQuery(
+                        table,
+                        "*",
+                        "WHERE f0 IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)"),
+                initialRecords);
 
-        collectAndCheck(
-                tEnv,
-                "managed_table_" + randomSinkId,
-                Collections.emptyMap(),
-                "f1 in ('aaa', 'bbb', 'ccc', 'ddd', 'eee', 'fff')",
-                input);
+        List<Row> expected = new ArrayList<>(initialRecords);
+        expected.remove(20);
+        testBatchRead(
+                buildQuery(table, "*", "WHERE f1 IN ('aaa', 'bbb', 'ccc', 'ddd', 'eee')"),
+                expected);
     }
 
     @Test
     public void testUnsupportedPredicate() throws Exception {
+        String table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Arrays.asList("currency", "dt"),
+                        Collections.singletonList("dt"));
+
+        insertInto(
+                table,
+                "('US Dollar', 102, '2022-01-01')",
+                "('Euro', 114, '2022-01-01')",
+                "('Yen', 1, '2022-01-01')",
+                "('Euro', 114, '2022-01-01')",
+                "('US Dollar', 114, '2022-01-01')",
+                "('Euro', 119, '2022-01-02')");
+
         // test unsupported filter
-        collectAndCheckBatchReadWrite(
-                true,
-                true,
-                "currency similar to 'Euro'",
-                Collections.emptyList(),
+        testBatchRead(
+                buildQuery(table, "*", "WHERE currency SIMILAR TO 'Euro'"),
                 Arrays.asList(
                         changelogRow("+I", "Euro", 114L, "2022-01-01"),
                         changelogRow("+I", "Euro", 119L, "2022-01-02")));
     }
 
+    // ----------------------------------------------------------------------------------------------------------------
+    // Others
+    // ----------------------------------------------------------------------------------------------------------------
+
+    @Test
+    public void testSourceParallelism() throws Exception {
+        List<Row> initialRecords =
+                Arrays.asList(
+                        changelogRow("+I", "US Dollar", 102L),
+                        changelogRow("+I", "Euro", 114L),
+                        changelogRow("+I", "Yen", 1L),
+                        changelogRow("+I", "Euro", 114L),
+                        changelogRow("+I", "Euro", 119L));
+
+        String table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.emptyList(),
+                        Collections.emptyList());
+
+        insertInto(
+                table,
+                "('US Dollar', 102)",
+                "('Euro', 114)",
+                "('Yen', 1)",
+                "('Euro', 114)",
+                "('Euro', 119)");
+
+        testBatchRead(buildSimpleQuery(table), initialRecords);
+
+        // without hint
+        assertThat(sourceParallelism(buildSimpleQuery(table))).isEqualTo(bExeEnv.getParallelism());
+
+        // with hint
+        assertThat(
+                        sourceParallelism(
+                                buildQueryWithTableOptions(
+                                        table,
+                                        "*",
+                                        "",
+                                        new HashMap<String, String>() {
+                                            {
+                                                put(SCAN_PARALLELISM.key(), "66");
+                                            }
+                                        })))
+                .isEqualTo(66);
+    }
+
+    @Test
+    public void testSinkParallelism() throws Exception {
+        testSinkParallelism(null, bExeEnv.getParallelism());
+        testSinkParallelism(23, 23);
+    }
+
     @Test
     public void testChangeBucketNumber() throws Exception {
-        rootPath = TEMPORARY_FOLDER.newFolder().getPath();
-        tEnv = StreamTableEnvironment.create(buildBatchEnv(), EnvironmentSettings.inBatchMode());
-        tEnv.executeSql(
+        String table = "MyTable_" + UUID.randomUUID();
+        bEnv.executeSql(
                 String.format(
-                        "CREATE TABLE IF NOT EXISTS rates (\n"
+                        "CREATE TABLE `%s` (\n"
                                 + "currency STRING,\n"
                                 + " rate BIGINT,\n"
                                 + " dt STRING\n"
                                 + ") PARTITIONED BY (dt)\n"
                                 + "WITH (\n"
-                                + " 'bucket' = '2',\n"
-                                + " 'root-path' = '%s'\n"
+                                + " 'bucket' = '2'\n"
                                 + ")",
-                        rootPath));
-        tEnv.executeSql("INSERT INTO rates VALUES('US Dollar', 102, '2022-06-20')").await();
+                        table));
+
+        insertInto(table, "('US Dollar', 102, '2022-06-20')");
 
         // increase bucket num from 2 to 3
-        assertChangeBucketWithoutRescale(3);
+        assertChangeBucketWithoutRescale(table, 3);
 
         // decrease bucket num from 3 to 1
-        assertChangeBucketWithoutRescale(1);
-    }
-
-    private void assertChangeBucketWithoutRescale(int bucketNum) throws Exception {
-        tEnv.executeSql(String.format("ALTER TABLE rates SET ('bucket' = '%d')", bucketNum));
-        // read is ok
-        assertThat(BlockingIterator.of(tEnv.executeSql("SELECT * FROM rates").collect()).collect())
-                .containsExactlyInAnyOrder(changelogRow("+I", "US Dollar", 102L, "2022-06-20"));
-        assertThatThrownBy(
-                        () ->
-                                tEnv.executeSql(
-                                                "INSERT INTO rates VALUES('US Dollar', 102, '2022-06-20')")
-                                        .await())
-                .getRootCause()
-                .isInstanceOf(TableException.class)
-                .hasMessage(
-                        String.format(
-                                "Try to write partition {dt=2022-06-20} with a new bucket num %d, but the previous bucket num is 2. "
-                                        + "Please switch to batch mode, and perform INSERT OVERWRITE to rescale current data layout first.",
-                                bucketNum));
+        assertChangeBucketWithoutRescale(table, 1);
     }
 
     @Test
-    public void testSuccessiveWriteAndRead() throws Exception {
-        String managedTable =
-                collectAndCheckBatchReadWrite(false, false, null, Collections.emptyList(), rates());
-        // write rates() twice
-        tEnv.executeSql(
-                        String.format(
-                                "INSERT INTO `%s`"
-                                        + " VALUES ('US Dollar', 102),\n"
-                                        + "('Euro', 114),\n"
-                                        + "('Yen', 1),\n"
-                                        + "('Euro', 114),\n"
-                                        + "('Euro', 119)",
-                                managedTable))
-                .await();
-        collectAndCheck(
-                tEnv,
-                managedTable,
-                Collections.emptyMap(),
-                "currency = 'Yen'",
-                Collections.nCopies(2, changelogRow("+I", "Yen", 1L)));
-    }
+    public void testStreamingInsertOverwrite() {
+        String table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt String"),
+                        Collections.emptyList(),
+                        Collections.singletonList("dt"));
 
-    @Test
-    public void testStreamingInsertOverwrite() throws Exception {
-        rootPath = TEMPORARY_FOLDER.newFolder().getPath();
-        tEnv =
-                StreamTableEnvironment.create(
-                        buildStreamEnv(), EnvironmentSettings.inStreamingMode());
-        tEnv.executeSql(
-                String.format(
-                        "CREATE TABLE IF NOT EXISTS rates (\n"
-                                + "currency STRING,\n"
-                                + " rate BIGINT,\n"
-                                + " dt STRING\n"
-                                + ") PARTITIONED BY (dt)\n"
-                                + "WITH (\n"
-                                + " 'bucket' = '2',\n"
-                                + " 'root-path' = '%s'\n"
-                                + ")",
-                        rootPath));
         assertThatThrownBy(
                         () ->
-                                tEnv.executeSql(
-                                        "INSERT OVERWRITE rates VALUES('US Dollar', 102, '2022-06-20')"))
+                                sEnv.executeSql(
+                                        String.format(
+                                                "INSERT OVERWRITE `%s` VALUES('US Dollar', 102, '2022-06-20')",
+                                                table)))
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessage("Table store doesn't support streaming INSERT OVERWRITE.");
     }
 
-    // ------------------------ Tools ----------------------------------
+    // ----------------------------------------------------------------------------------------------------------------
+    // Tools
+    // ----------------------------------------------------------------------------------------------------------------
 
     private void validateOverwriteResult(
-            TableEnvironment tEnv,
-            String table,
-            String partitionSpec,
-            String selectSpec,
-            List<Row> expected)
+            String table, String partitionSpec, String projectionSpec, List<Row> expected)
             throws Exception {
-        tEnv.executeSql(
-                        String.format("INSERT INTO %s VALUES ", table)
-                                + "(0, '2023-01-01', 'hi'), "
-                                + "(0, '2023-01-01', 'hello'), "
-                                + "(0, '2023-01-02', 'world'), "
-                                + "(1, '2023-01-01', 'flink'), "
-                                + "(1, '2023-01-02', 'table'), "
-                                + "(1, '2023-01-02', 'store')")
-                .await();
+        insertInto(
+                table,
+                "(0, '2023-01-01', 'hi')",
+                "(0, '2023-01-01', 'hello')",
+                "(0, '2023-01-02', 'world')",
+                "(1, '2023-01-01', 'flink')",
+                "(1, '2023-01-02', 'table')",
+                "(1, '2023-01-02', 'store')");
 
-        assertThat(
-                        CollectionUtil.iteratorToList(
-                                tEnv.executeSql("SELECT * FROM " + table).collect()))
-                .containsExactlyInAnyOrderElementsOf(
-                        Arrays.asList(
-                                changelogRow("+I", 0, "2023-01-01", "hi"),
-                                changelogRow("+I", 0, "2023-01-01", "hello"),
-                                changelogRow("+I", 0, "2023-01-02", "world"),
-                                changelogRow("+I", 1, "2023-01-01", "flink"),
-                                changelogRow("+I", 1, "2023-01-02", "table"),
-                                changelogRow("+I", 1, "2023-01-02", "store")));
+        testBatchRead(
+                buildSimpleQuery(table),
+                Arrays.asList(
+                        changelogRow("+I", 0, "2023-01-01", "hi"),
+                        changelogRow("+I", 0, "2023-01-01", "hello"),
+                        changelogRow("+I", 0, "2023-01-02", "world"),
+                        changelogRow("+I", 1, "2023-01-01", "flink"),
+                        changelogRow("+I", 1, "2023-01-02", "table"),
+                        changelogRow("+I", 1, "2023-01-02", "store")));
 
-        tEnv.executeSql(
+        bEnv.executeSql(
                         String.format(
-                                "INSERT OVERWRITE %s %s SELECT %s FROM %s WHERE false",
-                                table, partitionSpec, selectSpec, table))
+                                "INSERT OVERWRITE `%s` %s SELECT %s FROM `%s` WHERE false",
+                                table, partitionSpec, projectionSpec, table))
                 .await();
 
-        assertThat(
-                        CollectionUtil.iteratorToList(
-                                tEnv.executeSql("SELECT * FROM " + table).collect()))
-                .containsExactlyInAnyOrderElementsOf(expected);
-    }
-
-    private String collectAndCheckBatchReadWrite(
-            boolean partitioned,
-            boolean hasPk,
-            @Nullable String filter,
-            List<String> projection,
-            List<Row> expected)
-            throws Exception {
-        return collectAndCheckBatchReadWrite(
-                partitioned ? Collections.singletonList("dt") : Collections.emptyList(),
-                hasPk
-                        ? partitioned
-                                ? Arrays.asList("currency", "dt")
-                                : Collections.singletonList("currency")
-                        : Collections.emptyList(),
-                filter,
-                projection,
-                expected);
-    }
-
-    private String collectAndCheckStreamingReadWriteWithClose(
-            boolean enableLogStore,
-            boolean partitioned,
-            boolean hasPk,
-            Map<String, String> readHints,
-            @Nullable String filter,
-            List<String> projection,
-            List<Row> expected)
-            throws Exception {
-        return collectAndCheckStreamingReadWriteWithClose(
-                enableLogStore,
-                partitioned ? Collections.singletonList("dt") : Collections.emptyList(),
-                hasPk
-                        ? partitioned
-                                ? Arrays.asList("currency", "dt")
-                                : Collections.singletonList("currency")
-                        : Collections.emptyList(),
-                readHints,
-                filter,
-                projection,
-                expected);
-    }
-
-    private Tuple2<String, BlockingIterator<Row, Row>>
-            collectAndCheckStreamingReadWriteWithoutClose(
-                    Map<String, String> readHints,
-                    @Nullable String filter,
-                    List<String> projection,
-                    List<Row> expected)
-                    throws Exception {
-        return collectAndCheckStreamingReadWriteWithoutClose(
-                Collections.singletonList("dt"),
-                Arrays.asList("currency", "dt"),
-                readHints,
-                filter,
-                projection,
-                expected);
-    }
-
-    private void collectLatestLogAndCheck(
-            boolean insertOnly,
-            boolean partitioned,
-            boolean hasPk,
-            @Nullable String filter,
-            List<String> projection,
-            List<Row> expected)
-            throws Exception {
-        collectLatestLogAndCheck(
-                insertOnly,
-                partitioned ? Collections.singletonList("dt") : Collections.emptyList(),
-                hasPk
-                        ? partitioned
-                                ? Arrays.asList("currency", "dt")
-                                : Collections.singletonList("currency")
-                        : Collections.emptyList(),
-                filter,
-                projection,
-                expected);
-    }
-
-    private void collectChangelogFromTimestampAndCheck(
-            boolean insertOnly,
-            boolean partitioned,
-            boolean hasPk,
-            long timestamp,
-            List<Row> expected)
-            throws Exception {
-        collectChangelogFromTimestampAndCheck(
-                insertOnly,
-                partitioned ? Collections.singletonList("dt") : Collections.emptyList(),
-                hasPk
-                        ? partitioned
-                                ? Arrays.asList("currency", "dt")
-                                : Collections.singletonList("currency")
-                        : Collections.emptyList(),
-                timestamp,
-                expected);
+        testBatchRead(buildSimpleQuery(table), expected);
     }
 
     private int sourceParallelism(String sql) {
-        DataStream<Row> stream = tEnv.toChangelogStream(tEnv.sqlQuery(sql));
+        DataStream<Row> stream =
+                ((StreamTableEnvironment) bEnv).toChangelogStream(bEnv.sqlQuery(sql));
         return stream.getParallelism();
     }
 
     private void testSinkParallelism(Integer configParallelism, int expectedParallelism)
-            throws IOException {
+            throws Exception {
         // 1. create a mock table sink
         Map<String, String> options = new HashMap<>();
         if (configParallelism != null) {
             options.put(SINK_PARALLELISM.key(), configParallelism.toString());
         }
-        options.put(
-                "path",
-                new File(TEMPORARY_FOLDER.newFolder(), UUID.randomUUID().toString())
-                        .toURI()
-                        .toString());
+        options.put("path", getTempFilePath(UUID.randomUUID().toString()));
 
         DynamicTableFactory.Context context =
                 new FactoryUtil.DefaultDynamicTableContext(
@@ -1750,8 +1068,17 @@ public class ReadWriteTableITCase extends ReadWriteTableTestBase {
                         new Configuration(),
                         Thread.currentThread().getContextClassLoader(),
                         false);
-        new TableStoreManagedFactory().onCreateTable(context, false);
-        DynamicTableSink tableSink = new TableStoreManagedFactory().createDynamicTableSink(context);
+
+        // create table
+        Path path = CoreOptions.path(context.getCatalogTable().getOptions());
+        path.getFileSystem().mkdirs(path);
+        // update schema
+        new SchemaManager(path)
+                .commitNewVersion(UpdateSchema.fromCatalogTable(context.getCatalogTable()));
+
+        DynamicTableSink tableSink =
+                new TableStoreSink(
+                        context.getObjectIdentifier(), buildFileStoreTable(context), context, null);
         assertThat(tableSink).isInstanceOf(TableStoreSink.class);
 
         // 2. get sink provider
@@ -1762,7 +1089,7 @@ public class ReadWriteTableITCase extends ReadWriteTableTestBase {
 
         // 3. assert parallelism from transformation
         DataStream<RowData> mockSource =
-                env.fromCollection(Collections.singletonList(GenericRowData.of()));
+                bExeEnv.fromCollection(Collections.singletonList(GenericRowData.of()));
         DataStreamSink<?> sink = sinkProvider.consumeDataStream(null, mockSource);
         Transformation<?> transformation = sink.getTransformation();
         // until a PartitionTransformation, see TableStore.SinkBuilder.build()
@@ -1770,5 +1097,22 @@ public class ReadWriteTableITCase extends ReadWriteTableTestBase {
             assertThat(transformation.getParallelism()).isIn(1, expectedParallelism);
             transformation = transformation.getInputs().get(0);
         }
+    }
+
+    private void assertChangeBucketWithoutRescale(String table, int bucketNum) throws Exception {
+        bEnv.executeSql(String.format("ALTER TABLE `%s` SET ('bucket' = '%d')", table, bucketNum));
+        // read is ok
+        assertThat(
+                        BlockingIterator.of(bEnv.executeSql(buildSimpleQuery(table)).collect())
+                                .collect())
+                .containsExactlyInAnyOrder(changelogRow("+I", "US Dollar", 102L, "2022-06-20"));
+        assertThatThrownBy(() -> insertInto(table, "('US Dollar', 102, '2022-06-20')"))
+                .rootCause()
+                .isInstanceOf(TableException.class)
+                .hasMessage(
+                        String.format(
+                                "Try to write partition {dt=2022-06-20} with a new bucket num %d, but the previous bucket num is 2. "
+                                        + "Please switch to batch mode, and perform INSERT OVERWRITE to rescale current data layout first.",
+                                bucketNum));
     }
 }

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ReadWriteTableTestBase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ReadWriteTableTestBase.java
@@ -50,7 +50,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.table.store.CoreOptions.SCAN_MODE;
-import static org.apache.flink.table.store.CoreOptions.SCAN_TIMESTAMP_MILLIS;
 import static org.apache.flink.table.store.connector.FlinkConnectorOptions.LOG_SYSTEM;
 import static org.apache.flink.table.store.connector.FlinkConnectorOptions.ROOT_PATH;
 import static org.apache.flink.table.store.connector.FlinkConnectorOptions.relativeTablePath;
@@ -245,33 +244,6 @@ public class ReadWriteTableTestBase extends KafkaTableTestBase {
                         hints,
                         filter,
                         projection,
-                        expected)
-                .f1
-                .close();
-    }
-
-    protected void collectChangelogFromTimestampAndCheck(
-            boolean insertOnly,
-            List<String> partitionKeys,
-            List<String> primaryKeys,
-            long timestamp,
-            List<Row> expected)
-            throws Exception {
-        Map<String, String> hints = new HashMap<>();
-        hints.put(SCAN_MODE.key(), "from-timestamp");
-        hints.put(SCAN_TIMESTAMP_MILLIS.key(), String.valueOf(timestamp));
-        collectAndCheckUnderSameEnv(
-                        true,
-                        true,
-                        insertOnly,
-                        partitionKeys,
-                        primaryKeys,
-                        Collections.emptyList(),
-                        null,
-                        true,
-                        hints,
-                        null,
-                        Collections.emptyList(),
                         expected)
                 .f1
                 .close();

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/StreamingReadWriteTableWithKafkaLogITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/StreamingReadWriteTableWithKafkaLogITCase.java
@@ -1,0 +1,1451 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector;
+
+import org.apache.flink.table.store.CoreOptions;
+import org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil;
+import org.apache.flink.table.store.file.utils.BlockingIterator;
+import org.apache.flink.table.store.kafka.KafkaTableTestBase;
+import org.apache.flink.types.Row;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.UUID;
+
+import static org.apache.flink.table.planner.factories.TestValuesTableFactory.changelogRow;
+import static org.apache.flink.table.store.CoreOptions.SCAN_MODE;
+import static org.apache.flink.table.store.CoreOptions.SCAN_TIMESTAMP_MILLIS;
+import static org.apache.flink.table.store.connector.FlinkConnectorOptions.LOG_SYSTEM;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.assertNoMoreRecords;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.buildQuery;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.buildQueryWithTableOptions;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.buildSimpleQuery;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.checkFileStorePath;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.createTemporaryTable;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.init;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.insertInto;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.insertIntoFromTable;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.insertIntoPartition;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.insertOverwritePartition;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.testBatchRead;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.testStreamingRead;
+import static org.apache.flink.table.store.connector.util.ReadWriteTableTestUtil.testStreamingReadWithReadFirst;
+import static org.apache.flink.table.store.kafka.KafkaLogOptions.BOOTSTRAP_SERVERS;
+import static org.apache.flink.table.store.kafka.KafkaLogOptions.TOPIC;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Streaming reading and writing with Kafka log IT cases. */
+public class StreamingReadWriteTableWithKafkaLogITCase extends KafkaTableTestBase {
+
+    private final Map<String, String> scanLatest =
+            new HashMap<String, String>() {
+                {
+                    put(SCAN_MODE.key(), CoreOptions.StartupMode.LATEST.toString());
+                }
+            };
+
+    @Before
+    public void setUp() throws Exception {
+        init(createAndRegisterTempFile("").toString());
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // Write First/Kafka log table auto created/scan.mode = latest-full (default setting)
+    // ----------------------------------------------------------------------------------------------------------------
+
+    @Test
+    public void testReadWriteWithPartitionedRecordsWithPk() throws Exception {
+        // test hybrid read
+        List<Row> initialRecords =
+                Arrays.asList(
+                        // dt = 2022-01-01
+                        changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                        changelogRow("+I", "Euro", 114L, "2022-01-01"),
+                        changelogRow("+I", "Yen", 1L, "2022-01-01"),
+                        changelogRow("+U", "Euro", 116L, "2022-01-01"),
+                        changelogRow("-D", "Yen", 1L, "2022-01-01"),
+                        changelogRow("-D", "Euro", 116L, "2022-01-01"),
+                        // dt = 2022-01-02
+                        changelogRow("+I", "Euro", 119L, "2022-01-02"),
+                        changelogRow("+U", "Euro", 119L, "2022-01-02"));
+
+        String temporaryTable =
+                createTemporaryTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Arrays.asList("currency", "dt"),
+                        Collections.singletonList("dt"),
+                        initialRecords,
+                        "dt:2022-01-01;dt:2022-01-02",
+                        false,
+                        "I,UA,D");
+
+        String table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Arrays.asList("currency", "dt"),
+                        Collections.singletonList("dt"));
+
+        insertIntoFromTable(temporaryTable, table);
+
+        checkFileStorePath(table, Arrays.asList("dt=2022-01-01", "dt=2022-01-02"));
+
+        BlockingIterator<Row, Row> streamItr =
+                testStreamingRead(
+                        buildQuery(
+                                table,
+                                "*",
+                                "WHERE dt >= '2022-01-01' AND dt <= '2022-01-03' OR currency = 'HK Dollar'"),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                                changelogRow("+I", "Euro", 119L, "2022-01-02")));
+
+        // test log store in hybrid mode accepts all filters
+        insertIntoPartition(
+                table, "PARTITION (dt = '2022-01-03')", "('HK Dollar', 100)", "('Yen', 20)");
+
+        insertIntoPartition(table, "PARTITION (dt = '2022-01-04')", "('Yen', 20)");
+
+        assertThat(streamItr.collect(2))
+                .containsExactlyInAnyOrderElementsOf(
+                        Arrays.asList(
+                                changelogRow("+I", "HK Dollar", 100L, "2022-01-03"),
+                                changelogRow("+I", "Yen", 20L, "2022-01-03")));
+
+        // overwrite partition 2022-01-02
+        insertOverwritePartition(
+                table, "PARTITION (dt = '2022-01-02')", "('Euro', 100)", "('Yen', 1)");
+
+        // check no changelog generated for streaming read
+        assertNoMoreRecords(streamItr);
+
+        // batch read to check data refresh
+        testBatchRead(
+                buildSimpleQuery(table),
+                Arrays.asList(
+                        changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                        changelogRow("+I", "Euro", 100L, "2022-01-02"),
+                        changelogRow("+I", "Yen", 1L, "2022-01-02"),
+                        changelogRow("+I", "HK Dollar", 100L, "2022-01-03"),
+                        changelogRow("+I", "Yen", 20L, "2022-01-03"),
+                        changelogRow("+I", "Yen", 20L, "2022-01-04")));
+
+        streamItr.close();
+
+        // filter on partition
+        testStreamingRead(
+                        buildQuery(table, "*", "WHERE dt = '2022-01-01'"),
+                        Collections.singletonList(
+                                changelogRow("+I", "US Dollar", 102L, "2022-01-01")))
+                .close();
+
+        // test field filter
+        testStreamingRead(
+                        buildQuery(table, "*", "WHERE currency = 'US Dollar'"),
+                        Collections.singletonList(
+                                changelogRow("+I", "US Dollar", 102L, "2022-01-01")))
+                .close();
+
+        // test partition and field filter
+        testStreamingRead(
+                        buildQuery(table, "*", "WHERE dt = '2022-01-01' AND rate = 1"),
+                        Collections.emptyList())
+                .close();
+
+        // test projection and filter
+        testStreamingRead(
+                        buildQuery(
+                                table,
+                                "rate, dt, currency",
+                                "WHERE dt = '2022-01-02' AND currency = 'Euro'"),
+                        Collections.singletonList(changelogRow("+I", 100L, "2022-01-02", "Euro")))
+                .close();
+    }
+
+    @Test
+    public void testReadWriteWithPartitionedRecordsWithoutPk() throws Exception {
+        // file store bounded read with merge
+        List<Row> initialRecords =
+                Arrays.asList(
+                        // dt = 2022-01-01
+                        changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                        changelogRow("+I", "Euro", 116L, "2022-01-01"),
+                        changelogRow("-D", "Euro", 116L, "2022-01-01"),
+                        changelogRow("+I", "Yen", 1L, "2022-01-01"),
+                        changelogRow("-D", "Yen", 1L, "2022-01-01"),
+                        // dt = 2022-01-02
+                        changelogRow("+I", "Euro", 114L, "2022-01-02"),
+                        changelogRow("-U", "Euro", 114L, "2022-01-02"),
+                        changelogRow("+U", "Euro", 119L, "2022-01-02"),
+                        changelogRow("-D", "Euro", 119L, "2022-01-02"),
+                        changelogRow("+I", "Euro", 115L, "2022-01-02"));
+
+        String temporaryTable =
+                createTemporaryTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Collections.emptyList(),
+                        Collections.singletonList("dt"),
+                        initialRecords,
+                        "dt:2022-01-01;dt:2022-01-02",
+                        false,
+                        "I,UA,UB,D");
+
+        String table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Collections.emptyList(),
+                        Collections.singletonList("dt"));
+
+        insertIntoFromTable(temporaryTable, table);
+
+        checkFileStorePath(table, Arrays.asList("dt=2022-01-01", "dt=2022-01-02"));
+
+        testStreamingRead(
+                        buildSimpleQuery(table),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                                changelogRow("+I", "Euro", 115L, "2022-01-02")))
+                .close();
+
+        // test partition filter
+        testStreamingRead(
+                        buildQuery(table, "*", "WHERE dt IS NOT NULL"),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                                changelogRow("+I", "Euro", 115L, "2022-01-02")))
+                .close();
+
+        testStreamingRead(buildQuery(table, "*", "WHERE dt IS NULL"), Collections.emptyList())
+                .close();
+
+        // test field filter
+        testStreamingRead(
+                        buildQuery(table, "*", "WHERE currency = 'US Dollar' OR rate = 115"),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                                changelogRow("+I", "Euro", 115L, "2022-01-02")))
+                .close();
+
+        // test partition and field filter
+        testStreamingRead(
+                        buildQuery(
+                                table,
+                                "*",
+                                "WHERE (dt = '2022-01-02' AND currency = 'US Dollar') OR (dt = '2022-01-01' AND rate = 115)"),
+                        Collections.emptyList())
+                .close();
+
+        // test projection
+        testStreamingRead(
+                        buildQuery(table, "rate", ""),
+                        Arrays.asList(changelogRow("+I", 102L), changelogRow("+I", 115L)))
+                .close();
+
+        // test projection and filter
+        testStreamingRead(
+                        buildQuery(table, "rate", "WHERE dt <> '2022-01-01'"),
+                        Collections.singletonList(changelogRow("+I", 115L)))
+                .close();
+    }
+
+    @Test
+    public void testSReadWriteWithNonPartitionedRecordsWithPk() throws Exception {
+        // file store bounded read with merge
+        List<Row> initialRecords =
+                Arrays.asList(
+                        changelogRow("+I", "US Dollar", 102L),
+                        changelogRow("+I", "Euro", 114L),
+                        changelogRow("+I", "Yen", 1L),
+                        changelogRow("+U", "Euro", 116L),
+                        changelogRow("-D", "Euro", 116L),
+                        changelogRow("+I", "Euro", 119L),
+                        changelogRow("+U", "Euro", 119L),
+                        changelogRow("-D", "Yen", 1L));
+
+        String temporaryTable =
+                createTemporaryTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.singletonList("currency"),
+                        Collections.emptyList(),
+                        initialRecords,
+                        null,
+                        false,
+                        "I, UA, D");
+
+        String table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.singletonList("currency"),
+                        Collections.emptyList());
+
+        insertIntoFromTable(temporaryTable, table);
+
+        checkFileStorePath(table, Collections.emptyList());
+
+        testStreamingRead(
+                        buildSimpleQuery(table),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L),
+                                changelogRow("+I", "Euro", 119L)))
+                .close();
+
+        // test field filter
+        testStreamingRead(buildQuery(table, "*", "WHERE currency = 'Yen'"), Collections.emptyList())
+                .close();
+
+        // test projection
+        testStreamingRead(
+                        buildQuery(table, "currency", ""),
+                        Arrays.asList(changelogRow("+I", "US Dollar"), changelogRow("+I", "Euro")))
+                .close();
+
+        // test projection and filter
+        testStreamingRead(
+                        buildQuery(table, "currency", "WHERE rate = 102"),
+                        Collections.singletonList(changelogRow("+I", "US Dollar")))
+                .close();
+    }
+
+    @Test
+    public void testReadWriteWithNonPartitionedRecordsWithoutPk() throws Exception {
+        // with default full scan mode, will merge
+        List<Row> initialRecords =
+                Arrays.asList(
+                        changelogRow("+I", "US Dollar", 102L),
+                        changelogRow("+I", "Euro", 114L),
+                        changelogRow("+I", "Yen", 1L),
+                        changelogRow("-U", "Euro", 114L),
+                        changelogRow("+U", "Euro", 116L),
+                        changelogRow("-D", "Euro", 116L),
+                        changelogRow("+I", "Euro", 119L),
+                        changelogRow("-U", "Euro", 119L),
+                        changelogRow("+U", "Euro", 119L),
+                        changelogRow("-D", "Yen", 1L),
+                        changelogRow("+I", null, 100L),
+                        changelogRow("+I", "HK Dollar", null));
+
+        String temporaryTable =
+                createTemporaryTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        initialRecords,
+                        null,
+                        false,
+                        "I,UA,UB,D");
+
+        String table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.emptyList(),
+                        Collections.emptyList());
+
+        insertIntoFromTable(temporaryTable, table);
+
+        checkFileStorePath(table, Collections.emptyList());
+
+        testStreamingRead(
+                        buildSimpleQuery(table),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L),
+                                changelogRow("+I", "Euro", 119L),
+                                changelogRow("+I", null, 100L),
+                                changelogRow("+I", "HK Dollar", null)))
+                .close();
+
+        // test field filter
+        testStreamingRead(
+                        buildQuery(table, "*", "WHERE currency IS NOT NULL"),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L),
+                                changelogRow("+I", "Euro", 119L),
+                                changelogRow("+I", "HK Dollar", null)))
+                .close();
+
+        testStreamingRead(
+                        buildQuery(table, "*", "WHERE rate IS NOT NULL"),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L),
+                                changelogRow("+I", "Euro", 119L),
+                                changelogRow("+I", null, 100L)))
+                .close();
+
+        // test projection and filter
+        testStreamingRead(
+                        buildQuery(
+                                table, "rate", "WHERE currency IS NOT NULL AND rate IS NOT NULL"),
+                        Arrays.asList(changelogRow("+I", 102L), changelogRow("+I", 119L)))
+                .close();
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // Read First/Manually create Kafka log table/scan.mode = latest
+    // ----------------------------------------------------------------------------------------------------------------
+
+    @Test
+    public void testReadLatestChangelogOfPartitionedRecordsWithPk() throws Exception {
+        List<Row> initialRecords =
+                Arrays.asList(
+                        // dt = 2022-01-01
+                        changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                        changelogRow("+I", "Euro", 114L, "2022-01-01"),
+                        changelogRow("+I", "Yen", 1L, "2022-01-01"),
+                        changelogRow("+U", "Euro", 116L, "2022-01-01"),
+                        changelogRow("-D", "Yen", 1L, "2022-01-01"),
+                        changelogRow("-D", "Euro", 116L, "2022-01-01"),
+                        // dt = 2022-01-02
+                        changelogRow("+I", "Euro", 119L, "2022-01-02"),
+                        changelogRow("+U", "Euro", 119L, "2022-01-02"));
+
+        String temporaryTable =
+                createTemporaryTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Arrays.asList("currency", "dt"),
+                        Collections.singletonList("dt"),
+                        initialRecords,
+                        "dt:2022-01-01;dt:2022-01-02",
+                        false,
+                        "I,UA,D");
+
+        String table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Arrays.asList("currency", "dt"),
+                        Collections.singletonList("dt"),
+                        true);
+
+        BlockingIterator<Row, Row> streamItr =
+                testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(table, "*", "", scanLatest),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                                changelogRow("+I", "Euro", 114L, "2022-01-01"),
+                                changelogRow("+I", "Yen", 1L, "2022-01-01"),
+                                changelogRow("-U", "Euro", 114L, "2022-01-01"),
+                                changelogRow("+U", "Euro", 116L, "2022-01-01"),
+                                changelogRow("-D", "Yen", 1L, "2022-01-01"),
+                                changelogRow("-D", "Euro", 116L, "2022-01-01"),
+                                changelogRow("+I", "Euro", 119L, "2022-01-02")));
+
+        // test only read the latest log
+        insertInto(table, "('US Dollar', 104, '2022-01-01')", "('Euro', 100, '2022-01-02')");
+        assertThat(streamItr.collect(4))
+                .containsExactlyInAnyOrderElementsOf(
+                        Arrays.asList(
+                                changelogRow("-U", "US Dollar", 102L, "2022-01-01"),
+                                changelogRow("+U", "US Dollar", 104L, "2022-01-01"),
+                                changelogRow("-U", "Euro", 119L, "2022-01-02"),
+                                changelogRow("+U", "Euro", 100L, "2022-01-02")));
+
+        assertNoMoreRecords(streamItr);
+        streamItr.close();
+
+        // test partition filter
+        table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Arrays.asList("currency", "dt"),
+                        Collections.singletonList("dt"),
+                        true);
+
+        testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(
+                                table, "*", "WHERE dt = '2022-01-01'", scanLatest),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                                changelogRow("+I", "Euro", 114L, "2022-01-01"),
+                                changelogRow("+I", "Yen", 1L, "2022-01-01"),
+                                changelogRow("-U", "Euro", 114L, "2022-01-01"),
+                                changelogRow("+U", "Euro", 116L, "2022-01-01"),
+                                changelogRow("-D", "Yen", 1L, "2022-01-01"),
+                                changelogRow("-D", "Euro", 116L, "2022-01-01")))
+                .close();
+
+        // test field filter
+        table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Arrays.asList("currency", "dt"),
+                        Collections.singletonList("dt"),
+                        true);
+
+        testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(
+                                table, "*", "WHERE currency = 'Yen'", scanLatest),
+                        Arrays.asList(
+                                changelogRow("+I", "Yen", 1L, "2022-01-01"),
+                                changelogRow("-D", "Yen", 1L, "2022-01-01")))
+                .close();
+
+        table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Arrays.asList("currency", "dt"),
+                        Collections.singletonList("dt"),
+                        true);
+
+        testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(table, "*", "WHERE rate = 114", scanLatest),
+                        Arrays.asList(
+                                // part = 2022-01-01
+                                changelogRow("+I", "Euro", 114L, "2022-01-01"),
+                                changelogRow("-U", "Euro", 114L, "2022-01-01")))
+                .close();
+
+        // test partition and field filter
+        table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Arrays.asList("currency", "dt"),
+                        Collections.singletonList("dt"),
+                        true);
+
+        testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(
+                                table, "*", "WHERE rate = 114 AND dt = '2022-01-02'", scanLatest),
+                        Collections.emptyList())
+                .close();
+
+        // test projection
+        table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Arrays.asList("currency", "dt"),
+                        Collections.singletonList("dt"),
+                        true);
+
+        testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(table, "rate", "", scanLatest),
+                        Arrays.asList(
+                                // part = 2022-01-01
+                                changelogRow("+I", 102L), // US Dollar
+                                changelogRow("+I", 114L), // Euro
+                                changelogRow("+I", 1L), // Yen
+                                changelogRow("-U", 114L), // Euro
+                                changelogRow("+U", 116L), // Euro
+                                changelogRow("-D", 1L), // Yen
+                                changelogRow("-D", 116L), // Euro
+                                // part = 2022-01-02
+                                changelogRow("+I", 119L) // Euro
+                                ))
+                .close();
+
+        // test projection and filter
+        table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Arrays.asList("currency", "dt"),
+                        Collections.singletonList("dt"),
+                        true);
+
+        testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(
+                                table, "rate", "WHERE dt = '2022-01-02'", scanLatest),
+                        Collections.singletonList(changelogRow("+I", 119L)) // Euro
+                        )
+                .close();
+    }
+
+    @Test
+    public void testReadLatestChangelogOfPartitionedRecordsWithoutPk() throws Exception {
+        List<Row> initialRecords =
+                Arrays.asList(
+                        // dt = 2022-01-01
+                        changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                        changelogRow("+I", "Euro", 116L, "2022-01-01"),
+                        changelogRow("-D", "Euro", 116L, "2022-01-01"),
+                        changelogRow("+I", "Yen", 1L, "2022-01-01"),
+                        changelogRow("-D", "Yen", 1L, "2022-01-01"),
+                        // dt = 2022-01-02
+                        changelogRow("+I", "Euro", 114L, "2022-01-02"),
+                        changelogRow("-U", "Euro", 114L, "2022-01-02"),
+                        changelogRow("+U", "Euro", 119L, "2022-01-02"),
+                        changelogRow("-D", "Euro", 119L, "2022-01-02"),
+                        changelogRow("+I", "Euro", 115L, "2022-01-02"));
+
+        String temporaryTable =
+                createTemporaryTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Collections.emptyList(),
+                        Collections.singletonList("dt"),
+                        initialRecords,
+                        "dt:2022-01-01;dt:2022-01-02",
+                        false,
+                        "I,UA,UB,D");
+
+        String table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Collections.emptyList(),
+                        Collections.singletonList("dt"),
+                        true);
+
+        testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(table, "*", "", scanLatest),
+                        Arrays.asList(
+                                // part = 2022-01-01
+                                changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                                changelogRow("+I", "Euro", 116L, "2022-01-01"),
+                                changelogRow("-D", "Euro", 116L, "2022-01-01"),
+                                changelogRow("+I", "Yen", 1L, "2022-01-01"),
+                                changelogRow("-D", "Yen", 1L, "2022-01-01"),
+                                // part = 2022-01-02
+                                changelogRow("+I", "Euro", 114L, "2022-01-02"),
+                                changelogRow("-D", "Euro", 114L, "2022-01-02"),
+                                changelogRow("+I", "Euro", 119L, "2022-01-02"),
+                                changelogRow("-D", "Euro", 119L, "2022-01-02"),
+                                changelogRow("+I", "Euro", 115L, "2022-01-02")))
+                .close();
+
+        // test partition filter
+        table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Collections.emptyList(),
+                        Collections.singletonList("dt"),
+                        true);
+
+        testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(
+                                table, "*", "WHERE dt = '2022-01-01'", scanLatest),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                                changelogRow("+I", "Euro", 116L, "2022-01-01"),
+                                changelogRow("-D", "Euro", 116L, "2022-01-01"),
+                                changelogRow("+I", "Yen", 1L, "2022-01-01"),
+                                changelogRow("-D", "Yen", 1L, "2022-01-01")))
+                .close();
+
+        // test field filter
+        testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(
+                                table, "*", "WHERE currency = 'US Dollar' OR rate = 1", scanLatest),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                                changelogRow("+I", "Yen", 1L, "2022-01-01"),
+                                changelogRow("-D", "Yen", 1L, "2022-01-01")))
+                .close();
+
+        // test partition and field filter
+        table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Collections.emptyList(),
+                        Collections.singletonList("dt"),
+                        true);
+
+        testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(
+                                table, "*", "WHERE dt = '2022-01-02' AND rate = 114", scanLatest),
+                        Arrays.asList(
+                                changelogRow("+I", "Euro", 114L, "2022-01-02"),
+                                changelogRow("-D", "Euro", 114L, "2022-01-02")))
+                .close();
+
+        // test projection
+        table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Collections.emptyList(),
+                        Collections.singletonList("dt"),
+                        true);
+
+        testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(table, "rate", "", scanLatest),
+                        Arrays.asList(
+                                changelogRow("+I", 102L),
+                                changelogRow("+I", 116L),
+                                changelogRow("-D", 116L),
+                                changelogRow("+I", 1L),
+                                changelogRow("-D", 1L),
+                                changelogRow("+I", 114L),
+                                changelogRow("-D", 114L),
+                                changelogRow("+I", 119L),
+                                changelogRow("-D", 119L),
+                                changelogRow("+I", 115L)))
+                .close();
+
+        // test projection and filter
+        table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Collections.emptyList(),
+                        Collections.singletonList("dt"),
+                        true);
+
+        testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(
+                                table, "rate", "WHERE dt <> '2022-01-01'", scanLatest),
+                        Arrays.asList(
+                                changelogRow("+I", 114L),
+                                changelogRow("-D", 114L),
+                                changelogRow("+I", 119L),
+                                changelogRow("-D", 119L),
+                                changelogRow("+I", 115L)))
+                .close();
+    }
+
+    @Test
+    public void testReadLatestChangelogOfNonPartitionedRecordsWithPk() throws Exception {
+        List<Row> initialRecords =
+                Arrays.asList(
+                        changelogRow("+I", "US Dollar", 102L),
+                        changelogRow("+I", "Euro", 114L),
+                        changelogRow("+I", "Yen", 1L),
+                        changelogRow("+U", "Euro", 116L),
+                        changelogRow("-D", "Euro", 116L),
+                        changelogRow("+I", "Euro", 119L),
+                        changelogRow("+U", "Euro", 119L),
+                        changelogRow("-D", "Yen", 1L));
+
+        String temporaryTable =
+                createTemporaryTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.singletonList("currency"),
+                        Collections.emptyList(),
+                        initialRecords,
+                        null,
+                        false,
+                        "I,UA,D");
+
+        String table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.singletonList("currency"),
+                        Collections.emptyList(),
+                        true);
+
+        testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(table, "*", "", scanLatest),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L),
+                                changelogRow("+I", "Euro", 114L),
+                                changelogRow("+I", "Yen", 1L),
+                                changelogRow("-U", "Euro", 114L),
+                                changelogRow("+U", "Euro", 116L),
+                                changelogRow("-D", "Euro", 116L),
+                                changelogRow("+I", "Euro", 119L),
+                                changelogRow("-D", "Yen", 1L)))
+                .close();
+
+        // test field filter
+        table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.singletonList("currency"),
+                        Collections.emptyList(),
+                        true);
+
+        testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(
+                                table, "*", "WHERE currency = 'Euro'", scanLatest),
+                        Arrays.asList(
+                                changelogRow("+I", "Euro", 114L),
+                                changelogRow("-U", "Euro", 114L),
+                                changelogRow("+U", "Euro", 116L),
+                                changelogRow("-D", "Euro", 116L),
+                                changelogRow("+I", "Euro", 119L)))
+                .close();
+
+        // test projection
+        table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.singletonList("currency"),
+                        Collections.emptyList(),
+                        true);
+
+        testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(table, "currency", "", scanLatest),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar"),
+                                changelogRow("+I", "Euro"),
+                                changelogRow("+I", "Yen"),
+                                changelogRow("-D", "Euro"),
+                                changelogRow("+I", "Euro"),
+                                changelogRow("-D", "Yen")))
+                .close();
+
+        // test projection and filter
+        table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.singletonList("currency"),
+                        Collections.emptyList(),
+                        true);
+
+        testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(
+                                table, "rate", "WHERE currency = 'Euro'", scanLatest),
+                        Arrays.asList(
+                                changelogRow("+I", 114L),
+                                changelogRow("-U", 114L),
+                                changelogRow("+U", 116L),
+                                changelogRow("-D", 116L),
+                                changelogRow("+I", 119L)))
+                .close();
+    }
+
+    @Test
+    public void testReadLatestChangelogOfNonPartitionedRecordsWithoutPk() throws Exception {
+        List<Row> initialRecords =
+                Arrays.asList(
+                        changelogRow("+I", "US Dollar", 102L),
+                        changelogRow("+I", "Euro", 114L),
+                        changelogRow("+I", "Yen", 1L),
+                        changelogRow("-U", "Euro", 114L),
+                        changelogRow("+U", "Euro", 116L),
+                        changelogRow("-D", "Euro", 116L),
+                        changelogRow("+I", "Euro", 119L),
+                        changelogRow("-U", "Euro", 119L),
+                        changelogRow("+U", "Euro", 119L),
+                        changelogRow("-D", "Yen", 1L),
+                        changelogRow("+I", null, 100L),
+                        changelogRow("+I", "HK Dollar", null));
+
+        String temporaryTable =
+                createTemporaryTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        initialRecords,
+                        null,
+                        false,
+                        "I,UA,UB,D");
+
+        String table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        true);
+
+        testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(table, "*", "", scanLatest),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L),
+                                changelogRow("+I", "Euro", 114L),
+                                changelogRow("+I", "Yen", 1L),
+                                changelogRow("-D", "Euro", 114L),
+                                changelogRow("+I", "Euro", 116L),
+                                changelogRow("-D", "Euro", 116L),
+                                changelogRow("+I", "Euro", 119L),
+                                changelogRow("-D", "Euro", 119L),
+                                changelogRow("+I", "Euro", 119L),
+                                changelogRow("-D", "Yen", 1L),
+                                changelogRow("+I", null, 100L),
+                                changelogRow("+I", "HK Dollar", null)))
+                .close();
+
+        // test field filter
+        table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        true);
+
+        testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(
+                                table, "*", "WHERE currency = 'Euro'", scanLatest),
+                        Arrays.asList(
+                                changelogRow("+I", "Euro", 114L),
+                                changelogRow("-D", "Euro", 114L),
+                                changelogRow("+I", "Euro", 116L),
+                                changelogRow("-D", "Euro", 116L),
+                                changelogRow("+I", "Euro", 119L),
+                                changelogRow("-D", "Euro", 119L),
+                                changelogRow("+I", "Euro", 119L)))
+                .close();
+
+        // test projection
+        table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        true);
+
+        testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(table, "currency, rate", "", scanLatest),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L),
+                                changelogRow("+I", "Euro", 114L),
+                                changelogRow("+I", "Yen", 1L),
+                                changelogRow("-D", "Euro", 114L),
+                                changelogRow("+I", "Euro", 116L),
+                                changelogRow("-D", "Euro", 116L),
+                                changelogRow("+I", "Euro", 119L),
+                                changelogRow("-D", "Euro", 119L),
+                                changelogRow("+I", "Euro", 119L),
+                                changelogRow("-D", "Yen", 1L),
+                                changelogRow("+I", null, 100L),
+                                changelogRow("+I", "HK Dollar", null)))
+                .close();
+
+        // test projection and filter
+        table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        true);
+
+        testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(
+                                table, "currency", "WHERE currency IS NOT NULL", scanLatest),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar"),
+                                changelogRow("+I", "Euro"),
+                                changelogRow("+I", "Yen"),
+                                changelogRow("-D", "Euro"),
+                                changelogRow("+I", "Euro"),
+                                changelogRow("-D", "Euro"),
+                                changelogRow("+I", "Euro"),
+                                changelogRow("-D", "Euro"),
+                                changelogRow("+I", "Euro"),
+                                changelogRow("-D", "Yen"),
+                                changelogRow("+I", "HK Dollar")))
+                .close();
+
+        table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        true);
+
+        testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(
+                                table, "currency", "WHERE rate = 119", scanLatest),
+                        Arrays.asList(
+                                changelogRow("+I", "Euro"),
+                                changelogRow("-D", "Euro"),
+                                changelogRow("+I", "Euro")))
+                .close();
+    }
+
+    @Test
+    public void testReadLatestChangelogOfInsertOnlyRecords() throws Exception {
+        List<Row> initialRecords =
+                Arrays.asList(
+                        changelogRow("+I", "US Dollar", 102L),
+                        changelogRow("+I", "Euro", 114L),
+                        changelogRow("+I", "Yen", 1L),
+                        changelogRow("+I", "Euro", 114L),
+                        changelogRow("+I", "Euro", 119L));
+
+        // without pk
+        String temporaryTable =
+                createTemporaryTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        initialRecords,
+                        null,
+                        true,
+                        "I");
+
+        String table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        true);
+
+        testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(table, "*", "", scanLatest),
+                        initialRecords)
+                .close();
+
+        // currency as pk in the next tests
+        temporaryTable =
+                createTemporaryTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.singletonList("currency"),
+                        Collections.emptyList(),
+                        initialRecords,
+                        null,
+                        true,
+                        "I");
+
+        table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.singletonList("currency"),
+                        Collections.emptyList(),
+                        true);
+
+        testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(table, "*", "", scanLatest),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L),
+                                changelogRow("+I", "Euro", 114L),
+                                changelogRow("+I", "Yen", 1L),
+                                changelogRow("-U", "Euro", 114L),
+                                changelogRow("+U", "Euro", 119L)))
+                .close();
+
+        // test field filter
+        table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.singletonList("currency"),
+                        Collections.emptyList(),
+                        true);
+
+        testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(table, "*", "WHERE rate = 114", scanLatest),
+                        Arrays.asList(
+                                changelogRow("+I", "Euro", 114L), changelogRow("-U", "Euro", 114L)))
+                .close();
+
+        // test projection
+        table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.singletonList("currency"),
+                        Collections.emptyList(),
+                        true);
+
+        testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(table, "rate", "", scanLatest),
+                        Arrays.asList(
+                                changelogRow("+I", 102L),
+                                changelogRow("+I", 114L),
+                                changelogRow("+I", 1L),
+                                changelogRow("-U", 114L),
+                                changelogRow("+U", 119L)))
+                .close();
+
+        // test projection and filter
+        table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.singletonList("currency"),
+                        Collections.emptyList(),
+                        true);
+
+        testStreamingReadWithReadFirst(
+                        temporaryTable,
+                        table,
+                        buildQueryWithTableOptions(
+                                table, "currency", "WHERE rate = 114", scanLatest),
+                        Arrays.asList(changelogRow("+I", "Euro"), changelogRow("-U", "Euro")))
+                .close();
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // Write First/Kafka log table auto created/scan.mode = from-timestamp
+    // ----------------------------------------------------------------------------------------------------------------
+
+    @Test
+    public void testReadInsertOnlyChangelogFromTimestamp() throws Exception {
+        // test records 0
+        List<Row> initialRecords0 =
+                Arrays.asList(
+                        // dt = 2022-01-01
+                        changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                        changelogRow("+I", "Euro", 114L, "2022-01-01"),
+                        changelogRow("+I", "Yen", 1L, "2022-01-01"),
+                        changelogRow("+I", "Euro", 114L, "2022-01-01"),
+                        changelogRow("+I", "US Dollar", 114L, "2022-01-01"),
+                        // dt = 2022-01-02
+                        changelogRow("+I", "Euro", 119L, "2022-01-02"));
+
+        // partitioned without pk, scan from timestamp 0
+        String temporaryTable =
+                createTemporaryTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Collections.emptyList(),
+                        Collections.singletonList("dt"),
+                        initialRecords0,
+                        "dt:2022-01-01;dt:2022-01-02",
+                        true,
+                        "I");
+
+        String table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Collections.emptyList(),
+                        Collections.singletonList("dt"));
+
+        insertIntoFromTable(temporaryTable, table);
+
+        testStreamingRead(
+                        buildQueryWithTableOptions(table, "*", "", scanFromTimeStampMillis(0L)),
+                        initialRecords0)
+                .close();
+
+        // partitioned with pk, scan from timestamp 0
+        temporaryTable =
+                createTemporaryTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Arrays.asList("currency", "dt"),
+                        Collections.singletonList("dt"),
+                        initialRecords0,
+                        "dt:2022-01-01;dt:2022-01-02",
+                        true,
+                        "I");
+
+        table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Arrays.asList("currency", "dt"),
+                        Collections.singletonList("dt"));
+
+        insertIntoFromTable(temporaryTable, table);
+
+        testStreamingRead(
+                        buildQueryWithTableOptions(table, "*", "", scanFromTimeStampMillis(0L)),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                                changelogRow("+I", "Yen", 1L, "2022-01-01"),
+                                changelogRow("+I", "Euro", 114L, "2022-01-01"),
+                                changelogRow("-U", "US Dollar", 102L, "2022-01-01"),
+                                changelogRow("+U", "US Dollar", 114L, "2022-01-01"),
+                                changelogRow("+I", "Euro", 119L, "2022-01-02")))
+                .close();
+
+        // test records 1
+        List<Row> initialRecords1 =
+                Arrays.asList(
+                        changelogRow("+I", "US Dollar", 102L),
+                        changelogRow("+I", "Euro", 114L),
+                        changelogRow("+I", "Yen", 1L),
+                        changelogRow("+I", "Euro", 114L),
+                        changelogRow("+I", "Euro", 119L));
+
+        // non-partitioned with pk, scan from timestamp 0
+        temporaryTable =
+                createTemporaryTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.singletonList("currency"),
+                        Collections.emptyList(),
+                        initialRecords1,
+                        null,
+                        true,
+                        "I");
+
+        table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.singletonList("currency"),
+                        Collections.emptyList());
+
+        insertIntoFromTable(temporaryTable, table);
+
+        testStreamingRead(
+                        buildQueryWithTableOptions(table, "*", "", scanFromTimeStampMillis(0L)),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L),
+                                changelogRow("+I", "Euro", 114L),
+                                changelogRow("+I", "Yen", 1L),
+                                changelogRow("-U", "Euro", 114L),
+                                changelogRow("+U", "Euro", 119L)))
+                .close();
+
+        // non-partitioned without pk, scan from timestamp 0
+        temporaryTable =
+                createTemporaryTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        initialRecords1,
+                        null,
+                        true,
+                        "I");
+
+        table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.emptyList(),
+                        Collections.emptyList());
+
+        insertIntoFromTable(temporaryTable, table);
+
+        testStreamingRead(
+                        buildQueryWithTableOptions(table, "*", "", scanFromTimeStampMillis(0L)),
+                        initialRecords1)
+                .close();
+    }
+
+    /**
+     * TODO.
+     *
+     * <p>This test will fail due to: <a
+     * href="https://issues.apache.org/jira/browse/FLINK-28185">FLINK-28185</a>. This bug will be
+     * fixed in Flink-1.16.1 and after we update flink version this case can work.
+     */
+    @Ignore
+    @Test
+    public void testReadInsertOnlyChangelogFromEnormousTimestamp() throws Exception {
+        List<Row> initialRecords =
+                Arrays.asList(
+                        changelogRow("+I", "US Dollar", 102L),
+                        changelogRow("+I", "Euro", 114L),
+                        changelogRow("+I", "Yen", 1L),
+                        changelogRow("+I", "Euro", 114L),
+                        changelogRow("+I", "Euro", 119L));
+
+        // non-partitioned without pk, scan from timestamp Long.MAX_VALUE - 1
+        String temporaryTable =
+                createTemporaryTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        initialRecords,
+                        null,
+                        true,
+                        "I");
+
+        String table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT"),
+                        Collections.emptyList(),
+                        Collections.emptyList());
+
+        insertIntoFromTable(temporaryTable, table);
+
+        testStreamingRead(
+                        buildQueryWithTableOptions(
+                                table, "*", "", scanFromTimeStampMillis(Long.MAX_VALUE - 1)),
+                        Collections.emptyList())
+                .close();
+    }
+
+    @Test
+    public void testReadRetractChangelogFromTimestamp() throws Exception {
+        // test data 0
+        List<Row> initialRecords0 =
+                Arrays.asList(
+                        // dt = 2022-01-01
+                        changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                        changelogRow("+I", "Euro", 116L, "2022-01-01"),
+                        changelogRow("-D", "Euro", 116L, "2022-01-01"),
+                        changelogRow("+I", "Yen", 1L, "2022-01-01"),
+                        changelogRow("-D", "Yen", 1L, "2022-01-01"),
+                        // dt = 2022-01-02
+                        changelogRow("+I", "Euro", 114L, "2022-01-02"),
+                        changelogRow("-U", "Euro", 114L, "2022-01-02"),
+                        changelogRow("+U", "Euro", 119L, "2022-01-02"),
+                        changelogRow("-D", "Euro", 119L, "2022-01-02"),
+                        changelogRow("+I", "Euro", 115L, "2022-01-02"));
+
+        // partitioned without pk, scan from timestamp 0
+        String temporaryTable =
+                createTemporaryTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Collections.emptyList(),
+                        Collections.singletonList("dt"),
+                        initialRecords0,
+                        "dt:2022-01-01;dt:2022-01-02",
+                        false,
+                        "I,UA,UB,D");
+
+        String table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Collections.emptyList(),
+                        Collections.singletonList("dt"));
+
+        insertIntoFromTable(temporaryTable, table);
+
+        testStreamingRead(
+                        buildQueryWithTableOptions(table, "*", "", scanFromTimeStampMillis(0L)),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                                changelogRow("+I", "Euro", 116L, "2022-01-01"),
+                                changelogRow("-D", "Euro", 116L, "2022-01-01"),
+                                changelogRow("+I", "Yen", 1L, "2022-01-01"),
+                                changelogRow("-D", "Yen", 1L, "2022-01-01"),
+                                changelogRow("+I", "Euro", 114L, "2022-01-02"),
+                                changelogRow("-D", "Euro", 114L, "2022-01-02"),
+                                changelogRow("+I", "Euro", 119L, "2022-01-02"),
+                                changelogRow("-D", "Euro", 119L, "2022-01-02"),
+                                changelogRow("+I", "Euro", 115L, "2022-01-02")))
+                .close();
+
+        // input is dailyRatesChangelogWithoutUB()
+        // test data 1
+        List<Row> initialRecords1 =
+                Arrays.asList(
+                        // dt = 2022-01-01
+                        changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                        changelogRow("+I", "Euro", 114L, "2022-01-01"),
+                        changelogRow("+I", "Yen", 1L, "2022-01-01"),
+                        changelogRow("+U", "Euro", 116L, "2022-01-01"),
+                        changelogRow("-D", "Yen", 1L, "2022-01-01"),
+                        changelogRow("-D", "Euro", 116L, "2022-01-01"),
+                        // dt = 2022-01-02
+                        changelogRow("+I", "Euro", 119L, "2022-01-02"),
+                        changelogRow("+U", "Euro", 119L, "2022-01-02"));
+
+        // partitioned with pk, scan from timestamp 0
+        temporaryTable =
+                createTemporaryTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Arrays.asList("currency", "dt"),
+                        Collections.singletonList("dt"),
+                        initialRecords1,
+                        "dt:2022-01-01;dt:2022-01-02",
+                        false,
+                        "I,UA,D");
+
+        table =
+                createTable(
+                        Arrays.asList("currency STRING", "rate BIGINT", "dt STRING"),
+                        Arrays.asList("currency", "dt"),
+                        Collections.singletonList("dt"));
+
+        insertIntoFromTable(temporaryTable, table);
+
+        testStreamingRead(
+                        buildQueryWithTableOptions(table, "*", "", scanFromTimeStampMillis(0L)),
+                        Arrays.asList(
+                                changelogRow("+I", "US Dollar", 102L, "2022-01-01"),
+                                changelogRow("+I", "Euro", 114L, "2022-01-01"),
+                                changelogRow("+I", "Yen", 1L, "2022-01-01"),
+                                changelogRow("-U", "Euro", 114L, "2022-01-01"),
+                                changelogRow("+U", "Euro", 116L, "2022-01-01"),
+                                changelogRow("-D", "Yen", 1L, "2022-01-01"),
+                                changelogRow("-D", "Euro", 116L, "2022-01-01"),
+                                changelogRow("+I", "Euro", 119L, "2022-01-02")))
+                .close();
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // Tools
+    // ----------------------------------------------------------------------------------------------------------------
+
+    private String createTable(
+            List<String> fieldsSpec, List<String> primaryKeys, List<String> partitionKeys)
+            throws Exception {
+        return createTable(fieldsSpec, primaryKeys, partitionKeys, false);
+    }
+
+    private String createTable(
+            List<String> fieldsSpec,
+            List<String> primaryKeys,
+            List<String> partitionKeys,
+            boolean manuallyCreateLogTable)
+            throws Exception {
+        String topic = "topic_" + UUID.randomUUID();
+        String table =
+                ReadWriteTableTestUtil.createTable(
+                        fieldsSpec,
+                        primaryKeys,
+                        partitionKeys,
+                        new HashMap<String, String>() {
+                            {
+                                put(LOG_SYSTEM.key(), "kafka");
+                                put(BOOTSTRAP_SERVERS.key(), getBootstrapServers());
+                                put(TOPIC.key(), topic);
+                            }
+                        });
+
+        if (manuallyCreateLogTable) {
+            createKafkaLogTable(topic);
+        }
+
+        return table;
+    }
+
+    private void createKafkaLogTable(String topic) throws Exception {
+        Properties properties = new Properties();
+        properties.put("bootstrap.servers", getBootstrapServers());
+
+        try (AdminClient adminClient = AdminClient.create(properties)) {
+            NewTopic topicObj =
+                    new NewTopic(topic, Optional.of(1), Optional.empty()).configs(new HashMap<>());
+            adminClient.createTopics(Collections.singleton(topicObj)).all().get();
+        }
+    }
+
+    private Map<String, String> scanFromTimeStampMillis(Long timeStampMillis) {
+        return new HashMap<String, String>() {
+            {
+                put(SCAN_MODE.key(), CoreOptions.StartupMode.FROM_TIMESTAMP.toString());
+                put(SCAN_TIMESTAMP_MILLIS.key(), String.valueOf(timeStampMillis));
+            }
+        };
+    }
+}

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/util/AbstractTestBase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/util/AbstractTestBase.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector.util;
+
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.util.FileUtils;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.UUID;
+
+/** Similar to Flink's AbstractTestBase but using Junit5. */
+public class AbstractTestBase extends TestLogger {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(org.apache.flink.test.util.AbstractTestBase.class);
+
+    private static final int DEFAULT_PARALLELISM = 4;
+
+    @RegisterExtension
+    protected static final MiniClusterExtension MINI_CLUSTER_EXTENSION =
+            new MiniClusterExtension(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(1)
+                            .setNumberSlotsPerTaskManager(DEFAULT_PARALLELISM)
+                            .build());
+
+    @TempDir protected static Path temporaryFolder;
+
+    // @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+    // ----------------------------------------------------------------------------------------------------------------
+    //  Temporary File Utilities
+    // ----------------------------------------------------------------------------------------------------------------
+
+    protected String getTempDirPath() {
+        return getTempDirPath("");
+    }
+
+    protected String getTempDirPath(String dirName) {
+        return createAndRegisterTempFile(dirName).toString();
+    }
+
+    protected String getTempFilePath(String fileName) {
+        return createAndRegisterTempFile(fileName).toString();
+    }
+
+    protected String createTempFile(String fileName, String contents) throws IOException {
+        File f = createAndRegisterTempFile(fileName);
+        if (!f.getParentFile().exists()) {
+            f.getParentFile().mkdirs();
+        }
+        f.createNewFile();
+        FileUtils.writeFileUtf8(f, contents);
+        return f.toString();
+    }
+
+    /** Create a subfolder to avoid returning the same folder when passing same file name. */
+    protected File createAndRegisterTempFile(String fileName) {
+        return new File(
+                temporaryFolder.toFile(), String.format("%s/%s", UUID.randomUUID(), fileName));
+    }
+}

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/util/AbstractTestBase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/util/AbstractTestBase.java
@@ -51,8 +51,6 @@ public class AbstractTestBase extends TestLogger {
 
     @TempDir protected static Path temporaryFolder;
 
-    // @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
-
     // ----------------------------------------------------------------------------------------------------------------
     //  Temporary File Utilities
     // ----------------------------------------------------------------------------------------------------------------

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/util/ReadWriteTableTestUtil.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/util/ReadWriteTableTestUtil.java
@@ -1,0 +1,330 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector.util;
+
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.store.connector.ReadWriteTableITCase;
+import org.apache.flink.table.store.connector.StreamingReadWriteTableWithKafkaLogITCase;
+import org.apache.flink.table.store.file.utils.BlockingIterator;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+
+import javax.annotation.Nullable;
+
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.apache.flink.table.planner.factories.TestValuesTableFactory.registerData;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test util for {@link ReadWriteTableITCase} and {@link StreamingReadWriteTableWithKafkaLogITCase}.
+ */
+public class ReadWriteTableTestUtil {
+
+    private static final Time TIME_OUT = Time.seconds(10);
+
+    public static final int DEFAULT_PARALLELISM = 2;
+
+    public static TableEnvironment sEnv;
+
+    public static StreamExecutionEnvironment bExeEnv;
+    public static TableEnvironment bEnv;
+
+    public static String warehouse;
+
+    public static void init(String warehouse) {
+        StreamExecutionEnvironment sExeEnv = buildStreamEnv(DEFAULT_PARALLELISM);
+        sExeEnv.getConfig().setRestartStrategy(RestartStrategies.noRestart());
+        sEnv = StreamTableEnvironment.create(sExeEnv);
+
+        bExeEnv = buildBatchEnv(DEFAULT_PARALLELISM);
+        bExeEnv.getConfig().setRestartStrategy(RestartStrategies.noRestart());
+        bEnv = StreamTableEnvironment.create(bExeEnv, EnvironmentSettings.inBatchMode());
+
+        ReadWriteTableTestUtil.warehouse = warehouse;
+        String catalog = "TABLE_STORE";
+        sEnv.executeSql(
+                String.format(
+                        "CREATE CATALOG %s WITH ('type'='table-store', 'warehouse'='%s');",
+                        catalog, warehouse));
+        sEnv.useCatalog(catalog);
+
+        bEnv.registerCatalog(catalog, sEnv.getCatalog(catalog).get());
+        bEnv.useCatalog(catalog);
+    }
+
+    private static StreamExecutionEnvironment buildStreamEnv(int parallelism) {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setRuntimeMode(RuntimeExecutionMode.STREAMING);
+        env.enableCheckpointing(100);
+        env.setParallelism(parallelism);
+        return env;
+    }
+
+    private static StreamExecutionEnvironment buildBatchEnv(int parallelism) {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
+        env.setParallelism(parallelism);
+        return env;
+    }
+
+    public static String createTable(
+            List<String> fieldsSpec, List<String> primaryKeys, List<String> partitionKeys) {
+        return createTable(fieldsSpec, primaryKeys, partitionKeys, new HashMap<>());
+    }
+
+    public static String createTable(
+            List<String> fieldsSpec,
+            List<String> primaryKeys,
+            List<String> partitionKeys,
+            Map<String, String> options) {
+        String table = "MyTable_" + UUID.randomUUID();
+        sEnv.executeSql(buildDdl(table, fieldsSpec, primaryKeys, partitionKeys, options));
+        return table;
+    }
+
+    public static String createTemporaryTable(
+            List<String> fieldsSpec,
+            List<String> primaryKeys,
+            List<String> partitionKeys,
+            List<Row> initialRecords,
+            @Nullable String partitionList,
+            boolean bounded,
+            String changelogMode) {
+        String temporaryTableDdlFormat =
+                "CREATE TEMPORARY TABLE `%s`( %s %s) %s WITH (\n"
+                        + "'connector' = 'values',\n"
+                        + "'disable-lookup' = 'true',\n"
+                        + "'data-id' = '%s',\n"
+                        + "%s"
+                        + "'bounded' = '%s',\n"
+                        + "'changelog-mode' = '%s'\n"
+                        + ");";
+
+        String temporaryTable = "temp_" + UUID.randomUUID();
+
+        sEnv.executeSql(
+                String.format(
+                        temporaryTableDdlFormat,
+                        temporaryTable,
+                        String.join(",", fieldsSpec),
+                        buildPkConstraint(primaryKeys),
+                        buildPartitionSpec(partitionKeys),
+                        registerData(initialRecords),
+                        partitionList == null
+                                ? ""
+                                : String.format("'partition-list' = '%s',\n", partitionList),
+                        bounded,
+                        changelogMode));
+
+        return temporaryTable;
+    }
+
+    public static void insertInto(String table, String... records) throws Exception {
+        insertIntoPartition(table, "", records);
+    }
+
+    public static void insertIntoPartition(String table, String partitionSpec, String... records)
+            throws Exception {
+        sEnv.executeSql(
+                        String.format(
+                                "INSERT INTO `%s` %s VALUES %s;",
+                                table, partitionSpec, String.join(",", records)))
+                .await();
+    }
+
+    public static void insertIntoFromTable(String source, String sink) throws Exception {
+        sEnv.executeSql(String.format("INSERT INTO `%s` SELECT * FROM `%s`;", sink, source))
+                .await();
+    }
+
+    public static void insertOverwrite(String table, String... records) throws Exception {
+        insertOverwritePartition(table, "", records);
+    }
+
+    public static void insertOverwritePartition(
+            String table, String partitionSpe, String... records) throws Exception {
+        String insert =
+                String.format(
+                        "INSERT OVERWRITE `%s` %s VALUES %s;",
+                        table, partitionSpe, String.join(",", records));
+        bEnv.executeSql(insert).await();
+    }
+
+    public static String buildSimpleQuery(String table) {
+        return buildQuery(table, "*", "");
+    }
+
+    public static String buildQuery(String table, String projection, String filter) {
+        return buildQueryWithTableOptions(table, projection, filter, new HashMap<>());
+    }
+
+    public static String buildQueryWithTableOptions(
+            String table, String projection, String filter, Map<String, String> options) {
+        String queryFormat = "SELECT %s FROM `%s` %s %s;";
+        return String.format(
+                queryFormat, projection, table, buildTableOptionsSpec(options), filter);
+    }
+
+    public static void checkFileStorePath(String table, List<String> partitionSpec) {
+        String relativeFilePath = String.format("/%s.db/%s", sEnv.getCurrentDatabase(), table);
+        // check snapshot file path
+        assertThat(Paths.get(warehouse, relativeFilePath, "snapshot")).exists();
+        // check manifest file path
+        assertThat(Paths.get(warehouse, relativeFilePath, "manifest")).exists();
+        // check data file path
+        if (partitionSpec.isEmpty()) {
+            partitionSpec = Collections.singletonList("");
+        }
+        partitionSpec.stream()
+                .map(str -> str.replaceAll(",", "/"))
+                .forEach(
+                        partition -> {
+                            assertThat(Paths.get(warehouse, relativeFilePath, partition)).exists();
+                            // at least exists bucket-0
+                            assertThat(
+                                            Paths.get(
+                                                    warehouse,
+                                                    relativeFilePath,
+                                                    partition,
+                                                    "bucket-0"))
+                                    .exists();
+                        });
+    }
+
+    public static void testBatchRead(String query, List<Row> expected) throws Exception {
+        CloseableIterator<Row> resultItr = bEnv.executeSql(query).collect();
+        try (BlockingIterator<Row, Row> iterator = BlockingIterator.of(resultItr)) {
+            if (expected.isEmpty()) {
+                assertThat(resultItr.hasNext()).isFalse();
+            } else {
+                assertThat(
+                                iterator.collect(
+                                        expected.size(), TIME_OUT.getSize(), TIME_OUT.getUnit()))
+                        .containsExactlyInAnyOrderElementsOf(expected);
+            }
+        }
+    }
+
+    public static BlockingIterator<Row, Row> testStreamingRead(String query, List<Row> expected)
+            throws Exception {
+        BlockingIterator<Row, Row> iterator = BlockingIterator.of(sEnv.executeSql(query).collect());
+
+        if (expected.isEmpty()) {
+            assertNoMoreRecords(iterator);
+        } else {
+            assertThat(iterator.collect(expected.size()))
+                    .containsExactlyInAnyOrderElementsOf(expected);
+        }
+
+        return iterator;
+    }
+
+    public static BlockingIterator<Row, Row> testStreamingReadWithReadFirst(
+            String source, String sink, String query, List<Row> expected) throws Exception {
+        BlockingIterator<Row, Row> iterator = BlockingIterator.of(sEnv.executeSql(query).collect());
+
+        insertIntoFromTable(source, sink);
+
+        if (expected.isEmpty()) {
+            assertNoMoreRecords(iterator);
+        } else {
+            assertThat(iterator.collect(expected.size()))
+                    .containsExactlyInAnyOrderElementsOf(expected);
+        }
+
+        return iterator;
+    }
+
+    public static void assertNoMoreRecords(BlockingIterator<Row, Row> iterator) throws Exception {
+        List<Row> expectedRecords = Collections.emptyList();
+        try {
+            // set expectation size to 1 to let time pass by until timeout
+            // just wait 5s to avoid too long time
+            expectedRecords = iterator.collect(1, 5L, TimeUnit.SECONDS);
+            iterator.close();
+        } catch (TimeoutException ignored) {
+            // don't throw exception
+        }
+        assertThat(expectedRecords).isEmpty();
+    }
+
+    private static String buildDdl(
+            String table,
+            List<String> fieldsSpec,
+            List<String> primaryKeys,
+            List<String> partitionKeys,
+            Map<String, String> options) {
+        return String.format(
+                "CREATE TABLE `%s`(%s %s) %s %s;",
+                table,
+                String.join(",", fieldsSpec),
+                buildPkConstraint(primaryKeys),
+                buildPartitionSpec(partitionKeys),
+                buildOptionsSpec(options));
+    }
+
+    private static String buildPkConstraint(List<String> primaryKeys) {
+        if (!primaryKeys.isEmpty()) {
+            return String.format(",PRIMARY KEY (%s) NOT ENFORCED", String.join(",", primaryKeys));
+        }
+        return "";
+    }
+
+    private static String buildPartitionSpec(List<String> partitionKeys) {
+        if (!partitionKeys.isEmpty()) {
+            return String.format("PARTITIONED BY (%s)", String.join(",", partitionKeys));
+        }
+        return "";
+    }
+
+    private static String buildOptionsSpec(Map<String, String> options) {
+        if (!options.isEmpty()) {
+            return String.format("WITH ( %s )", optionsToString(options));
+        }
+        return "";
+    }
+
+    private static String buildTableOptionsSpec(Map<String, String> hints) {
+        if (!hints.isEmpty()) {
+            return String.format("/*+ OPTIONS ( %s ) */", optionsToString(hints));
+        }
+        return "";
+    }
+
+    private static String optionsToString(Map<String, String> options) {
+        List<String> pairs = new ArrayList<>();
+        options.forEach((k, v) -> pairs.add(String.format("'%s' = '%s'", k, v)));
+        return String.join(",", pairs);
+    }
+}


### PR DESCRIPTION
1. Split Kafka log related cases into a new test class.
2. `testQueryContainsDefaultFieldName` & `testSuccessiveWriteAndRead` in `ReadWriteTableITCase` seems trivial so I remove them.
3. Introduce new `AbstractTestBase` using Junit5.