### PR TITLE
[hotfix] Remove Catalog.getTableSchema

### DIFF
--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileSystemCatalogITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/FileSystemCatalogITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.store.connector;
 
+import org.apache.flink.table.store.file.catalog.AbstractCatalog;
 import org.apache.flink.table.store.file.catalog.Catalog;
 import org.apache.flink.table.store.file.catalog.Identifier;
 import org.apache.flink.table.store.file.utils.BlockingIterator;
@@ -81,7 +82,7 @@ public class FileSystemCatalogITCase extends KafkaTableTestBase {
         Identifier identifier = new Identifier(DB_NAME, "t3");
         Catalog catalog =
                 ((FlinkCatalog) tEnv.getCatalog(tEnv.getCurrentCatalog()).get()).catalog();
-        Path tablePath = catalog.getTableLocation(identifier);
+        Path tablePath = ((AbstractCatalog) catalog).getDataTableLocation(identifier);
         assertEquals(
                 tablePath.toString(),
                 new File(path, DB_NAME + ".db" + File.separator + "t3").toString());

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/AbstractCatalog.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/AbstractCatalog.java
@@ -68,7 +68,7 @@ public abstract class AbstractCatalog implements Catalog {
             Path location = getTableLocation(originidentifier);
             return SystemTableLoader.load(type, fileIO, location);
         } else {
-            TableSchema tableSchema = getTableSchema(identifier);
+            TableSchema tableSchema = getDataTableSchema(identifier);
             return FileStoreTableFactory.create(fileIO, getTableLocation(identifier), tableSchema);
         }
     }
@@ -78,4 +78,6 @@ public abstract class AbstractCatalog implements Catalog {
     }
 
     protected abstract String warehouse();
