### PR TITLE
[FLINK-31009] Add recordCount to snapshot meta

### DIFF
--- a/docs/content/docs/how-to/querying-tables.md
+++ b/docs/content/docs/how-to/querying-tables.md
@@ -100,18 +100,18 @@ SELECT * FROM my_catalog.my_db.`MyTable$snapshots`;
 
 ### Snapshots Table
 
-You can query the snapshot history information of the table through snapshots table.
+You can query the snapshot history information of the table through snapshots table, including the record count occurred in the snapshot.
 
 ```sql
 SELECT * FROM MyTable$snapshots;
 
 /*
-+--------------+------------+-----------------+-------------------+--------------+-------------------------+
-|  snapshot_id |  schema_id |     commit_user | commit_identifier |  commit_kind |             commit_time |
-+--------------+------------+-----------------+-------------------+--------------+-------------------------+
-|            2 |          0 | 7ca4cd28-98e... |                 2 |       APPEND | 2022-10-26 11:44:15.600 |
-|            1 |          0 | 870062aa-3e9... |                 1 |       APPEND | 2022-10-26 11:44:15.148 |
-+--------------+------------+-----------------+-------------------+--------------+-------------------------+
++--------------+------------+-----------------+-------------------+--------------+-------------------------+---------------------+---------------------+-------------------------+
+|  snapshot_id |  schema_id |     commit_user | commit_identifier |  commit_kind |             commit_time |  total_record_count |  delta_record_count |  changelog_record_count |
++--------------+------------+-----------------+-------------------+--------------+-------------------------+---------------------+---------------------+-------------------------+
+|            2 |          0 | 7ca4cd28-98e... |                 2 |       APPEND | 2022-10-26 11:44:15.600 |                   2 |                   2 |                       0 |
+|            1 |          0 | 870062aa-3e9... |                 1 |       APPEND | 2022-10-26 11:44:15.148 |                   1 |                   1 |                       0 |
++--------------+------------+-----------------+-------------------+--------------+-------------------------+---------------------+---------------------+-------------------------+
 2 rows in set
 */
 ```

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AbstractFileStoreScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/AbstractFileStoreScan.java
@@ -252,22 +252,18 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
     private List<ManifestFileMeta> readManifests(Snapshot snapshot) {
         switch (scanKind) {
             case ALL:
-                return snapshot.readAllDataManifests(manifestList);
+                return snapshot.dataManifests(manifestList);
             case DELTA:
-                return manifestList.read(snapshot.deltaManifestList());
+                return snapshot.deltaManifests(manifestList);
             case CHANGELOG:
-                if (snapshot.version() >= 2) {
-                    if (snapshot.changelogManifestList() == null) {
-                        return Collections.emptyList();
-                    } else {
-                        return manifestList.read(snapshot.changelogManifestList());
-                    }
+                if (snapshot.version() > Snapshot.TABLE_STORE_02_VERSION) {
+                    return snapshot.changelogManifests(manifestList);
                 }
 
                 // compatible with Table Store 0.2, we'll read extraFiles in DataFileMeta
                 // see comments on DataFileMeta#extraFiles
                 if (snapshot.commitKind() == Snapshot.CommitKind.APPEND) {
-                    return manifestList.read(snapshot.deltaManifestList());
+                    return snapshot.deltaManifests(manifestList);
                 }
                 throw new IllegalStateException(
                         String.format(

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreExpireImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreExpireImpl.java
@@ -184,7 +184,7 @@ public class FileStoreExpireImpl implements FileStoreExpire {
         // delete manifests
         Snapshot exclusiveSnapshot = snapshotManager.snapshot(endExclusiveId);
         Set<ManifestFileMeta> manifestsInUse =
-                new HashSet<>(exclusiveSnapshot.readAllDataManifests(manifestList));
+                new HashSet<>(exclusiveSnapshot.dataManifests(manifestList));
         // to avoid deleting twice
         Set<ManifestFileMeta> deletedManifests = new HashSet<>();
         for (long id = beginInclusiveId; id < endExclusiveId; id++) {
@@ -193,7 +193,7 @@ public class FileStoreExpireImpl implements FileStoreExpire {
             }
 
             Snapshot toExpire = snapshotManager.snapshot(id);
-            // cannot call `toExpire.readAllDataManifests` directly, it is possible that a job is
+            // cannot call `toExpire.dataManifests` directly, it is possible that a job is
             // killed during expiration, so some manifest files may have been deleted
             List<ManifestFileMeta> toExpireManifests = new ArrayList<>();
             toExpireManifests.addAll(tryReadManifestList(toExpire.baseManifestList()));

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/system/SnapshotsTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/system/SnapshotsTable.java
@@ -71,7 +71,10 @@ public class SnapshotsTable implements Table {
                             new DataField(3, "commit_identifier", new BigIntType(false)),
                             new DataField(
                                     4, "commit_kind", SerializationUtils.newStringType(false)),
-                            new DataField(5, "commit_time", new TimestampType(false, 3))));
+                            new DataField(5, "commit_time", new TimestampType(false, 3)),
+                            new DataField(6, "total_record_count", new BigIntType(true)),
+                            new DataField(7, "delta_record_count", new BigIntType(true)),
+                            new DataField(8, "changelog_record_count", new BigIntType(true))));
 
     private final FileIO fileIO;
     private final Path location;
@@ -206,7 +209,10 @@ public class SnapshotsTable implements Table {
                     Timestamp.fromLocalDateTime(
                             LocalDateTime.ofInstant(
                                     Instant.ofEpochMilli(snapshot.timeMillis()),
-                                    ZoneId.systemDefault())));
+                                    ZoneId.systemDefault())),
+                    snapshot.totalRecordCount(),
+                    snapshot.deltaRecordCount(),
+                    snapshot.changelogRecordCount());
         }
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/TestFileStore.java
@@ -457,10 +457,7 @@ public class TestFileStore extends KeyValueFileStore {
         }
 
         // manifests
