### PR TITLE
[FLINK-31008] Fix the bug that ContinuousFileSplitEnumerator may be out of order when allocating splits.

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/ContinuousFileSplitEnumerator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/ContinuousFileSplitEnumerator.java
@@ -33,6 +33,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -91,6 +92,19 @@ public class ContinuousFileSplitEnumerator
                 .add(split);
     }
 
+    private void addSplitsBack(Collection<FileStoreSourceSplit> splits) {
+        List<FileStoreSourceSplit> backSplits = new ArrayList<>(splits);
+        Collections.reverse(backSplits);
+        backSplits.forEach(this::addSplitToHead);
+    }
+
+    private void addSplitToHead(FileStoreSourceSplit split) {
+        ((LinkedList<FileStoreSourceSplit>)
+                        bucketSplits.computeIfAbsent(
+                                ((DataSplit) split.split()).bucket(), i -> new LinkedList<>()))
+                .addFirst(split);
+    }
+
     @Override
     public void start() {
         context.callAsync(
@@ -121,7 +135,7 @@ public class ContinuousFileSplitEnumerator
     @Override
     public void addSplitsBack(List<FileStoreSourceSplit> splits, int subtaskId) {
         LOG.debug("File Source Enumerator adds splits back: {}", splits);
-        addSplits(splits);
+        addSplitsBack(splits);
     }
 
     @Override

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/ContinuousFileSplitEnumeratorTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/ContinuousFileSplitEnumeratorTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector.source;
+
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.connector.testutils.source.reader.TestingSplitEnumeratorContext;
+import org.apache.flink.table.store.file.io.DataFileMeta;
+import org.apache.flink.table.store.table.source.DataSplit;
+import org.apache.flink.table.store.table.source.snapshot.SnapshotEnumerator;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.apache.flink.table.store.file.mergetree.compact.MergeTreeCompactManagerTest.row;
+
+/** Unit tests for the {@link ContinuousFileSplitEnumerator}. */
+public class ContinuousFileSplitEnumeratorTest {
+
+    @Test
+    public void testSplitAllocationIsOrdered() throws Exception {
+        final TestingSplitEnumeratorContext<FileStoreSourceSplit> context =
+                new TestingSplitEnumeratorContext<>(1);
+        context.registerReader(0, "test-host");
+
+        List<FileStoreSourceSplit> initialSplits = new ArrayList<>();
+        FileStoreSourceSplit split1 = createSnapshotSplit(1, 0, Collections.emptyList());
+        FileStoreSourceSplit split2 = createSnapshotSplit(2, 0, Collections.emptyList());
+        initialSplits.add(split1);
+        initialSplits.add(split2);
+        final ContinuousFileSplitEnumerator enumerator =
+                new Builder()
+                        .setSplitEnumeratorContext(context)
+                        .setInitialSplits(initialSplits)
+                        .setDiscoveryInterval(3)
+                        .build();
+
+        // The first time split is allocated, split1 should be allocated
+        enumerator.handleSplitRequest(0, "test-host");
+        Assert.assertEquals(1, context.getSplitAssignments().size());
+        Assert.assertTrue(context.getSplitAssignments().containsKey(0));
+        List<FileStoreSourceSplit> assignedSplits =
+                context.getSplitAssignments().get(0).getAssignedSplits();
+        Assert.assertEquals(1, assignedSplits.size());
+        Assert.assertEquals(split1, assignedSplits.get(0));
+
+        // split1 is added back
+        enumerator.addSplitsBack(Collections.singletonList(split1), 0);
+        context.getSplitAssignments().clear();
+        Assert.assertEquals(0, context.getSplitAssignments().size());
+
+        // The split is allocated for the second time, and split1 is allocated first
+        enumerator.handleSplitRequest(0, "test-host");
+        Assert.assertEquals(1, context.getSplitAssignments().size());
+        Assert.assertTrue(context.getSplitAssignments().containsKey(0));
+        assignedSplits = context.getSplitAssignments().get(0).getAssignedSplits();
+        Assert.assertEquals(1, assignedSplits.size());
+        Assert.assertEquals(split1, assignedSplits.get(0));
+
+        // continuing to allocate split, split2 is allocated.
+        context.getSplitAssignments().clear();
+        enumerator.handleSplitRequest(0, "test-host");
+        Assert.assertEquals(1, context.getSplitAssignments().size());
+        Assert.assertTrue(context.getSplitAssignments().containsKey(0));
+        assignedSplits = context.getSplitAssignments().get(0).getAssignedSplits();
+        Assert.assertEquals(1, assignedSplits.size());
+        Assert.assertEquals(split2, assignedSplits.get(0));
+    }
+
+    private static FileStoreSourceSplit createSnapshotSplit(
+            int snapshotId, int bucket, List<DataFileMeta> files) {
+        return new FileStoreSourceSplit(
+                UUID.randomUUID().toString(),
+                new DataSplit(snapshotId, row(1), bucket, files, true),
+                0);
+    }
+
+    private static class Builder {
+        private SplitEnumeratorContext<FileStoreSourceSplit> context;
+        private Collection<FileStoreSourceSplit> initialSplits = Collections.emptyList();
+        private Long nextSnapshotId;
+        private long discoveryInterval = Long.MAX_VALUE;
+        private SnapshotEnumerator snapshotEnumerator;
+
+        public Builder setSplitEnumeratorContext(
+                SplitEnumeratorContext<FileStoreSourceSplit> context) {
+            this.context = context;
+            return this;
+        }
+
+        public Builder setInitialSplits(Collection<FileStoreSourceSplit> initialSplits) {
+            this.initialSplits = initialSplits;
+            return this;
+        }
+
+        public Builder setNextSnapshotId(Long nextSnapshotId) {
+            this.nextSnapshotId = nextSnapshotId;
+            return this;
+        }
+
+        public Builder setDiscoveryInterval(long discoveryInterval) {
+            this.discoveryInterval = discoveryInterval;
+            return this;
+        }
+
+        public Builder setSnapshotEnumerator(SnapshotEnumerator snapshotEnumerator) {
+            this.snapshotEnumerator = snapshotEnumerator;
+            return this;
+        }
+
+        public ContinuousFileSplitEnumerator build() {
+            return new ContinuousFileSplitEnumerator(
+                    context, initialSplits, nextSnapshotId, discoveryInterval, snapshotEnumerator);
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

 Fix the bug that `ContinuousFileSplitEnumerator` may be out of order when allocating splits.

## Brief change log

When `addSplitsBack` is executed, splits are placed at the head of the queue to ensure that they are allocated in the previous order.

## Verifying this change

Added a `ContinuousFileSplitEnumeratorTest` class for verifying that splits are allocated sequentially.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
