### PR TITLE
[hotfix] Improve documentation for table.type

### DIFF
--- a/docs/layouts/shortcodes/generated/catalog_configuration.html
+++ b/docs/layouts/shortcodes/generated/catalog_configuration.html
@@ -40,9 +40,9 @@
         </tr>
         <tr>
             <td><h5>table.type</h5></td>
-            <td style="word-wrap: break-word;">MANAGED_TABLE</td>
+            <td style="word-wrap: break-word;">managed</td>
             <td><p>Enum</p></td>
-            <td>Type of table.<br /><br />Possible values:<ul><li>"MANAGED_TABLE": Table Store owned table where the entire lifecycle of the table data is managed.</li><li>"EXTERNAL_TABLE": The table where Table Store has loose coupling with the data stored in external locations.</li></ul></td>
+            <td>Type of table.<br /><br />Possible values:<ul><li>"managed": Table Store owned table where the entire lifecycle of the table data is managed.</li><li>"external": The table where Table Store has loose coupling with the data stored in external locations.</li></ul></td>
         </tr>
         <tr>
             <td><h5>uri</h5></td>

--- a/flink-table-store-common/src/main/java/org/apache/flink/table/store/table/TableType.java
+++ b/flink-table-store-common/src/main/java/org/apache/flink/table/store/table/TableType.java
@@ -26,10 +26,10 @@ import static org.apache.flink.table.store.options.description.TextElement.text;
 /** Enum of catalog table type. */
 public enum TableType implements DescribedEnum {
     MANAGED(
-            "MANAGED_TABLE",
+            "managed",
             "Table Store owned table where the entire lifecycle of the table data is managed."),
     EXTERNAL(
-            "EXTERNAL_TABLE",
+            "external",
             "The table where Table Store has loose coupling with the data stored in external locations.");
 
     private final String value;

--- a/flink-table-store-hive/flink-table-store-hive-catalog/src/main/java/org/apache/flink/table/store/hive/HiveCatalog.java
+++ b/flink-table-store-hive/flink-table-store-hive-catalog/src/main/java/org/apache/flink/table/store/hive/HiveCatalog.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.schema.UpdateSchema;
 import org.apache.flink.table.store.fs.FileIO;
 import org.apache.flink.table.store.fs.Path;
+import org.apache.flink.table.store.options.OptionsUtils;
 import org.apache.flink.table.store.table.TableType;
 import org.apache.flink.table.store.types.DataField;
 import org.apache.flink.table.store.utils.StringUtils;
@@ -52,6 +53,7 @@ import org.apache.thrift.TException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -340,7 +342,10 @@ public class HiveCatalog extends AbstractCatalog {
 
     private Table newHmsTable(Identifier identifier) {
         long currentTimeMillis = System.currentTimeMillis();
-        final TableType tableType = hiveConf.getEnum(TABLE_TYPE.key(), TableType.MANAGED);
+        TableType tableType =
+                OptionsUtils.convertToEnum(
+                        hiveConf.get(TABLE_TYPE.key(), TableType.MANAGED.toString()),
+                        TableType.class);
         Table table =
                 new Table(
                         identifier.getObjectName(),
@@ -355,7 +360,7 @@ public class HiveCatalog extends AbstractCatalog {
                         new HashMap<>(),
                         null,
                         null,
-                        tableType.toString());
+                        tableType.toString().toUpperCase(Locale.ROOT) + "_TABLE");
         table.getParameters()
                 .put(hive_metastoreConstants.META_TABLE_STORAGE, STORAGE_HANDLER_CLASS_NAME);
         if (TableType.EXTERNAL.equals(tableType)) {


### PR DESCRIPTION
True value is `managed` and `external`, but previous is `MANAGED_TABLE` and `EXTERNAL_TABLE` in documentation.