### PR TITLE
[FLINK-31232] Parquet format supports MULTISET type for Table Store

### DIFF
--- a/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/parquet/ParquetSchemaConverter.java
+++ b/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/parquet/ParquetSchemaConverter.java
@@ -21,7 +21,9 @@ package org.apache.flink.table.store.format.parquet;
 import org.apache.flink.table.store.types.ArrayType;
 import org.apache.flink.table.store.types.DataType;
 import org.apache.flink.table.store.types.DecimalType;
+import org.apache.flink.table.store.types.IntType;
 import org.apache.flink.table.store.types.MapType;
+import org.apache.flink.table.store.types.MultisetType;
 import org.apache.flink.table.store.types.RowType;
 
 import org.apache.parquet.schema.ConversionPatterns;
@@ -125,6 +127,14 @@ public class ParquetSchemaConverter {
                         MAP_REPEATED_NAME,
                         convertToParquetType("key", mapType.getKeyType()),
                         convertToParquetType("value", mapType.getValueType()));
+            case MULTISET:
+                MultisetType multisetType = (MultisetType) type;
+                return ConversionPatterns.mapType(
+                        repetition,
+                        name,
+                        MAP_REPEATED_NAME,
+                        convertToParquetType("key", multisetType.getElementType()),
+                        convertToParquetType("value", new IntType(false)));
             case ROW:
                 RowType rowType = (RowType) type;
                 return new GroupType(repetition, name, convertToParquetTypes(rowType));

--- a/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/parquet/reader/ParquetSplitReaderUtil.java
+++ b/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/parquet/reader/ParquetSplitReaderUtil.java
@@ -35,7 +35,9 @@ import org.apache.flink.table.store.format.parquet.ParquetSchemaConverter;
 import org.apache.flink.table.store.types.ArrayType;
 import org.apache.flink.table.store.types.DataType;
 import org.apache.flink.table.store.types.DecimalType;
+import org.apache.flink.table.store.types.IntType;
 import org.apache.flink.table.store.types.MapType;
+import org.apache.flink.table.store.types.MultisetType;
 import org.apache.flink.table.store.types.RowType;
 
 import org.apache.parquet.ParquetRuntimeException;
@@ -126,21 +128,38 @@ public class ParquetSplitReaderUtil {
                         fieldType);
             case MAP:
                 MapType mapType = (MapType) fieldType;
-                ArrayColumnReader keyReader =
+                ArrayColumnReader mapKeyReader =
                         new ArrayColumnReader(
                                 descriptors.get(0),
                                 pages.getPageReader(descriptors.get(0)),
                                 true,
                                 descriptors.get(0).getPrimitiveType(),
                                 new ArrayType(mapType.getKeyType()));
-                ArrayColumnReader valueReader =
+                ArrayColumnReader mapValueReader =
                         new ArrayColumnReader(
                                 descriptors.get(1),
                                 pages.getPageReader(descriptors.get(1)),
                                 true,
                                 descriptors.get(1).getPrimitiveType(),
                                 new ArrayType(mapType.getValueType()));
-                return new MapColumnReader(keyReader, valueReader);
+                return new MapColumnReader(mapKeyReader, mapValueReader);
+            case MULTISET:
+                MultisetType multisetType = (MultisetType) fieldType;
+                ArrayColumnReader multisetKeyReader =
+                        new ArrayColumnReader(
+                                descriptors.get(0),
+                                pages.getPageReader(descriptors.get(0)),
+                                true,
+                                descriptors.get(0).getPrimitiveType(),
+                                new ArrayType(multisetType.getElementType()));
+                ArrayColumnReader multisetValueReader =
+                        new ArrayColumnReader(
+                                descriptors.get(1),
+                                pages.getPageReader(descriptors.get(1)),
+                                true,
+                                descriptors.get(1).getPrimitiveType(),
+                                new ArrayType(new IntType(false)));
+                return new MapColumnReader(multisetKeyReader, multisetValueReader);
             case ROW:
                 RowType rowType = (RowType) fieldType;
                 GroupType groupType = type.asGroupType();
@@ -270,19 +289,36 @@ public class ParquetSplitReaderUtil {
                                 depth));
             case MAP:
                 MapType mapType = (MapType) fieldType;
-                GroupType repeatedType = type.asGroupType().getType(0).asGroupType();
+                GroupType mapRepeatedType = type.asGroupType().getType(0).asGroupType();
                 return new HeapMapVector(
                         batchSize,
                         createWritableColumnVector(
                                 batchSize,
                                 mapType.getKeyType(),
-                                repeatedType.getType(0),
+                                mapRepeatedType.getType(0),
                                 descriptors,
                                 depth + 2),
                         createWritableColumnVector(
                                 batchSize,
                                 mapType.getValueType(),
-                                repeatedType.getType(1),
+                                mapRepeatedType.getType(1),
+                                descriptors,
+                                depth + 2));
+            case MULTISET:
+                MultisetType multisetType = (MultisetType) fieldType;
+                GroupType multisetRepeatedType = type.asGroupType().getType(0).asGroupType();
+                return new HeapMapVector(
+                        batchSize,
+                        createWritableColumnVector(
+                                batchSize,
+                                multisetType.getElementType(),
+                                multisetRepeatedType.getType(0),
+                                descriptors,
+                                depth + 2),
+                        createWritableColumnVector(
+                                batchSize,
+                                new IntType(false),
+                                multisetRepeatedType.getType(1),
                                 descriptors,
                                 depth + 2));
             case ROW:

