### PR TITLE
[FLINK-30861] Fix java.lang.ClassNotFoundException: org.apache.hadoop.hive.common.ValidWriteIdList in Table Store Hive catalog

### DIFF
--- a/flink-table-store-hive/flink-table-store-hive-catalog/pom.xml
+++ b/flink-table-store-hive/flink-table-store-hive-catalog/pom.xml
@@ -541,6 +541,7 @@ under the License.
                                     <include>org.apache.hive.shims:hive-shims-0.23</include>
                                     <include>org.apache.hive:hive-serde</include>
                                     <include>org.apache.hive:hive-metastore</include>
+                                    <include>org.apache.hive:hive-storage-api</include>
                                 </includes>
                             </artifactSet>
                             <relocations>


### PR DESCRIPTION
Table Store Hive catalog throws `java.lang.ClassNotFoundException: org.apache.hadoop.hive.common.ValidWriteIdList` under certain environment. We need to package `hive-storage-api` dependency.