### PR TITLE
[hotfix] Fix checkstyle error in flink-table-store-hive module

### DIFF
--- a/flink-table-store-hive/flink-table-store-hive-connector/src/main/2/org/apache/flink/table/store/hive/objectinspector/TableStoreTimestampObjectInspector.java
+++ b/flink-table-store-hive/flink-table-store-hive-connector/src/main/2/org/apache/flink/table/store/hive/objectinspector/TableStoreTimestampObjectInspector.java
@@ -18,12 +18,12 @@
 
 package org.apache.flink.table.store.hive.objectinspector;
 
+import org.apache.flink.table.store.data.Timestamp;
+
 import org.apache.hadoop.hive.serde2.io.TimestampWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.AbstractPrimitiveJavaObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
-
-import org.apache.flink.table.store.data.Timestamp;
 
 /** {@link AbstractPrimitiveJavaObjectInspector} for TIMESTAMP type. */
 public class TableStoreTimestampObjectInspector extends AbstractPrimitiveJavaObjectInspector


### PR DESCRIPTION
Currently if we run `mvn clean install` against the master branch, it will report checkstyle error like below:
> [INFO] --- maven-checkstyle-plugin:2.17:check (validate) @ flink-table-store-hive-connector ---
> [INFO] There is 1 error reported by Checkstyle 8.14 with /tools/maven/checkstyle.xml ruleset.
> [ERROR] src/main/2/org/apache/flink/table/store/hive/objectinspector/TableStoreTimestampObjectInspector.java:[26] (imports) ImportOrder: Import org.apache.flink.table.store.data.Timestamp appears after other imports that it should precede

And this PR supplies a straight-forward hotfix.