--- a/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/parquet/writer/ParquetRowDataWriter.java
+++ b/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/parquet/writer/ParquetRowDataWriter.java
@@ -27,8 +27,10 @@ import org.apache.flink.table.store.format.parquet.ParquetSchemaConverter;
 import org.apache.flink.table.store.types.ArrayType;
 import org.apache.flink.table.store.types.DataType;
 import org.apache.flink.table.store.types.DecimalType;
+import org.apache.flink.table.store.types.IntType;
 import org.apache.flink.table.store.types.LocalZonedTimestampType;
 import org.apache.flink.table.store.types.MapType;
+import org.apache.flink.table.store.types.MultisetType;
 import org.apache.flink.table.store.types.RowType;
 import org.apache.flink.table.store.types.TimestampType;
 import org.apache.flink.table.store.utils.Preconditions;
@@ -120,6 +122,10 @@ public class ParquetRowDataWriter {
                     && annotation instanceof LogicalTypeAnnotation.MapLogicalTypeAnnotation) {
                 return new MapWriter(
                         ((MapType) t).getKeyType(), ((MapType) t).getValueType(), groupType);
+            } else if (t instanceof MultisetType
+                    && annotation instanceof LogicalTypeAnnotation.MapLogicalTypeAnnotation) {
+                return new MapWriter(
+                        ((MultisetType) t).getElementType(), new IntType(false), groupType);
             } else if (t instanceof RowType && type instanceof GroupType) {
                 return new RowWriter((RowType) t, groupType);
             } else {

--- a/flink-table-store-format/src/test/java/org/apache/flink/table/store/format/parquet/ParquetReadWriteTest.java
+++ b/flink-table-store-format/src/test/java/org/apache/flink/table/store/format/parquet/ParquetReadWriteTest.java
@@ -40,6 +40,7 @@ import org.apache.flink.table.store.types.DoubleType;
 import org.apache.flink.table.store.types.FloatType;
 import org.apache.flink.table.store.types.IntType;
 import org.apache.flink.table.store.types.MapType;
+import org.apache.flink.table.store.types.MultisetType;
 import org.apache.flink.table.store.types.RowType;
 import org.apache.flink.table.store.types.SmallIntType;
 import org.apache.flink.table.store.types.TimestampType;
@@ -111,6 +112,7 @@ public class ParquetReadWriteTest {
                                     new VarCharType(VarCharType.MAX_LENGTH),
                                     new VarCharType(VarCharType.MAX_LENGTH)),
                             new MapType(new IntType(), new BooleanType()),
+                            new MultisetType(new VarCharType(VarCharType.MAX_LENGTH)),
                             RowType.builder()
                                     .fields(new VarCharType(VarCharType.MAX_LENGTH), new IntType())
                                     .build())
@@ -415,8 +417,9 @@ public class ParquetReadWriteTest {
                                 .isEqualTo(Decimal.fromBigDecimal(BigDecimal.valueOf(v), 20, 0));
                         assertThat(row.getMap(30).valueArray().getString(0)).hasToString("" + v);
                         assertThat(row.getMap(31).valueArray().getBoolean(0)).isEqualTo(v % 2 == 0);
-                        assertThat(row.getRow(32, 2).getString(0)).hasToString("" + v);
-                        assertThat(row.getRow(32, 2).getInt(1)).isEqualTo(v.intValue());
+                        assertThat(row.getMap(32).keyArray().getString(0)).hasToString("" + v);
+                        assertThat(row.getRow(33, 2).getString(0)).hasToString("" + v);
+                        assertThat(row.getRow(33, 2).getInt(1)).isEqualTo(v.intValue());
                     }
                     cnt.incrementAndGet();
                 });
@@ -434,6 +437,9 @@ public class ParquetReadWriteTest {
 
         Map<Integer, Boolean> f31 = new HashMap<>();
         f31.put(v, v % 2 == 0);
+
+        Map<BinaryString, Integer> f32 = new HashMap<>();
+        f32.put(BinaryString.fromString("" + v), v);
 
         return GenericRow.of(
                 BinaryString.fromString("" + v),
@@ -482,6 +488,7 @@ public class ParquetReadWriteTest {
                         new Object[] {Decimal.fromBigDecimal(BigDecimal.valueOf(v), 20, 0), null}),
                 new GenericMap(f30),
                 new GenericMap(f31),
+                new GenericMap(f32),
                 GenericRow.of(BinaryString.fromString("" + v), v));
     }
 


### PR DESCRIPTION
Parquet format should support MULTISET type for Table Store. Meanwhile, the FileStats couldn't support the MULTISET type because the null count of ColumnStatistics for ARRAY, MAP and MULTISET type in Parquet isn't right.

**The brief change log**
- The reader, writer and converter of Parquet format supports MULTISET type.