-        List<ManifestFileMeta> manifests = snapshot.readAllDataManifests(manifestList);
-        if (snapshot.changelogManifestList() != null) {
-            manifests.addAll(manifestList.read(snapshot.changelogManifestList()));
-        }
+        List<ManifestFileMeta> manifests = snapshot.allManifests(manifestList);
         manifests.forEach(m -> result.add(pathFactory.toManifestFilePath(m.fileName())));
 
         // data file

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreScanTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/operation/KeyValueFileStoreScanTest.java
@@ -201,7 +201,7 @@ public class KeyValueFileStoreScanTest {
         ManifestList manifestList = store.manifestListFactory().create();
         long wantedSnapshotId = random.nextLong(snapshotManager.latestSnapshotId()) + 1;
         Snapshot wantedSnapshot = snapshotManager.snapshot(wantedSnapshotId);
-        List<ManifestFileMeta> wantedManifests = wantedSnapshot.readAllDataManifests(manifestList);
+        List<ManifestFileMeta> wantedManifests = wantedSnapshot.dataManifests(manifestList);
 
         FileStoreScan scan = store.newScan();
         scan.withManifestList(wantedManifests);

--- a/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/source/LogHybridSourceFactory.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/source/LogHybridSourceFactory.java
@@ -44,7 +44,7 @@ public class LogHybridSourceFactory
         Snapshot snapshot = enumerator.snapshot();
         Map<Integer, Long> logOffsets = null;
         if (snapshot != null) {
-            logOffsets = snapshot.getLogOffsets();
+            logOffsets = snapshot.logOffsets();
         }
         return provider.createSource(logOffsets);
     }

--- a/flink-table-store-flink/flink-table-store-flink-common/src/test/java/org/apache/flink/table/store/connector/CatalogTableITCase.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/test/java/org/apache/flink/table/store/connector/CatalogTableITCase.java
@@ -58,6 +58,19 @@ public class CatalogTableITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testSnapshotsTableWithRecordCount() throws Exception {
+        sql("CREATE TABLE T (a INT, b INT)");
+        sql("INSERT INTO T VALUES (1, 2)");
+        sql("INSERT INTO T VALUES (3, 4)");
+
+        List<Row> result =
+                sql(
+                        "SELECT snapshot_id, total_record_count, delta_record_count, changelog_record_count FROM T$snapshots");
+        assertThat(result)
+                .containsExactlyInAnyOrder(Row.of(1L, 1L, 1L, 0L), Row.of(2L, 2L, 1L, 0L));
+    }
+
+    @Test
     public void testOptionsTable() throws Exception {
         sql("CREATE TABLE T (a INT, b INT)");
         sql("ALTER TABLE T SET ('snapshot.time-retained' = '5 h')");

--- a/flink-table-store-spark/src/test/java/org/apache/flink/table/store/spark/SparkReadITCase.java
+++ b/flink-table-store-spark/src/test/java/org/apache/flink/table/store/spark/SparkReadITCase.java
@@ -100,6 +100,19 @@ public class SparkReadITCase extends SparkReadTestBase {
     }
 
     @Test
+    public void testSnapshotsTableWithRecordCount() {
+        List<Row> rows =
+                spark.table("tablestore.default.`t1$snapshots`")
+                        .select(
+                                "snapshot_id",
+                                "total_record_count",
+                                "delta_record_count",
+                                "changelog_record_count")
+                        .collectAsList();
+        assertThat(rows.toString()).isEqualTo("[[1,2,2,0]]");
+    }
+
+    @Test
     public void testCatalogFilterPushDown() {
         innerTestSimpleTypeFilterPushDown(spark.table("tablestore.default.t1"));
 


### PR DESCRIPTION
Record count represents the total number of data records. `Snapshot` could add `baseRecordCount`, `deltaRecordCount` and `changelogRecordCount` recording the record count of all changes occurred in the snapshot.

**The brief change log**

- Supports `baseRecordCount`, `deltaRecordCount` and `changelogRecordCount` recording the record count of all changes occurred in `Snapshot` and `SnapshotsTable`.