+
+    protected abstract TableSchema getDataTableSchema(Identifier identifier) throws TableNotExistException ;
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/AbstractCatalog.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/AbstractCatalog.java
@@ -79,5 +79,6 @@ public abstract class AbstractCatalog implements Catalog {
 
     protected abstract String warehouse();
 
-    protected abstract TableSchema getDataTableSchema(Identifier identifier) throws TableNotExistException ;
+    protected abstract TableSchema getDataTableSchema(Identifier identifier)
+            throws TableNotExistException;
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/Catalog.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/Catalog.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.store.file.catalog;
 
 import org.apache.flink.table.store.file.schema.SchemaChange;
-import org.apache.flink.table.store.file.schema.TableSchema;
 import org.apache.flink.table.store.file.schema.UpdateSchema;
 import org.apache.flink.table.store.fs.Path;
 import org.apache.flink.table.store.table.Table;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/Catalog.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/Catalog.java
@@ -101,15 +101,6 @@ public interface Catalog extends AutoCloseable {
     Path getTableLocation(Identifier identifier);
 
     /**
-     * Return a {@link TableSchema} identified by the given {@link Identifier}.
-     *
-     * @param identifier Path of the table
-     * @return The requested table schema
-     * @throws TableNotExistException if the target does not exist
-     */
-    TableSchema getTableSchema(Identifier identifier) throws TableNotExistException;
-
-    /**
      * Return a {@link Table} identified by the given {@link Identifier}.
      *
      * @param identifier Path of the table

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/Catalog.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/Catalog.java
@@ -20,7 +20,6 @@ package org.apache.flink.table.store.file.catalog;
 
 import org.apache.flink.table.store.file.schema.SchemaChange;
 import org.apache.flink.table.store.file.schema.UpdateSchema;
-import org.apache.flink.table.store.fs.Path;
 import org.apache.flink.table.store.table.Table;
 
 import java.util.List;
@@ -90,14 +89,6 @@ public interface Catalog extends AutoCloseable {
      * @throws DatabaseNotExistException if the database does not exist
      */
     List<String> listTables(String databaseName) throws DatabaseNotExistException;
-
-    /**
-     * Return the table location path identified by the given {@link Identifier}.
-     *
-     * @param identifier Path of the table
-     * @return The requested table location
-     */
-    Path getTableLocation(Identifier identifier);
 
     /**
      * Return a {@link Table} identified by the given {@link Identifier}.

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/FileSystemCatalog.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/FileSystemCatalog.java
@@ -109,7 +109,7 @@ public class FileSystemCatalog extends AbstractCatalog {
     }
 
     @Override
-    public TableSchema getTableSchema(Identifier identifier) throws TableNotExistException {
+    public TableSchema getDataTableSchema(Identifier identifier) throws TableNotExistException {
         Path path = getTableLocation(identifier);
         return new SchemaManager(fileIO, path)
                 .latest()

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/FileSystemCatalog.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/catalog/FileSystemCatalog.java
@@ -110,15 +110,15 @@ public class FileSystemCatalog extends AbstractCatalog {
 
     @Override
     public TableSchema getDataTableSchema(Identifier identifier) throws TableNotExistException {
-        Path path = getTableLocation(identifier);
+        Path path = getDataTableLocation(identifier);
         return new SchemaManager(fileIO, path)
                 .latest()
                 .orElseThrow(() -> new TableNotExistException(identifier));
     }
 
     @Override
-    public boolean tableExists(Identifier identifier) {
-        return tableExists(getTableLocation(identifier));
+    public boolean dataTableExists(Identifier identifier) {
+        return tableExists(getDataTableLocation(identifier));
     }
 
     private boolean tableExists(Path tablePath) {
@@ -128,7 +128,7 @@ public class FileSystemCatalog extends AbstractCatalog {
     @Override
     public void dropTable(Identifier identifier, boolean ignoreIfNotExists)
             throws TableNotExistException {
-        Path path = getTableLocation(identifier);
+        Path path = getDataTableLocation(identifier);
         if (!tableExists(path)) {
             if (ignoreIfNotExists) {
                 return;
@@ -147,7 +147,7 @@ public class FileSystemCatalog extends AbstractCatalog {
             throw new DatabaseNotExistException(identifier.getDatabaseName());
         }
 
-        Path path = getTableLocation(identifier);
+        Path path = getDataTableLocation(identifier);
         if (tableExists(path)) {
             if (ignoreIfExists) {
                 return;
@@ -162,7 +162,7 @@ public class FileSystemCatalog extends AbstractCatalog {
     @Override
     public void renameTable(Identifier fromTable, Identifier toTable, boolean ignoreIfNotExists)
             throws TableNotExistException, TableAlreadyExistException {
-        Path fromPath = getTableLocation(fromTable);
+        Path fromPath = getDataTableLocation(fromTable);
         if (!tableExists(fromPath)) {
             if (ignoreIfNotExists) {
                 return;
@@ -171,7 +171,7 @@ public class FileSystemCatalog extends AbstractCatalog {
             throw new TableNotExistException(fromTable);
         }
 
-        Path toPath = getTableLocation(toTable);
+        Path toPath = getDataTableLocation(toTable);
         if (tableExists(toPath)) {
             throw new TableAlreadyExistException(toTable);
         }
@@ -188,7 +188,7 @@ public class FileSystemCatalog extends AbstractCatalog {
         }
         uncheck(
                 () ->
-                        new SchemaManager(fileIO, getTableLocation(identifier))
+                        new SchemaManager(fileIO, getDataTableLocation(identifier))
                                 .commitChanges(changes));
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/system/SystemTableLoader.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/system/SystemTableLoader.java
@@ -23,6 +23,10 @@ import org.apache.flink.table.store.fs.Path;
 import org.apache.flink.table.store.table.FileStoreTableFactory;
 import org.apache.flink.table.store.table.Table;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import static org.apache.flink.table.store.table.system.AuditLogTable.AUDIT_LOG;
 import static org.apache.flink.table.store.table.system.FilesTable.FILES;
 import static org.apache.flink.table.store.table.system.OptionsTable.OPTIONS;
@@ -31,6 +35,10 @@ import static org.apache.flink.table.store.table.system.SnapshotsTable.SNAPSHOTS
 
 /** Loader to load system {@link Table}s. */
 public class SystemTableLoader {
+
+    public static final List<String> SYSTEM_TABLES =
+            Collections.unmodifiableList(
+                    Arrays.asList(SNAPSHOTS, OPTIONS, SCHEMAS, AUDIT_LOG, FILES));
 
     public static Table load(String type, FileIO fileIO, Path location) {
         switch (type.toLowerCase()) {

--- a/flink-table-store-hive/flink-table-store-hive-catalog/src/main/java/org/apache/flink/table/store/hive/HiveCatalog.java
+++ b/flink-table-store-hive/flink-table-store-hive-catalog/src/main/java/org/apache/flink/table/store/hive/HiveCatalog.java
@@ -174,7 +174,7 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     @Override
-    public TableSchema getTableSchema(Identifier identifier) throws TableNotExistException {
+    public TableSchema getDataTableSchema(Identifier identifier) throws TableNotExistException {
         if (!tableStoreTableExists(identifier)) {
             throw new TableNotExistException(identifier);
         }

--- a/flink-table-store-hive/flink-table-store-hive-catalog/src/main/java/org/apache/flink/table/store/hive/HiveCatalog.java
+++ b/flink-table-store-hive/flink-table-store-hive-catalog/src/main/java/org/apache/flink/table/store/hive/HiveCatalog.java
@@ -178,7 +178,7 @@ public class HiveCatalog extends AbstractCatalog {
         if (!tableStoreTableExists(identifier)) {
             throw new TableNotExistException(identifier);
         }
-        Path tableLocation = getTableLocation(identifier);
+        Path tableLocation = getDataTableLocation(identifier);
         return new SchemaManager(fileIO, tableLocation)
                 .latest()
                 .orElseThrow(
@@ -186,7 +186,7 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     @Override
-    public boolean tableExists(Identifier identifier) {
+    public boolean dataTableExists(Identifier identifier) {
         return tableStoreTableExists(identifier);
     }
 
@@ -377,7 +377,7 @@ public class HiveCatalog extends AbstractCatalog {
                 schema.fields().stream()
                         .map(this::convertToFieldSchema)
                         .collect(Collectors.toList()));
-        sd.setLocation(getTableLocation(identifier).toString());
+        sd.setLocation(getDataTableLocation(identifier).toString());
 
         sd.setInputFormat(INPUT_FORMAT_CLASS_NAME);
         sd.setOutputFormat(OUTPUT_FORMAT_CLASS_NAME);
@@ -402,7 +402,7 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     private boolean schemaFileExists(Identifier identifier) {
-        return new SchemaManager(fileIO, getTableLocation(identifier)).latest().isPresent();
+        return new SchemaManager(fileIO, getDataTableLocation(identifier)).latest().isPresent();
     }
 
     private boolean tableStoreTableExists(Identifier identifier, boolean throwException) {
@@ -438,7 +438,8 @@ public class HiveCatalog extends AbstractCatalog {
 
     private SchemaManager schemaManager(Identifier identifier) {
         checkIdentifierUpperCase(identifier);
-        return new SchemaManager(fileIO, getTableLocation(identifier)).withLock(lock(identifier));
+        return new SchemaManager(fileIO, getDataTableLocation(identifier))
+                .withLock(lock(identifier));
     }
 
     private Lock lock(Identifier identifier) {

--- a/flink-table-store-hive/flink-table-store-hive-catalog/src/test/java/org/apache/flink/table/store/hive/HiveCatalogITCase.java
+++ b/flink-table-store-hive/flink-table-store-hive-catalog/src/test/java/org/apache/flink/table/store/hive/HiveCatalogITCase.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.internal.TableEnvironmentImpl;
 import org.apache.flink.table.store.connector.FlinkCatalog;
+import org.apache.flink.table.store.file.catalog.AbstractCatalog;
 import org.apache.flink.table.store.file.catalog.Catalog;
 import org.apache.flink.table.store.file.catalog.CatalogLock;
 import org.apache.flink.table.store.file.catalog.Identifier;
@@ -303,7 +304,8 @@ public class HiveCatalogITCase {
         Identifier identifier = new Identifier("test_db", "t3");
         Catalog catalog =
                 ((FlinkCatalog) tEnv.getCatalog(tEnv.getCurrentCatalog()).get()).catalog();
-        org.apache.flink.table.store.fs.Path tablePath = catalog.getTableLocation(identifier);
+        org.apache.flink.table.store.fs.Path tablePath =
+                ((AbstractCatalog) catalog).getDataTableLocation(identifier);
         Assert.assertEquals(tablePath.toString(), path + "test_db.db" + File.separator + "t3");
 
         // TODO: the hiverunner (4.0) has a bug ,it can not rename the table path correctly ,


### PR DESCRIPTION
Do some refactor to make system table related methods better.
- Remove `Catalog.getTableSchema`. Useless. Not work for system tables.
- Remove `Catalog.getTableLocation`. Useless. Not work for system tables.
- Correct `Catalog.tableExists`, now work for system tables.