### PR TITLE
[FLINK-30985] Allocate the splits belonging to the specified task from all buckets.

### DIFF
--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/ContinuousFileSplitEnumerator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/ContinuousFileSplitEnumerator.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.store.connector.source;
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.connector.source.SplitsAssignment;
 import org.apache.flink.table.store.table.source.DataSplit;
 import org.apache.flink.table.store.table.source.DataTableScan;
 import org.apache.flink.table.store.table.source.snapshot.SnapshotEnumerator;
@@ -163,22 +164,28 @@ public class ContinuousFileSplitEnumerator
     }
 
     private void assignSplits() {
+        Map<Integer, List<FileStoreSourceSplit>> toAssignSplits = new HashMap<>();
         bucketSplits.forEach(
                 (bucket, splits) -> {
                     if (splits.size() > 0) {
                         // To ensure the order of consumption, the data of the same bucket is given
                         // to a task to be consumed.
                         int task = bucket % context.currentParallelism();
-                        if (readersAwaitingSplit.remove(task)) {
+                        if (readersAwaitingSplit.contains(task)) {
                             // if the reader that requested another split has failed in the
                             // meantime, remove
                             // it from the list of waiting readers
                             if (!context.registeredReaders().containsKey(task)) {
+                                readersAwaitingSplit.remove(task);
                                 return;
                             }
-                            context.assignSplit(splits.poll(), task);
+                            toAssignSplits
+                                    .computeIfAbsent(task, i -> new ArrayList<>())
+                                    .add(splits.poll());
                         }
                     }
                 });
+        toAssignSplits.forEach((task, splits) -> readersAwaitingSplit.remove(task));
+        context.assignSplits(new SplitsAssignment<>(toAssignSplits));
     }
 }

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/ContinuousFileSplitEnumerator.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/ContinuousFileSplitEnumerator.java
@@ -185,7 +185,7 @@ public class ContinuousFileSplitEnumerator
                         }
                     }
                 });
