### PR TITLE
[FLINK-31072] Introduce streaming-read-atomic to ensure UB and UA cannot be split

### DIFF
--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -36,7 +36,7 @@
             <td><h5>streaming-read-atomic</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>The option to enable return per iterator instead of per record in streaming read. This can ensure that there will be no checkpoint segmentation in iterator consumption.</td>
+            <td>The option to enable return per iterator instead of per record in streaming read.This can ensure that there will be no checkpoint segmentation in iterator consumption.<br />By default, streaming source checkpoint will be performed in any time, this means 'UPDATE_BEFORE' and 'UPDATE_AFTER' can be split into two checkpoint. Downstream can see intermediate state.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -32,5 +32,11 @@
             <td>Boolean</td>
             <td>The option to enable shuffle data by dynamic partition fields in sink phase for table store.</td>
         </tr>
+        <tr>
+            <td><h5>streaming-read-atomic</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>The option to enable return per iterator instead of per record in streaming read. This can ensure that there will be no checkpoint segmentation in iterator consumption.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-table-store-common/src/main/java/org/apache/flink/table/store/utils/Reference.java
+++ b/flink-table-store-common/src/main/java/org/apache/flink/table/store/utils/Reference.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.utils;
+
+import java.util.Objects;
+
+/** Refer a object. */
+public class Reference<T> {
+
+    private T object;
+
+    public Reference(T object) {
+        this.object = object;
+    }
+
+    public T get() {
+        return object;
+    }
+
+    public void set(T object) {
+        this.object = object;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Reference<?> reference = (Reference<?>) o;
+        return Objects.equals(object, reference.object);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(object);
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toString(object);
+    }
+}

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/FlinkConnectorOptions.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/FlinkConnectorOptions.java
@@ -83,8 +83,17 @@ public class FlinkConnectorOptions {
                     .booleanType()
                     .defaultValue(false)
                     .withDescription(
-                            "The option to enable return per iterator instead of per record in streaming read."
-                                    + " This can ensure that there will be no checkpoint segmentation in iterator consumption.");
+                            Description.builder()
+                                    .text(
+                                            "The option to enable return per iterator instead of per record in streaming read.")
+                                    .text(
+                                            "This can ensure that there will be no checkpoint segmentation in iterator consumption.")
+                                    .linebreak()
+                                    .text(
+                                            "By default, streaming source checkpoint will be performed in any time,"
+                                                    + " this means 'UPDATE_BEFORE' and 'UPDATE_AFTER' can be split into two checkpoint."
+                                                    + " Downstream can see intermediate state.")
+                                    .build());
 
     public static List<ConfigOption<?>> getOptions() {
         final Field[] fields = FlinkConnectorOptions.class.getFields();

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/FlinkConnectorOptions.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/FlinkConnectorOptions.java
@@ -78,6 +78,14 @@ public class FlinkConnectorOptions {
                                     + "By default, if this option is not defined, the planner will derive the parallelism "
                                     + "for each statement individually by also considering the global configuration.");
 
+    public static final ConfigOption<Boolean> STREAMING_READ_ATOMIC =
+            ConfigOptions.key("streaming-read-atomic")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "The option to enable return per iterator instead of per record in streaming read."
+                                    + " This can ensure that there will be no checkpoint segmentation in iterator consumption.");
+
     public static List<ConfigOption<?>> getOptions() {
         final Field[] fields = FlinkConnectorOptions.class.getFields();
         final List<ConfigOption<?>> list = new ArrayList<>(fields.length);

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceReader.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceReader.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.store.connector.source;
 import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSourceReaderBase;
-import org.apache.flink.connector.file.src.util.RecordAndPosition;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.table.source.TableRead;
 
@@ -30,21 +29,18 @@ import javax.annotation.Nullable;
 import java.util.Map;
 
 /** A {@link SourceReader} that read records from {@link FileStoreSourceSplit}. */
-public final class FileStoreSourceReader
+public final class FileStoreSourceReader<T>
         extends SingleThreadMultiplexSourceReaderBase<
-                RecordAndPosition<RowData>,
-                RowData,
-                FileStoreSourceSplit,
-                FileStoreSourceSplitState> {
+                T, RowData, FileStoreSourceSplit, FileStoreSourceSplitState> {
 
     public FileStoreSourceReader(
-            SourceReaderContext readerContext, TableRead tableRead, @Nullable Long limit) {
+            RecordsFunction<T> recordsFunction,
+            SourceReaderContext readerContext,
+            TableRead tableRead,
+            @Nullable Long limit) {
         super(
-                () -> new FileStoreSourceSplitReader(tableRead, limit),
-                (element, output, splitState) -> {
-                    output.collect(element.getRecord());
-                    splitState.setPosition(element);
-                },
+                () -> new FileStoreSourceSplitReader<>(recordsFunction, tableRead, limit),
+                recordsFunction,
                 readerContext.getConfiguration(),
                 readerContext);
     }

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitReader.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitReader.java
@@ -86,7 +86,7 @@ public class FileStoreSourceSplitReader<T> implements SplitReader<T, FileStoreSo
             pool.recycler().recycle(iterator);
             return finishSplit();
         }
-        return recordsFunction.forRecords(currentSplitId, iterator.replace(nextBatch));
+        return recordsFunction.createRecords(currentSplitId, iterator.replace(nextBatch));
     }
 
     private boolean reachLimit() {
@@ -167,7 +167,8 @@ public class FileStoreSourceSplitReader<T> implements SplitReader<T, FileStoreSo
             currentReader = null;
         }
 
-        final RecordsWithSplitIds<T> finishRecords = recordsFunction.finishedSplit(currentSplitId);
+        final RecordsWithSplitIds<T> finishRecords =
+                recordsFunction.createRecordsWithFinishedSplit(currentSplitId);
         currentSplitId = null;
         return finishRecords;
     }

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitReader.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FileStoreSourceSplitReader.java
@@ -22,14 +22,15 @@ import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
-import org.apache.flink.connector.file.src.impl.FileRecords;
 import org.apache.flink.connector.file.src.reader.BulkFormat;
 import org.apache.flink.connector.file.src.util.MutableRecordAndPosition;
 import org.apache.flink.connector.file.src.util.Pool;
 import org.apache.flink.connector.file.src.util.RecordAndPosition;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.store.connector.FlinkRowData;
 import org.apache.flink.table.store.data.InternalRow;
 import org.apache.flink.table.store.file.utils.RecordReader;
