### PR TITLE
[FLINK-30038] Fix hive e2e fail

### DIFF
--- a/flink-table-store-e2e-tests/src/test/java/org/apache/flink/table/store/tests/E2eTestBase.java
+++ b/flink-table-store-e2e-tests/src/test/java/org/apache/flink/table/store/tests/E2eTestBase.java
@@ -31,6 +31,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -113,7 +114,9 @@ public abstract class E2eTestBase {
                 environment.withLogConsumer(s + "_1", new Slf4jLogConsumer(LOG));
             }
             environment.waitingFor(
-                    "hive-server_1", Wait.forLogMessage(".*Starting HiveServer2.*", 1));
+                    "hive-server_1",
+                    Wait.forLogMessage(".*Starting HiveServer2.*", 1)
+                            .withStartupTimeout(Duration.ofSeconds(180)));
         }
         if (withSpark) {
             List<String> sparkServices = Arrays.asList("spark-master", "spark-worker");

--- a/flink-table-store-e2e-tests/src/test/java/org/apache/flink/table/store/tests/E2eTestBase.java
+++ b/flink-table-store-e2e-tests/src/test/java/org/apache/flink/table/store/tests/E2eTestBase.java
@@ -113,6 +113,7 @@ public abstract class E2eTestBase {
             for (String s : hiveServices) {
                 environment.withLogConsumer(s + "_1", new Slf4jLogConsumer(LOG));
             }
+            // Increase timeout from 60s (default value) to 180s
             environment.waitingFor(
                     "hive-server_1",
                     Wait.forLogMessage(".*Starting HiveServer2.*", 1)


### PR DESCRIPTION
The hive e2e always fails according to followed error information:
`Caused by: org.testcontainers.containers.ContainerLaunchException: Timed out waiting for log output matching '.Starting HiveServer2.'
at org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy.waitUntilReady(LogMessageWaitStrategy.java:49)`

The main reason is the `metastore` finishes to start too late which cause the test case monitor the log of `hive-server` timeout. 
This PR aims to increase timeout from 60s(default value) to 180s for `hive-server`. I have executed `ci` five times and the `hive-server` timeout does not appear again.