-        toAssignSplits.forEach((task, splits) -> readersAwaitingSplit.remove(task));
+        toAssignSplits.keySet().forEach(readersAwaitingSplit::remove);
         context.assignSplits(new SplitsAssignment<>(toAssignSplits));
     }
 }

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/ContinuousFileSplitEnumeratorTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/ContinuousFileSplitEnumeratorTest.java
@@ -24,7 +24,6 @@ import org.apache.flink.table.store.file.io.DataFileMeta;
 import org.apache.flink.table.store.table.source.DataSplit;
 import org.apache.flink.table.store.table.source.snapshot.SnapshotEnumerator;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -36,6 +35,7 @@ import java.util.UUID;
 
 import static org.apache.flink.connector.testutils.source.reader.TestingSplitEnumeratorContext.SplitAssignmentState;
 import static org.apache.flink.table.store.file.mergetree.compact.MergeTreeCompactManagerTest.row;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit tests for the {@link ContinuousFileSplitEnumerator}. */
 public class ContinuousFileSplitEnumeratorTest {
@@ -64,31 +64,23 @@ public class ContinuousFileSplitEnumeratorTest {
         Map<Integer, SplitAssignmentState<FileStoreSourceSplit>> assignments =
                 context.getSplitAssignments();
         // Only subtask-0 is allocated.
-        Assertions.assertThat(assignments.size()).isEqualTo(1);
-        Assertions.assertThat(assignments.containsKey(0)).isTrue();
+        assertThat(assignments).containsOnlyKeys(0);
         List<FileStoreSourceSplit> assignedSplits = assignments.get(0).getAssignedSplits();
-        Assertions.assertThat(assignedSplits.size()).isEqualTo(2);
-        for (int i = 0; i < 2; i++) {
-            Assertions.assertThat(assignedSplits.get(i)).isEqualTo(expectedSplits.get(i));
-        }
+        assertThat(assignedSplits).hasSameElementsAs(expectedSplits.subList(0, 2));
 
         // split1 and split2 is added back
         enumerator.addSplitsBack(assignedSplits, 0);
         context.getSplitAssignments().clear();
-        Assertions.assertThat(context.getSplitAssignments().size()).isEqualTo(0);
+        assertThat(context.getSplitAssignments()).isEmpty();
 
         // The split is allocated for the second time, and split1 is allocated first
         enumerator.handleSplitRequest(0, "test-host");
         enumerator.handleSplitRequest(0, "test-host");
         assignments = context.getSplitAssignments();
         // Only subtask-0 is allocated.
-        Assertions.assertThat(assignments.size()).isEqualTo(1);
-        Assertions.assertThat(assignments.containsKey(0)).isTrue();
+        assertThat(assignments).containsOnlyKeys(0);
         assignedSplits = assignments.get(0).getAssignedSplits();
-        Assertions.assertThat(assignedSplits.size()).isEqualTo(2);
-        for (int i = 0; i < 2; i++) {
-            Assertions.assertThat(assignedSplits.get(i)).isEqualTo(expectedSplits.get(i));
-        }
+        assertThat(assignedSplits).hasSameElementsAs(expectedSplits.subList(0, 2));
 
         // continuing to allocate split
         context.getSplitAssignments().clear();
@@ -96,13 +88,9 @@ public class ContinuousFileSplitEnumeratorTest {
         enumerator.handleSplitRequest(0, "test-host");
         assignments = context.getSplitAssignments();
         // Only subtask-0 is allocated.
-        Assertions.assertThat(assignments.size()).isEqualTo(1);
-        Assertions.assertThat(assignments.containsKey(0));
+        assertThat(assignments).containsOnlyKeys(0);
         assignedSplits = assignments.get(0).getAssignedSplits();
-        Assertions.assertThat(assignedSplits.size()).isEqualTo(2);
-        for (int i = 0; i < 2; i++) {
-            Assertions.assertThat(assignedSplits.get(i)).isEqualTo(expectedSplits.get(i + 2));
-        }
+        assertThat(assignedSplits).hasSameElementsAs(expectedSplits.subList(2, 4));
     }
 
     @Test
@@ -131,29 +119,21 @@ public class ContinuousFileSplitEnumeratorTest {
         Map<Integer, SplitAssignmentState<FileStoreSourceSplit>> assignments =
                 context.getSplitAssignments();
         // Only subtask-0 is allocated.
-        Assertions.assertThat(assignments.size()).isEqualTo(1);
-        Assertions.assertThat(assignments.containsKey(0)).isTrue();
+        assertThat(assignments).containsOnlyKeys(0);
         List<FileStoreSourceSplit> assignedSplits = assignments.get(0).getAssignedSplits();
-        Assertions.assertThat(assignedSplits.size()).isEqualTo(2);
-        for (int i = 0; i < 2; i++) {
-            Assertions.assertThat(assignedSplits.get(i)).isEqualTo(expectedSplits.get(i));
-        }
+        assertThat(assignedSplits).hasSameElementsAs(expectedSplits.subList(0, 2));
 
         // clear assignments
         context.getSplitAssignments().clear();
-        Assertions.assertThat(context.getSplitAssignments().size()).isEqualTo(0);
+        assertThat(context.getSplitAssignments()).isEmpty();
 
         // continuing to allocate the rest splits
         enumerator.handleSplitRequest(0, "test-host");
         assignments = context.getSplitAssignments();
         // Only subtask-0 is allocated.
-        Assertions.assertThat(assignments.size()).isEqualTo(1);
-        Assertions.assertThat(assignments.containsKey(0)).isTrue();
+        assertThat(assignments).containsOnlyKeys(0);
         assignedSplits = assignments.get(0).getAssignedSplits();
-        Assertions.assertThat(assignedSplits.size()).isEqualTo(2);
-        for (int i = 0; i < 2; i++) {
-            Assertions.assertThat(assignedSplits.get(i)).isEqualTo(expectedSplits.get(i + 2));
-        }
+        assertThat(assignedSplits).hasSameElementsAs(expectedSplits.subList(2, 4));
     }
 
     private static FileStoreSourceSplit createSnapshotSplit(


### PR DESCRIPTION
## What is the purpose of the change

Allocate the splits belonging to the specified task from all buckets to prevent some buckets from being consumed during backpressure.

## Brief change log

When performing split allocation, if a task requires a split, a split is taken from each bucket belonging to the task and added to the allocation list.

## Verifying this change

Added `ContinuousFileSplitEnumeratorTest#testSplitAllocationIsFair` to verify that the allocation is fair.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
