### PR TITLE
[FLINK-31201] Scan to generate splits should care about file order

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreScan.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreScan.java
@@ -28,7 +28,7 @@ import org.apache.flink.table.store.file.predicate.Predicate;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -74,9 +74,9 @@ public interface FileStoreScan {
         /** Return a map group by partition and bucket. */
         default Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> groupByPartFiles(
                 List<ManifestEntry> files) {
-            Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> groupBy = new HashMap<>();
+            Map<BinaryRowData, Map<Integer, List<DataFileMeta>>> groupBy = new LinkedHashMap<>();
             for (ManifestEntry entry : files) {
-                groupBy.computeIfAbsent(entry.partition(), k -> new HashMap<>())
+                groupBy.computeIfAbsent(entry.partition(), k -> new LinkedHashMap<>())
                         .computeIfAbsent(entry.bucket(), k -> new ArrayList<>())
                         .add(entry.file());
             }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/AppendOnlyFileStoreTableTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.store.file.schema.UpdateSchema;
 import org.apache.flink.table.store.table.sink.TableCommit;
 import org.apache.flink.table.store.table.sink.TableWrite;
 import org.apache.flink.table.store.table.source.AbstractDataTableScan;
+import org.apache.flink.table.store.table.source.DataSplit;
 import org.apache.flink.table.store.table.source.Split;
 import org.apache.flink.table.store.table.source.TableRead;
 
@@ -112,21 +113,29 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
     }
 
     @Test
-    public void testStreamingReadWrite() throws Exception {
-        writeData();
+    public void testBatchPlanOrder() throws Exception {
         FileStoreTable table = createFileStoreTable();
 
-        List<Split> splits = table.newScan().withKind(ScanKind.DELTA).plan().splits();
-        TableRead read = table.newRead();
-        assertThat(getResult(read, splits, binaryRow(1), 0, STREAMING_ROW_TO_STRING))
-                .isEqualTo(
-                        Arrays.asList(
-                                "+1|11|101|binary|varbinary|mapKey:mapVal|multiset",
-                                "+1|12|102|binary|varbinary|mapKey:mapVal|multiset"));
-        assertThat(getResult(read, splits, binaryRow(2), 0, STREAMING_ROW_TO_STRING))
-                .isEqualTo(
-                        Collections.singletonList(
-                                "+2|21|201|binary|varbinary|mapKey:mapVal|multiset"));
+        TableWrite write = table.newWrite(commitUser);
+        TableCommit commit = table.newCommit(commitUser);
+
+        write.write(rowData(1, 10, 100L));
+        commit.commit(0, write.prepareCommit(true, 0));
+
+        write.write(rowData(2, 22, 202L));
+        commit.commit(1, write.prepareCommit(true, 1));
+
+        write.write(rowData(3, 33, 303L));
+        commit.commit(2, write.prepareCommit(true, 2));
+        write.close();
+
+        List<Split> splits = table.newScan().plan().splits();
+        int[] partitions =
+                splits.stream()
+                        .map(split -> ((DataSplit) split).partition().getInt(0))
+                        .mapToInt(Integer::intValue)
+                        .toArray();
+        assertThat(partitions).containsExactly(1, 2, 3);
     }
 
     @Test


### PR DESCRIPTION
Currently, it is out of order for partitions. Because HashMap is used, we may be able to use LinkedHashMap to make the order according to the creation time of the first file.