### PR TITLE
[docs] Remove "embedded" SQL CLI parameter in the Flink quickstart documentation

### DIFF
--- a/docs/content/docs/engines/flink.md
+++ b/docs/content/docs/engines/flink.md
@@ -110,7 +110,7 @@ the Flink dashboard and see that the cluster is up and running.
 You can now start Flink SQL client to execute SQL scripts.
 
 ```bash
-<FLINK_HOME>/bin/sql-client.sh embedded
+<FLINK_HOME>/bin/sql-client.sh
 ```
 
 **Step 5: Create a Catalog and a Table**


### PR DESCRIPTION
The embedded mode has been the default mode of SQL CLI since Flink v1.13. Therefore, users don't need to type the "embedded" parameter when launching SQL CLI. 

```bash
# starting Flink SQL CLI
./bin/sql-client.sh
```