+import org.apache.flink.table.store.file.utils.RecordReader.RecordIterator;
 import org.apache.flink.table.store.table.source.TableRead;
 
 import javax.annotation.Nullable;
@@ -39,9 +40,9 @@ import java.util.LinkedList;
 import java.util.Queue;
 
 /** The {@link SplitReader} implementation for the file store source. */
-public class FileStoreSourceSplitReader
-        implements SplitReader<
-                RecordAndPosition<org.apache.flink.table.data.RowData>, FileStoreSourceSplit> {
+public class FileStoreSourceSplitReader<T> implements SplitReader<T, FileStoreSourceSplit> {
+
+    private final RecordsFunction<T> recordsFunction;
 
     private final TableRead tableRead;
 
@@ -54,9 +55,11 @@ public class FileStoreSourceSplitReader
     @Nullable private RecordReader<InternalRow> currentReader;
     @Nullable private String currentSplitId;
     private long currentNumRead;
-    private RecordReader.RecordIterator<InternalRow> currentFirstBatch;
+    private RecordIterator<InternalRow> currentFirstBatch;
 
-    public FileStoreSourceSplitReader(TableRead tableRead, @Nullable Long limit) {
+    public FileStoreSourceSplitReader(
+            RecordsFunction<T> recordsFunction, TableRead tableRead, @Nullable Long limit) {
+        this.recordsFunction = recordsFunction;
         this.tableRead = tableRead;
         this.limit = limit;
         this.splits = new LinkedList<>();
@@ -65,15 +68,14 @@ public class FileStoreSourceSplitReader
     }
 
     @Override
-    public RecordsWithSplitIds<RecordAndPosition<org.apache.flink.table.data.RowData>> fetch()
-            throws IOException {
+    public RecordsWithSplitIds<T> fetch() throws IOException {
         checkSplitOrStartNext();
 
         // pool first, pool size is 1, the underlying implementation does not allow multiple batches
         // to be read at the same time
         FileStoreRecordIterator iterator = pool();
 
-        RecordReader.RecordIterator<InternalRow> nextBatch;
+        RecordIterator<InternalRow> nextBatch;
         if (currentFirstBatch != null) {
             nextBatch = currentFirstBatch;
             currentFirstBatch = null;
@@ -84,7 +86,7 @@ public class FileStoreSourceSplitReader
             pool.recycler().recycle(iterator);
             return finishSplit();
         }
-        return FileRecords.forRecords(currentSplitId, iterator.replace(nextBatch));
+        return recordsFunction.forRecords(currentSplitId, iterator.replace(nextBatch));
     }
 
     private boolean reachLimit() {
@@ -142,7 +144,7 @@ public class FileStoreSourceSplitReader
 
     private void seek(long toSkip) throws IOException {
         while (true) {
-            RecordReader.RecordIterator<InternalRow> nextBatch = currentReader.readBatch();
+            RecordIterator<InternalRow> nextBatch = currentReader.readBatch();
             if (nextBatch == null) {
                 throw new RuntimeException(
                         String.format(
@@ -159,27 +161,25 @@ public class FileStoreSourceSplitReader
         }
     }
 
-    private FileRecords<org.apache.flink.table.data.RowData> finishSplit() throws IOException {
+    private RecordsWithSplitIds<T> finishSplit() throws IOException {
         if (currentReader != null) {
             currentReader.close();
             currentReader = null;
         }
 
-        final FileRecords<org.apache.flink.table.data.RowData> finishRecords =
-                FileRecords.finishedSplit(currentSplitId);
+        final RecordsWithSplitIds<T> finishRecords = recordsFunction.finishedSplit(currentSplitId);
         currentSplitId = null;
         return finishRecords;
     }
 
-    private class FileStoreRecordIterator
-            implements BulkFormat.RecordIterator<org.apache.flink.table.data.RowData> {
+    private class FileStoreRecordIterator implements BulkFormat.RecordIterator<RowData> {
 
-        private RecordReader.RecordIterator<InternalRow> iterator;
+        private RecordIterator<InternalRow> iterator;
 
-        private final MutableRecordAndPosition<org.apache.flink.table.data.RowData>
-                recordAndPosition = new MutableRecordAndPosition<>();
+        private final MutableRecordAndPosition<RowData> recordAndPosition =
+                new MutableRecordAndPosition<>();
 
-        public FileStoreRecordIterator replace(RecordReader.RecordIterator<InternalRow> iterator) {
+        public FileStoreRecordIterator replace(RecordIterator<InternalRow> iterator) {
             this.iterator = iterator;
             this.recordAndPosition.set(null, RecordAndPosition.NO_OFFSET, currentNumRead);
             return this;
@@ -187,7 +187,7 @@ public class FileStoreSourceSplitReader
 
         @Nullable
         @Override
-        public RecordAndPosition<org.apache.flink.table.data.RowData> next() {
+        public RecordAndPosition<RowData> next() {
             if (reachLimit()) {
                 return null;
             }

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FlinkSource.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/FlinkSource.java
@@ -64,7 +64,13 @@ public abstract class FlinkSource
         if (predicate != null) {
             read.withFilter(predicate);
         }
-        return new FileStoreSourceReader(context, read, limit);
+
+        return createSourceReader(context, read, limit);
+    }
+
+    public FileStoreSourceReader<?> createSourceReader(
+            SourceReaderContext context, TableRead read, @Nullable Long limit) {
+        return new FileStoreSourceReader<>(RecordsFunction.forSingle(), context, read, limit);
     }
 
     @Override

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/RecordsFunction.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/RecordsFunction.java
@@ -29,11 +29,14 @@ import org.apache.flink.table.data.RowData;
 /** Records construction and emitter in source. */
 public interface RecordsFunction<T> extends RecordEmitter<T, RowData, FileStoreSourceSplitState> {
 
-    RecordsWithSplitIds<T> forRecords(
+    /** Create a {@link RecordsWithSplitIds} to emit records. */
+    RecordsWithSplitIds<T> createRecords(
             String splitId, BulkFormat.RecordIterator<RowData> recordsForSplit);
 
-    RecordsWithSplitIds<T> finishedSplit(String splitId);
+    /** Create a {@link RecordsWithSplitIds} to indicate that the split is finished. */
+    RecordsWithSplitIds<T> createRecordsWithFinishedSplit(String splitId);
 
+    /** Emit records for {@code element}. */
     void emitRecord(T element, SourceOutput<RowData> output, FileStoreSourceSplitState state)
             throws Exception;
 
@@ -49,13 +52,14 @@ public interface RecordsFunction<T> extends RecordEmitter<T, RowData, FileStoreS
     class IterateRecordsFunction implements RecordsFunction<RecordAndPosition<RowData>> {
 
         @Override
-        public RecordsWithSplitIds<RecordAndPosition<RowData>> forRecords(
+        public RecordsWithSplitIds<RecordAndPosition<RowData>> createRecords(
                 String splitId, BulkFormat.RecordIterator<RowData> recordsForSplit) {
             return FileRecords.forRecords(splitId, recordsForSplit);
         }
 
         @Override
-        public RecordsWithSplitIds<RecordAndPosition<RowData>> finishedSplit(String splitId) {
+        public RecordsWithSplitIds<RecordAndPosition<RowData>> createRecordsWithFinishedSplit(
+                String splitId) {
             return FileRecords.finishedSplit(splitId);
         }
 
@@ -76,14 +80,14 @@ public interface RecordsFunction<T> extends RecordEmitter<T, RowData, FileStoreS
     class SingleRecordsFunction implements RecordsFunction<BulkFormat.RecordIterator<RowData>> {
 
         @Override
-        public RecordsWithSplitIds<BulkFormat.RecordIterator<RowData>> forRecords(
+        public RecordsWithSplitIds<BulkFormat.RecordIterator<RowData>> createRecords(
                 String splitId, BulkFormat.RecordIterator<RowData> recordsForSplit) {
             return SingleIteratorRecords.forRecords(splitId, recordsForSplit);
         }
 
         @Override
-        public RecordsWithSplitIds<BulkFormat.RecordIterator<RowData>> finishedSplit(
-                String splitId) {
+        public RecordsWithSplitIds<BulkFormat.RecordIterator<RowData>>
+                createRecordsWithFinishedSplit(String splitId) {
             return SingleIteratorRecords.finishedSplit(splitId);
         }
 

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/RecordsFunction.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/RecordsFunction.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector.source;
+
+import org.apache.flink.api.connector.source.SourceOutput;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.file.src.impl.FileRecords;
+import org.apache.flink.connector.file.src.reader.BulkFormat;
+import org.apache.flink.connector.file.src.util.RecordAndPosition;
+import org.apache.flink.table.data.RowData;
+
+/** Records construction and emitter in source. */
+public interface RecordsFunction<T> extends RecordEmitter<T, RowData, FileStoreSourceSplitState> {
+
+    RecordsWithSplitIds<T> forRecords(
+            String splitId, BulkFormat.RecordIterator<RowData> recordsForSplit);
+
+    RecordsWithSplitIds<T> finishedSplit(String splitId);
+
+    void emitRecord(T element, SourceOutput<RowData> output, FileStoreSourceSplitState state)
+            throws Exception;
+
+    static IterateRecordsFunction forIterate() {
+        return new IterateRecordsFunction();
+    }
+
+    static SingleRecordsFunction forSingle() {
+        return new SingleRecordsFunction();
+    }
+
+    /** Return one by one, possibly inserting checkpoint in the middle. */
+    class IterateRecordsFunction implements RecordsFunction<RecordAndPosition<RowData>> {
+
+        @Override
+        public RecordsWithSplitIds<RecordAndPosition<RowData>> forRecords(
+                String splitId, BulkFormat.RecordIterator<RowData> recordsForSplit) {
+            return FileRecords.forRecords(splitId, recordsForSplit);
+        }
+
+        @Override
+        public RecordsWithSplitIds<RecordAndPosition<RowData>> finishedSplit(String splitId) {
+            return FileRecords.finishedSplit(splitId);
+        }
+
+        @Override
+        public void emitRecord(
+                RecordAndPosition<RowData> element,
+                SourceOutput<RowData> output,
+                FileStoreSourceSplitState state) {
+            output.collect(element.getRecord());
+            state.setPosition(element);
+        }
+    }
+
+    /**
+     * Return per iterator instead of per record. This can ensure that there will be no checkpoint
+     * segmentation in iterator consumption.
+     */
+    class SingleRecordsFunction implements RecordsFunction<BulkFormat.RecordIterator<RowData>> {
+
+        @Override
+        public RecordsWithSplitIds<BulkFormat.RecordIterator<RowData>> forRecords(
+                String splitId, BulkFormat.RecordIterator<RowData> recordsForSplit) {
+            return SingleIteratorRecords.forRecords(splitId, recordsForSplit);
+        }
+
+        @Override
+        public RecordsWithSplitIds<BulkFormat.RecordIterator<RowData>> finishedSplit(
+                String splitId) {
+            return SingleIteratorRecords.finishedSplit(splitId);
+        }
+
+        @Override
+        public void emitRecord(
+                BulkFormat.RecordIterator<RowData> element,
+                SourceOutput<RowData> output,
+                FileStoreSourceSplitState state) {
+            RecordAndPosition<RowData> record;
+            while ((record = element.next()) != null) {
+                output.collect(record.getRecord());
+                state.setPosition(record);
+            }
+        }
+    }
+}

--- a/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/SingleIteratorRecords.java
+++ b/flink-table-store-connector/src/main/java/org/apache/flink/table/store/connector/source/SingleIteratorRecords.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector.source;
+
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.file.src.reader.BulkFormat;
+import org.apache.flink.table.store.utils.Reference;
+
+import javax.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * A {@link RecordsWithSplitIds} which contains only one iterator record. This can ensure that there
+ * will be no checkpoint segmentation in iterator consumption.
+ */
+public class SingleIteratorRecords<T> implements RecordsWithSplitIds<BulkFormat.RecordIterator<T>> {
+
+    @Nullable private String splitId;
+
+    @Nullable private Reference<BulkFormat.RecordIterator<T>> recordsForSplitCurrent;
+
+    @Nullable private final BulkFormat.RecordIterator<T> recordsForSplit;
+
+    private final Set<String> finishedSplits;
+
+    private SingleIteratorRecords(
+            @Nullable String splitId,
+            @Nullable BulkFormat.RecordIterator<T> recordsForSplit,
+            Set<String> finishedSplits) {
+        this.splitId = splitId;
+        this.recordsForSplit = recordsForSplit;
+        this.finishedSplits = finishedSplits;
+    }
+
+    @Nullable
+    @Override
+    public String nextSplit() {
+        // move the split one (from current value to null)
+        final String nextSplit = this.splitId;
+        this.splitId = null;
+
+        // move the iterator, from null to value (if first move) or to null (if second move)
+        this.recordsForSplitCurrent =
+                nextSplit != null ? new Reference<>(this.recordsForSplit) : null;
+
+        return nextSplit;
+    }
+
+    @Nullable
+    @Override
+    public BulkFormat.RecordIterator<T> nextRecordFromSplit() {
+        if (this.recordsForSplitCurrent == null) {
+            throw new IllegalStateException();
+        }
+
+        BulkFormat.RecordIterator<T> recordsForSplit = this.recordsForSplitCurrent.get();
+        this.recordsForSplitCurrent.set(null);
+        return recordsForSplit;
+    }
+
+    @Override
+    public Set<String> finishedSplits() {
+        return finishedSplits;
+    }
+
+    @Override
+    public void recycle() {
+        if (recordsForSplit != null) {
+            recordsForSplit.releaseBatch();
+        }
+    }
+
+    public static <T> SingleIteratorRecords<T> forRecords(
+            String splitId, BulkFormat.RecordIterator<T> recordsForSplit) {
+        return new SingleIteratorRecords<>(splitId, recordsForSplit, Collections.emptySet());
+    }
+
+    public static <T> SingleIteratorRecords<T> finishedSplit(String splitId) {
+        return new SingleIteratorRecords<>(null, null, Collections.singleton(splitId));
+    }
+}

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ContinuousFileStoreITCase.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/ContinuousFileStoreITCase.java
@@ -38,6 +38,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 
+import static org.apache.flink.table.store.connector.FlinkConnectorOptions.STREAMING_READ_ATOMIC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -63,6 +64,12 @@ public class ContinuousFileStoreITCase extends CatalogITCaseBase {
                 "CREATE TABLE IF NOT EXISTS T1 (a STRING, b STRING, c STRING)" + options,
                 "CREATE TABLE IF NOT EXISTS T2 (a STRING, b STRING, c STRING, PRIMARY KEY (a) NOT ENFORCED)"
                         + options);
+    }
+
+    @TestTemplate
+    public void testStreamingAtomic() throws Exception {
+        sql("ALTER TABLE T2 SET ('%s' = 'true')", STREAMING_READ_ATOMIC.key());
+        testSimple("T2");
     }
 
     @TestTemplate

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceReaderTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/FileStoreSourceReaderTest.java
@@ -64,7 +64,7 @@ public class FileStoreSourceReaderTest {
     @Test
     public void testRequestSplitWhenNoSplitRestored() throws Exception {
         final TestingReaderContext context = new TestingReaderContext();
-        final FileStoreSourceReader reader = createReader(context);
+        final FileStoreSourceReader<?> reader = createReader(context);
 
         reader.start();
         reader.close();
@@ -75,7 +75,7 @@ public class FileStoreSourceReaderTest {
     @Test
     public void testNoSplitRequestWhenSplitRestored() throws Exception {
         final TestingReaderContext context = new TestingReaderContext();
-        final FileStoreSourceReader reader = createReader(context);
+        final FileStoreSourceReader<?> reader = createReader(context);
 
         reader.addSplits(Collections.singletonList(createTestFileSplit()));
         reader.start();
@@ -84,8 +84,9 @@ public class FileStoreSourceReaderTest {
         assertThat(context.getNumSplitRequests()).isEqualTo(0);
     }
 
-    private FileStoreSourceReader createReader(TestingReaderContext context) {
-        return new FileStoreSourceReader(
+    private FileStoreSourceReader<?> createReader(TestingReaderContext context) {
+        return new FileStoreSourceReader<>(
+                RecordsFunction.forIterate(),
                 context,
                 new TestChangelogDataReadWrite(tempDir.toString(), null).createReadWithKey(),
                 null);

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/RecordsFunctionTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/RecordsFunctionTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector.source;
+
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.file.src.reader.BulkFormat;
+import org.apache.flink.connector.file.src.util.ArrayResultIterator;
+import org.apache.flink.connector.file.src.util.CheckpointedPosition;
+import org.apache.flink.connector.file.src.util.RecordAndPosition;
+import org.apache.flink.connector.testutils.source.reader.TestingReaderOutput;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.connector.source.RecordsFunction.IterateRecordsFunction;
+import org.apache.flink.table.store.connector.source.RecordsFunction.SingleRecordsFunction;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link RecordsFunction}. */
+public class RecordsFunctionTest {
+
+    private RowData[] rows;
+    private ArrayResultIterator<RowData> iter;
+    private TestingReaderOutput<RowData> output;
+    private FileStoreSourceSplitState state;
+
+    @BeforeEach
+    public void beforeEach() {
+        iter = new ArrayResultIterator<>();
+        rows = new RowData[] {GenericRowData.of(1, 1), GenericRowData.of(2, 2)};
+        iter.set(rows, rows.length, CheckpointedPosition.NO_OFFSET, 0);
+        output = new TestingReaderOutput<>();
+        state = new FileStoreSourceSplitState(new FileStoreSourceSplit("", null));
+    }
+
+    @Test
+    public void testSingle() {
+        SingleRecordsFunction function = RecordsFunction.forSingle();
+        RecordsWithSplitIds<BulkFormat.RecordIterator<RowData>> records =
+                function.forRecords("", iter);
+        records.nextSplit();
+
+        BulkFormat.RecordIterator<RowData> iterator = records.nextRecordFromSplit();
+        assertThat(iterator).isNotNull();
+        function.emitRecord(iterator, output, state);
+        assertThat(output.getEmittedRecords()).containsExactly(rows);
+        assertThat(state.recordsToSkip()).isEqualTo(2);
+        assertThat(records.nextRecordFromSplit()).isNull();
+    }
+
+    @Test
+    public void testIterate() {
+        IterateRecordsFunction function = RecordsFunction.forIterate();
+        RecordsWithSplitIds<RecordAndPosition<RowData>> records = function.forRecords("", iter);
+        records.nextSplit();
+
+        RecordAndPosition<RowData> record = records.nextRecordFromSplit();
+        assertThat(record).isNotNull();
+        function.emitRecord(record, output, state);
+        assertThat(output.getEmittedRecords()).containsExactly(rows[0]);
+        assertThat(state.recordsToSkip()).isEqualTo(1);
+
+        record = records.nextRecordFromSplit();
+        assertThat(record).isNotNull();
+        function.emitRecord(record, output, state);
+        assertThat(output.getEmittedRecords()).containsExactly(rows);
+        assertThat(state.recordsToSkip()).isEqualTo(2);
+
+        assertThat(records.nextRecordFromSplit()).isNull();
+    }
+}

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/RecordsFunctionTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/RecordsFunctionTest.java
@@ -55,7 +55,7 @@ public class RecordsFunctionTest {
     public void testSingle() {
         SingleRecordsFunction function = RecordsFunction.forSingle();
         RecordsWithSplitIds<BulkFormat.RecordIterator<RowData>> records =
-                function.forRecords("", iter);
+                function.createRecords("", iter);
         records.nextSplit();
 
         BulkFormat.RecordIterator<RowData> iterator = records.nextRecordFromSplit();
@@ -69,7 +69,7 @@ public class RecordsFunctionTest {
     @Test
     public void testIterate() {
         IterateRecordsFunction function = RecordsFunction.forIterate();
-        RecordsWithSplitIds<RecordAndPosition<RowData>> records = function.forRecords("", iter);
+        RecordsWithSplitIds<RecordAndPosition<RowData>> records = function.createRecords("", iter);
         records.nextSplit();
 
         RecordAndPosition<RowData> record = records.nextRecordFromSplit();

--- a/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/SingleIteratorRecordsTest.java
+++ b/flink-table-store-connector/src/test/java/org/apache/flink/table/store/connector/source/SingleIteratorRecordsTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector.source;
+
+import org.apache.flink.connector.file.src.reader.BulkFormat;
+import org.apache.flink.connector.file.src.util.SingletonResultIterator;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Test for {@link SingleIteratorRecords}. */
+public class SingleIteratorRecordsTest {
+
+    @Test
+    void testEmptySplits() {
+        final String split = "empty";
+        final SingleIteratorRecords<Object> records = SingleIteratorRecords.finishedSplit(split);
+
+        assertThat(records.finishedSplits()).isEqualTo(Collections.singleton(split));
+    }
+
+    @Test
+    void testMoveToFirstSplit() {
+        final String splitId = "splitId";
+        final SingleIteratorRecords<Object> records =
+                SingleIteratorRecords.forRecords(splitId, new SingletonResultIterator<>());
+
+        final String firstSplitId = records.nextSplit();
+
+        assertThat(splitId).isEqualTo(firstSplitId);
+    }
+
+    @Test
+    void testMoveToSecondSplit() {
+        final SingleIteratorRecords<Object> records =
+                SingleIteratorRecords.forRecords("splitId", new SingletonResultIterator<>());
+        records.nextSplit();
+
+        final String secondSplitId = records.nextSplit();
+
+        assertThat(secondSplitId).isNull();
+    }
+
+    @Test
+    void testRecordsFromFirstSplit() {
+        final SingletonResultIterator<String> iter = new SingletonResultIterator<>();
+        iter.set("test", 18, 99);
+        final SingleIteratorRecords<String> records =
+                SingleIteratorRecords.forRecords("splitId", iter);
+        records.nextSplit();
+
+        final BulkFormat.RecordIterator<String> recAndPos = records.nextRecordFromSplit();
+
+        assertThat(recAndPos).isSameAs(iter);
+        assertThat(records.nextRecordFromSplit()).isNull();
+    }
+
+    @Test
+    void testRecordsInitiallyIllegal() {
+        final SingleIteratorRecords<Object> records =
+                SingleIteratorRecords.forRecords("splitId", new SingletonResultIterator<>());
+
+        assertThatThrownBy(records::nextRecordFromSplit).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void testRecordsOnSecondSplitIllegal() {
+        final SingleIteratorRecords<Object> records =
+                SingleIteratorRecords.forRecords("splitId", new SingletonResultIterator<>());
+        records.nextSplit();
+        records.nextSplit();
+
+        assertThatThrownBy(records::nextRecordFromSplit).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void testRecycleExhaustedBatch() {
+        final AtomicBoolean recycled = new AtomicBoolean(false);
+        final SingletonResultIterator<Object> iter =
+                new SingletonResultIterator<>(() -> recycled.set(true));
+        iter.set(new Object(), 1L, 2L);
+
+        final SingleIteratorRecords<Object> records =
+                SingleIteratorRecords.forRecords("test split", iter);
+        records.nextSplit();
+        records.nextRecordFromSplit();
+
+        // make sure we exhausted the iterator
+        assertThat(records.nextRecordFromSplit()).isNull();
+        assertThat(records.nextSplit()).isNull();
+
+        records.recycle();
+        assertThat(recycled.get()).isTrue();
+    }
+
+    @Test
+    void testRecycleNonExhaustedBatch() {
+        final AtomicBoolean recycled = new AtomicBoolean(false);
+        final SingletonResultIterator<Object> iter =
+                new SingletonResultIterator<>(() -> recycled.set(true));
+        iter.set(new Object(), 1L, 2L);
+
+        final SingleIteratorRecords<Object> records =
+                SingleIteratorRecords.forRecords("test split", iter);
+        records.nextSplit();
+
+        records.recycle();
+        assertThat(recycled.get()).isTrue();
+    }
+}


### PR DESCRIPTION
Currently, streaming source will be checkpoint in any time, this means UPDATE_BEFORE and UPDATE_AFTER can be split into two checkpoint.
Downstream can see intermediate state. This is weird in some cases.
So in this ticket, add streaming-read-atomic:
The option to enable return per iterator instead of per record in streaming read. This can ensure that there will be no checkpoint segmentation in iterator consumption.