### PR TITLE
[FLINK-30980] Support s3.signer-type for S3.

### DIFF
--- a/flink-table-store-filesystems/flink-table-store-s3-impl/src/main/java/org/apache/flink/table/store/s3/S3FileIO.java
+++ b/flink-table-store-filesystems/flink-table-store-s3-impl/src/main/java/org/apache/flink/table/store/s3/S3FileIO.java
@@ -49,7 +49,8 @@ public class S3FileIO extends HadoopCompliantFileIO {
     private static final String[][] MIRRORED_CONFIG_KEYS = {
         {"fs.s3a.access-key", "fs.s3a.access.key"},
         {"fs.s3a.secret-key", "fs.s3a.secret.key"},
-        {"fs.s3a.path-style-access", "fs.s3a.path.style.access"}
+        {"fs.s3a.path-style-access", "fs.s3a.path.style.access"},
+        {"fs.s3a.signer-type", "fs.s3a.signing-algorithm"}
     };
 
     /**


### PR DESCRIPTION
s3.signer-type mirrored to s3a.signing-algorithm.