### PR TITLE
[FLINK-30979] Support shuffling data by partition

### DIFF
--- a/docs/content/docs/how-to/writing-tables.md
+++ b/docs/content/docs/how-to/writing-tables.md
@@ -226,3 +226,10 @@ For more information of drop-partition, see
 {{< /tab >}}
 
 {{< /tabs >}}
+
+## Sink Data Shuffle
+
+Table Store supports shuffle data by bucket in sink phase. To improve data skew, Table Store also supports shuffling data by dynamic partition fields. You can add option `sink.partition-shuffle` to the table or enable it in job as followed.
+```
+INSERT TABLE mytable /*+ OPTIONS('sink.partition-shuffle'='true') */ SELECT ...;
+```

--- a/docs/content/docs/how-to/writing-tables.md
+++ b/docs/content/docs/how-to/writing-tables.md
@@ -96,6 +96,9 @@ Use `INSERT INTO` to apply records and changes to tables.
 INSERT INTO MyTable SELECT ...
 ```
 
+Table Store supports shuffle data by bucket in sink phase. To improve data skew, Table Store also
+supports shuffling data by partition fields. You can add option `sink.partition-shuffle` to the table.
+
 {{< /tab >}}
 
 {{< tab "Spark3" >}}
@@ -226,10 +229,3 @@ For more information of drop-partition, see
 {{< /tab >}}
 
 {{< /tabs >}}
-
-## Sink Data Shuffle
-
-Table Store supports shuffle data by bucket in sink phase. To improve data skew, Table Store also supports shuffling data by dynamic partition fields. You can add option `sink.partition-shuffle` to the table or enable it in job as followed.
-```
-INSERT TABLE mytable /*+ OPTIONS('sink.partition-shuffle'='true') */ SELECT ...;
-```

--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -21,6 +21,12 @@
             <td>Define a custom parallelism for the scan source. By default, if this option is not defined, the planner will derive the parallelism for each statement individually by also considering the global configuration.</td>
         </tr>
         <tr>
+            <td><h5>sink-store.shuffle-by-partition.enable</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>The option to enable shuffle data by dynamic partition fields in sink phase for table store.</td>
+        </tr>
+        <tr>
             <td><h5>sink.parallelism</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -21,16 +21,16 @@
             <td>Define a custom parallelism for the scan source. By default, if this option is not defined, the planner will derive the parallelism for each statement individually by also considering the global configuration.</td>
         </tr>
         <tr>
-            <td><h5>sink-store.shuffle-by-partition.enable</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>The option to enable shuffle data by dynamic partition fields in sink phase for table store.</td>
-        </tr>
-        <tr>
             <td><h5>sink.parallelism</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
             <td>Defines a custom parallelism for the sink. By default, if this option is not defined, the planner will derive the parallelism for each statement individually by also considering the global configuration.</td>
+        </tr>
+        <tr>
+            <td><h5>sink.partition-shuffle</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>The option to enable shuffle data by dynamic partition fields in sink phase for table store.</td>
         </tr>
     </tbody>
 </table>

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/FlinkConnectorOptions.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/FlinkConnectorOptions.java
@@ -57,6 +57,13 @@ public class FlinkConnectorOptions {
 
     public static final ConfigOption<Integer> SINK_PARALLELISM = FactoryUtil.SINK_PARALLELISM;
 
+    public static final ConfigOption<Boolean> SINK_SHUFFLE_BY_PARTITION =
+            ConfigOptions.key("sink.shuffle-by-partition.enable")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "The option to enable shuffle data by dynamic partition fields in sink phase");
+
     public static final ConfigOption<Integer> SCAN_PARALLELISM =
             ConfigOptions.key("scan.parallelism")
                     .intType()

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/FlinkConnectorOptions.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/FlinkConnectorOptions.java
@@ -58,11 +58,11 @@ public class FlinkConnectorOptions {
     public static final ConfigOption<Integer> SINK_PARALLELISM = FactoryUtil.SINK_PARALLELISM;
 
     public static final ConfigOption<Boolean> SINK_SHUFFLE_BY_PARTITION =
-            ConfigOptions.key("sink.shuffle-by-partition.enable")
+            ConfigOptions.key("sink-store.shuffle-by-partition.enable")
                     .booleanType()
                     .defaultValue(false)
                     .withDescription(
-                            "The option to enable shuffle data by dynamic partition fields in sink phase");
+                            "The option to enable shuffle data by dynamic partition fields in sink phase for table store.");
 
     public static final ConfigOption<Integer> SCAN_PARALLELISM =
             ConfigOptions.key("scan.parallelism")

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/FlinkConnectorOptions.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/FlinkConnectorOptions.java
@@ -58,7 +58,7 @@ public class FlinkConnectorOptions {
     public static final ConfigOption<Integer> SINK_PARALLELISM = FactoryUtil.SINK_PARALLELISM;
 
     public static final ConfigOption<Boolean> SINK_SHUFFLE_BY_PARTITION =
-            ConfigOptions.key("sink-store.shuffle-by-partition.enable")
+            ConfigOptions.key("sink.partition-shuffle")
                     .booleanType()
                     .defaultValue(false)
                     .withDescription(

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/FileStoreShuffleBucketTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/sink/FileStoreShuffleBucketTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector.sink;
+
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.store.connector.CatalogITCaseBase;
+import org.apache.flink.table.store.connector.FlinkConnectorOptions;
+import org.apache.flink.table.store.data.BinaryRow;
+import org.apache.flink.table.store.data.InternalRow;
+import org.apache.flink.table.store.file.io.DataFileMeta;
+import org.apache.flink.table.store.fs.local.LocalFileIO;
+import org.apache.flink.table.store.table.FileStoreTable;
+import org.apache.flink.table.store.table.FileStoreTableFactory;
+import org.apache.flink.table.store.table.sink.SinkRecord;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.apache.flink.table.store.connector.LogicalTypeConversion.toLogicalType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Tests of shuffle data by bucket and partition. */
+public class FileStoreShuffleBucketTest extends CatalogITCaseBase {
+    private static final int TOTAL_SOURCE_RECORD_COUNT = 1000;
+
+    @Before
+    public void after() throws Exception {
+        super.before();
+        CollectStoreSinkWrite.writeRowsMap.clear();
+    }
+
+    @Override
+    protected List<String> ddl() {
+        return Collections.singletonList(
+                "CREATE TABLE T (a INT, b INT, c INT, d INT, PRIMARY KEY (a, b) NOT ENFORCED) PARTITIONED BY (a)");
+    }
+
+    @Test
+    public void testShuffleByBucket() throws Exception {
+        FileStoreTable table =
+                FileStoreTableFactory.create(LocalFileIO.create(), getTableDirectory("T"));
+
+        insertDataToTable(table);
+
+        // Only one task will write records shuffled by bucket
+        assertEquals(CollectStoreSinkWrite.writeRowsMap.size(), 1);
+    }
+
+    @Test
+    public void testShuffleByBucketPartition() throws Exception {
+        FileStoreTable originalTable =
+                FileStoreTableFactory.create(LocalFileIO.create(), getTableDirectory("T"));
+        Map<String, String> dynamicOptions = originalTable.options().toMap();
+        dynamicOptions.put(FlinkConnectorOptions.SINK_SHUFFLE_BY_PARTITION.key(), "true");
+        FileStoreTable table = originalTable.copy(dynamicOptions);
+
+        insertDataToTable(table);
+
+        // Two tasks will write records shuffled by bucket and partition
+        assertEquals(CollectStoreSinkWrite.writeRowsMap.size(), 2);
+    }
+
+    private void insertDataToTable(FileStoreTable table) throws Exception {
+        RowType rowType = toLogicalType(table.rowType());
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
+        env.setParallelism(2);
+
+        List<RowData> sourceDataList = generateData();
+        DataStreamSource<RowData> sourceStream =
+                env.fromCollection(sourceDataList, InternalTypeInfo.of(rowType));
+        new FlinkSinkBuilder(table)
+                .withInput(sourceStream)
+                .withParallelism(env.getParallelism())
+                .withSinkProvider(
+                        "testUser",
+                        (StoreSinkWrite.Provider)
+                                (table1, context, ioManager) ->
+                                        (StoreSinkWrite) new CollectStoreSinkWrite())
+                .build();
+        env.execute();
+
+        assertEquals(
+                CollectStoreSinkWrite.writeRowsMap.values().stream().mapToInt(List::size).sum(),
+                TOTAL_SOURCE_RECORD_COUNT);
+    }
+
+    private List<RowData> generateData() {
+        List<RowData> rowDataList = new ArrayList<>(TOTAL_SOURCE_RECORD_COUNT);
+        for (int i = 0; i < TOTAL_SOURCE_RECORD_COUNT; i++) {
+            rowDataList.add(GenericRowData.of(i, i + 1, i + 2, i + 3));
+        }
+        return rowDataList;
+    }
+
+    /** Collect all received data with writer. */
+    private static class CollectStoreSinkWrite implements StoreSinkWrite {
+        private static final Map<StoreSinkWrite, List<InternalRow>> writeRowsMap =
+                new ConcurrentHashMap<>();
+
+        @Override
+        public SinkRecord write(InternalRow rowData) throws Exception {
+            List<InternalRow> rows = writeRowsMap.computeIfAbsent(this, key -> new ArrayList<>());
+            rows.add(rowData);
+            return null;
+        }
+
+        @Override
+        public SinkRecord toLogRecord(SinkRecord record) {
+            return record;
+        }
+
+        @Override
+        public void compact(BinaryRow partition, int bucket, boolean fullCompaction)
+                throws Exception {}
+
+        @Override
+        public void notifyNewFiles(
+                long snapshotId, BinaryRow partition, int bucket, List<DataFileMeta> files) {}
+
+        @Override
+        public List<Committable> prepareCommit(boolean doCompaction, long checkpointId)
+                throws IOException {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void snapshotState(StateSnapshotContext context) throws Exception {}
+
+        @Override
+        public void close() throws Exception {}
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/PartitionComputer.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/PartitionComputer.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.table.sink;
+
+import org.apache.flink.table.store.codegen.CodeGenUtils;
+import org.apache.flink.table.store.codegen.Projection;
+import org.apache.flink.table.store.data.BinaryRow;
+import org.apache.flink.table.store.data.InternalRow;
+import org.apache.flink.table.store.file.schema.TableSchema;
+import org.apache.flink.table.store.types.RowType;
+
+/** A {@link PartitionComputer} to compute partition by partition keys. */
+public class PartitionComputer {
+    private final Projection partitionProjection;
+
+    public PartitionComputer(TableSchema tableSchema) {
+        this(tableSchema.logicalRowType(), tableSchema.projection(tableSchema.partitionKeys()));
+    }
+
+    public PartitionComputer(RowType rowType, int[] partitionKeys) {
+        this.partitionProjection = CodeGenUtils.newProjection(rowType, partitionKeys);
+    }
+
+    public BinaryRow partition(InternalRow row) {
+        return this.partitionProjection.apply(row);
+    }
+}


### PR DESCRIPTION
Currently sink operator in flink will shuffle data by bucket id, which cause data skew when there is only 1 bucket with multiple partitions in the table. This PR aims to support shuffling data by bucket id and partition when `sink.shuffle-by-partition.enable` is set.

The main changes are
1. Added config `sink.shuffle-by-partition.enable` to support shuffling data by partition
2. Added `PartitionComputer` to get partition from row data
3. Added shuffling data by partition in `BucketStreamPartitioner`

The main tests are
1. Added `FileStoreShuffleBucketTest` to shuffle data by bucket and partition
