### PR TITLE
[FLINK-31252] Improve StaticFileStoreSplitEnumerator to assign batch splits

### DIFF
--- a/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/source/StaticFileStoreSplitEnumerator.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/source/StaticFileStoreSplitEnumerator.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.store.connector.source;
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.api.connector.source.SplitsAssignment;
-import org.apache.flink.table.store.annotation.VisibleForTesting;
 import org.apache.flink.table.store.file.Snapshot;
 
 import javax.annotation.Nullable;

--- a/flink-table-store-flink/flink-table-store-flink-common/src/test/java/org/apache/flink/table/store/connector/source/ContinuousFileSplitEnumeratorTest.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/test/java/org/apache/flink/table/store/connector/source/ContinuousFileSplitEnumeratorTest.java
@@ -136,7 +136,7 @@ public class ContinuousFileSplitEnumeratorTest {
         assertThat(assignedSplits).hasSameElementsAs(expectedSplits.subList(2, 4));
     }
 
-    private static FileStoreSourceSplit createSnapshotSplit(
+    public static FileStoreSourceSplit createSnapshotSplit(
             int snapshotId, int bucket, List<DataFileMeta> files) {
         return new FileStoreSourceSplit(
                 UUID.randomUUID().toString(),

--- a/flink-table-store-flink/flink-table-store-flink-common/src/test/java/org/apache/flink/table/store/connector/source/StaticFileStoreSplitEnumeratorTest.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/test/java/org/apache/flink/table/store/connector/source/StaticFileStoreSplitEnumeratorTest.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.connector.source;
+
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.connector.testutils.source.reader.TestingSplitEnumeratorContext;
+import org.apache.flink.table.store.file.io.DataFileMeta;
+import org.apache.flink.table.store.table.source.DataSplit;
+import org.apache.flink.table.store.table.source.snapshot.SnapshotEnumerator;
+
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.apache.flink.connector.testutils.source.reader.TestingSplitEnumeratorContext.SplitAssignmentState;
+import static org.apache.flink.table.store.file.mergetree.compact.MergeTreeCompactManagerTest.row;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for the {@link StaticFileStoreSplitEnumerator}. */
+public class StaticFileStoreSplitEnumeratorTest {
+
+    @Test
+    public void testSplitAllocationIsOrdered() throws Exception {
+        final TestingSplitEnumeratorContext<FileStoreSourceSplit> context =
+                new TestingSplitEnumeratorContext<>(2);
+        context.registerReader(0, "test-host");
+
+        List<FileStoreSourceSplit> initialSplits = new ArrayList<>();
+        for (int i = 1; i <= 4; i++) {
+            initialSplits.add(createSnapshotSplit(i, 0, Collections.emptyList()));
+        }
+        List<FileStoreSourceSplit> expectedSplits = new ArrayList<>(initialSplits);
+        StaticFileStoreSplitEnumerator enumerator = new StaticFileStoreSplitEnumerator(context, null, initialSplits);
+
+        // The first time split is allocated, split1 and split2 should be allocated
+        enumerator.handleSplitRequest(0, "test-host");
+        Map<Integer, SplitAssignmentState<FileStoreSourceSplit>> assignments =
+                context.getSplitAssignments();
+        // Only subtask-0 is allocated.
+        assertThat(assignments).containsOnlyKeys(0);
+        List<FileStoreSourceSplit> assignedSplits = assignments.get(0).getAssignedSplits();
+        assertThat(assignedSplits).hasSameElementsAs(expectedSplits.subList(0, 2));
+
+        // split1 and split2 is added back
+        enumerator.addSplitsBack(assignedSplits, 0);
+        context.getSplitAssignments().clear();
+        assertThat(context.getSplitAssignments()).isEmpty();
+
+        // The split is allocated for the second time, and split1 is allocated first
+        enumerator.handleSplitRequest(0, "test-host");
+        enumerator.handleSplitRequest(0, "test-host");
+        assignments = context.getSplitAssignments();
+        // Only subtask-0 is allocated.
+        assertThat(assignments).containsOnlyKeys(0);
+        assignedSplits = assignments.get(0).getAssignedSplits();
+        assertThat(assignedSplits).hasSameElementsAs(expectedSplits.subList(0, 2));
+
+        // continuing to allocate split
+        context.getSplitAssignments().clear();
+        enumerator.handleSplitRequest(0, "test-host");
+        enumerator.handleSplitRequest(0, "test-host");
+        assignments = context.getSplitAssignments();
+        // Only subtask-0 is allocated.
+        assertThat(assignments).containsOnlyKeys(0);
+        assignedSplits = assignments.get(0).getAssignedSplits();
+        assertThat(assignedSplits).hasSameElementsAs(expectedSplits.subList(2, 4));
+    }
+
+    @Test
+    public void testSplitAllocationIsFair() throws Exception {
+        final TestingSplitEnumeratorContext<FileStoreSourceSplit> context =
+                new TestingSplitEnumeratorContext<>(1);
+        context.registerReader(0, "test-host");
+
+        List<FileStoreSourceSplit> initialSplits = new ArrayList<>();
+        for (int i = 1; i <= 2; i++) {
+            initialSplits.add(createSnapshotSplit(i, 0, Collections.emptyList()));
+            initialSplits.add(createSnapshotSplit(i, 1, Collections.emptyList()));
+        }
+
+        List<FileStoreSourceSplit> expectedSplits = new ArrayList<>(initialSplits);
+
+        final ContinuousFileSplitEnumerator enumerator =
+                new Builder()
+                        .setSplitEnumeratorContext(context)
+                        .setInitialSplits(initialSplits)
+                        .setDiscoveryInterval(3)
+                        .build();
+
+        // each time a split is allocated from bucket-0 and bucket-1
+        enumerator.handleSplitRequest(0, "test-host");
+        Map<Integer, SplitAssignmentState<FileStoreSourceSplit>> assignments =
+                context.getSplitAssignments();
+        // Only subtask-0 is allocated.
+        assertThat(assignments).containsOnlyKeys(0);
+        List<FileStoreSourceSplit> assignedSplits = assignments.get(0).getAssignedSplits();
+        assertThat(assignedSplits).hasSameElementsAs(expectedSplits.subList(0, 2));
+
+        // clear assignments
+        context.getSplitAssignments().clear();
+        assertThat(context.getSplitAssignments()).isEmpty();
+
+        // continuing to allocate the rest splits
+        enumerator.handleSplitRequest(0, "test-host");
+        assignments = context.getSplitAssignments();
+        // Only subtask-0 is allocated.
+        assertThat(assignments).containsOnlyKeys(0);
+        assignedSplits = assignments.get(0).getAssignedSplits();
+        assertThat(assignedSplits).hasSameElementsAs(expectedSplits.subList(2, 4));
+    }
+
+    private static FileStoreSourceSplit createSnapshotSplit(
+            int snapshotId, int bucket, List<DataFileMeta> files) {
+        return new FileStoreSourceSplit(
+                UUID.randomUUID().toString(),
+                new DataSplit(snapshotId, row(1), bucket, files, true),
+                0);
+    }
+
+    private static class Builder {
+        private SplitEnumeratorContext<FileStoreSourceSplit> context;
+        private Collection<FileStoreSourceSplit> initialSplits = Collections.emptyList();
+        private Long nextSnapshotId;
+        private long discoveryInterval = Long.MAX_VALUE;
+        private SnapshotEnumerator snapshotEnumerator;
+
+        public Builder setSplitEnumeratorContext(
+                SplitEnumeratorContext<FileStoreSourceSplit> context) {
+            this.context = context;
+            return this;
+        }
+
+        public Builder setInitialSplits(Collection<FileStoreSourceSplit> initialSplits) {
+            this.initialSplits = initialSplits;
+            return this;
+        }
+
+        public Builder setNextSnapshotId(Long nextSnapshotId) {
+            this.nextSnapshotId = nextSnapshotId;
+            return this;
+        }
+
+        public Builder setDiscoveryInterval(long discoveryInterval) {
+            this.discoveryInterval = discoveryInterval;
+            return this;
+        }
+
+        public Builder setSnapshotEnumerator(SnapshotEnumerator snapshotEnumerator) {
+            this.snapshotEnumerator = snapshotEnumerator;
+            return this;
+        }
+
+        public ContinuousFileSplitEnumerator build() {
+            return new ContinuousFileSplitEnumerator(
+                    context, initialSplits, nextSnapshotId, discoveryInterval, snapshotEnumerator);
+        }
+    }
+}

--- a/flink-table-store-flink/flink-table-store-flink-common/src/test/java/org/apache/flink/table/store/connector/source/StaticFileStoreSplitEnumeratorTest.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/test/java/org/apache/flink/table/store/connector/source/StaticFileStoreSplitEnumeratorTest.java
@@ -18,164 +18,105 @@
 
 package org.apache.flink.table.store.connector.source;
 
-import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.connector.testutils.source.reader.TestingSplitEnumeratorContext;
-import org.apache.flink.table.store.file.io.DataFileMeta;
-import org.apache.flink.table.store.table.source.DataSplit;
-import org.apache.flink.table.store.table.source.snapshot.SnapshotEnumerator;
 
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import static org.apache.flink.connector.testutils.source.reader.TestingSplitEnumeratorContext.SplitAssignmentState;
-import static org.apache.flink.table.store.file.mergetree.compact.MergeTreeCompactManagerTest.row;
+import static org.apache.flink.table.store.connector.source.ContinuousFileSplitEnumeratorTest.createSnapshotSplit;
 import static org.assertj.core.api.Assertions.assertThat;
-
-
-import org.junit.jupiter.api.Test;
 
 /** Unit tests for the {@link StaticFileStoreSplitEnumerator}. */
 public class StaticFileStoreSplitEnumeratorTest {
 
     @Test
-    public void testSplitAllocationIsOrdered() throws Exception {
+    public void testSplitAllocation() {
         final TestingSplitEnumeratorContext<FileStoreSourceSplit> context =
                 new TestingSplitEnumeratorContext<>(2);
         context.registerReader(0, "test-host");
+        context.registerReader(1, "test-host");
 
-        List<FileStoreSourceSplit> initialSplits = new ArrayList<>();
+        List<FileStoreSourceSplit> splits = new ArrayList<>();
         for (int i = 1; i <= 4; i++) {
-            initialSplits.add(createSnapshotSplit(i, 0, Collections.emptyList()));
+            splits.add(createSnapshotSplit(i, 0, Collections.emptyList()));
         }
-        List<FileStoreSourceSplit> expectedSplits = new ArrayList<>(initialSplits);
-        StaticFileStoreSplitEnumerator enumerator = new StaticFileStoreSplitEnumerator(context, null, initialSplits);
+        StaticFileStoreSplitEnumerator enumerator =
+                new StaticFileStoreSplitEnumerator(context, null, splits);
 
-        // The first time split is allocated, split1 and split2 should be allocated
+        // test assign
         enumerator.handleSplitRequest(0, "test-host");
+        enumerator.handleSplitRequest(1, "test-host");
         Map<Integer, SplitAssignmentState<FileStoreSourceSplit>> assignments =
                 context.getSplitAssignments();
-        // Only subtask-0 is allocated.
-        assertThat(assignments).containsOnlyKeys(0);
-        List<FileStoreSourceSplit> assignedSplits = assignments.get(0).getAssignedSplits();
-        assertThat(assignedSplits).hasSameElementsAs(expectedSplits.subList(0, 2));
+        assertThat(assignments).containsOnlyKeys(0, 1);
+        assertThat(assignments.get(0).getAssignedSplits())
+                .containsExactly(splits.get(0), splits.get(2));
+        assertThat(assignments.get(1).getAssignedSplits())
+                .containsExactly(splits.get(1), splits.get(3));
 
-        // split1 and split2 is added back
-        enumerator.addSplitsBack(assignedSplits, 0);
+        // test addSplitsBack
+        enumerator.addSplitsBack(assignments.get(0).getAssignedSplits(), 0);
         context.getSplitAssignments().clear();
         assertThat(context.getSplitAssignments()).isEmpty();
-
-        // The split is allocated for the second time, and split1 is allocated first
         enumerator.handleSplitRequest(0, "test-host");
-        enumerator.handleSplitRequest(0, "test-host");
-        assignments = context.getSplitAssignments();
-        // Only subtask-0 is allocated.
-        assertThat(assignments).containsOnlyKeys(0);
-        assignedSplits = assignments.get(0).getAssignedSplits();
-        assertThat(assignedSplits).hasSameElementsAs(expectedSplits.subList(0, 2));
-
-        // continuing to allocate split
-        context.getSplitAssignments().clear();
-        enumerator.handleSplitRequest(0, "test-host");
-        enumerator.handleSplitRequest(0, "test-host");
-        assignments = context.getSplitAssignments();
-        // Only subtask-0 is allocated.
-        assertThat(assignments).containsOnlyKeys(0);
-        assignedSplits = assignments.get(0).getAssignedSplits();
-        assertThat(assignedSplits).hasSameElementsAs(expectedSplits.subList(2, 4));
+        assertThat(assignments.get(0).getAssignedSplits())
+                .containsExactly(splits.get(0), splits.get(2));
     }
 
     @Test
-    public void testSplitAllocationIsFair() throws Exception {
+    public void testSplitAllocationNotEvenly() {
         final TestingSplitEnumeratorContext<FileStoreSourceSplit> context =
-                new TestingSplitEnumeratorContext<>(1);
+                new TestingSplitEnumeratorContext<>(2);
         context.registerReader(0, "test-host");
+        context.registerReader(1, "test-host");
 
-        List<FileStoreSourceSplit> initialSplits = new ArrayList<>();
-        for (int i = 1; i <= 2; i++) {
-            initialSplits.add(createSnapshotSplit(i, 0, Collections.emptyList()));
-            initialSplits.add(createSnapshotSplit(i, 1, Collections.emptyList()));
+        List<FileStoreSourceSplit> splits = new ArrayList<>();
+        for (int i = 1; i <= 3; i++) {
+            splits.add(createSnapshotSplit(i, 0, Collections.emptyList()));
         }
+        StaticFileStoreSplitEnumerator enumerator =
+                new StaticFileStoreSplitEnumerator(context, null, splits);
 
-        List<FileStoreSourceSplit> expectedSplits = new ArrayList<>(initialSplits);
-
-        final ContinuousFileSplitEnumerator enumerator =
-                new Builder()
-                        .setSplitEnumeratorContext(context)
-                        .setInitialSplits(initialSplits)
-                        .setDiscoveryInterval(3)
-                        .build();
-
-        // each time a split is allocated from bucket-0 and bucket-1
+        // test assign
         enumerator.handleSplitRequest(0, "test-host");
+        enumerator.handleSplitRequest(1, "test-host");
         Map<Integer, SplitAssignmentState<FileStoreSourceSplit>> assignments =
                 context.getSplitAssignments();
-        // Only subtask-0 is allocated.
-        assertThat(assignments).containsOnlyKeys(0);
-        List<FileStoreSourceSplit> assignedSplits = assignments.get(0).getAssignedSplits();
-        assertThat(assignedSplits).hasSameElementsAs(expectedSplits.subList(0, 2));
+        assertThat(assignments).containsOnlyKeys(0, 1);
+        assertThat(assignments.get(0).getAssignedSplits())
+                .containsExactly(splits.get(0), splits.get(2));
+        assertThat(assignments.get(1).getAssignedSplits()).containsExactly(splits.get(1));
+    }
 
-        // clear assignments
-        context.getSplitAssignments().clear();
-        assertThat(context.getSplitAssignments()).isEmpty();
+    @Test
+    public void testSplitAllocationSomeEmpty() {
+        final TestingSplitEnumeratorContext<FileStoreSourceSplit> context =
+                new TestingSplitEnumeratorContext<>(3);
+        context.registerReader(0, "test-host");
+        context.registerReader(1, "test-host");
+        context.registerReader(2, "test-host");
 
-        // continuing to allocate the rest splits
+        List<FileStoreSourceSplit> splits = new ArrayList<>();
+        for (int i = 1; i <= 2; i++) {
+            splits.add(createSnapshotSplit(i, 0, Collections.emptyList()));
+        }
+        StaticFileStoreSplitEnumerator enumerator =
+                new StaticFileStoreSplitEnumerator(context, null, splits);
+
+        // test assign
         enumerator.handleSplitRequest(0, "test-host");
-        assignments = context.getSplitAssignments();
-        // Only subtask-0 is allocated.
-        assertThat(assignments).containsOnlyKeys(0);
-        assignedSplits = assignments.get(0).getAssignedSplits();
-        assertThat(assignedSplits).hasSameElementsAs(expectedSplits.subList(2, 4));
-    }
-
-    private static FileStoreSourceSplit createSnapshotSplit(
-            int snapshotId, int bucket, List<DataFileMeta> files) {
-        return new FileStoreSourceSplit(
-                UUID.randomUUID().toString(),
-                new DataSplit(snapshotId, row(1), bucket, files, true),
-                0);
-    }
-
-    private static class Builder {
-        private SplitEnumeratorContext<FileStoreSourceSplit> context;
-        private Collection<FileStoreSourceSplit> initialSplits = Collections.emptyList();
-        private Long nextSnapshotId;
-        private long discoveryInterval = Long.MAX_VALUE;
-        private SnapshotEnumerator snapshotEnumerator;
-
-        public Builder setSplitEnumeratorContext(
-                SplitEnumeratorContext<FileStoreSourceSplit> context) {
-            this.context = context;
-            return this;
-        }
-
-        public Builder setInitialSplits(Collection<FileStoreSourceSplit> initialSplits) {
-            this.initialSplits = initialSplits;
-            return this;
-        }
-
-        public Builder setNextSnapshotId(Long nextSnapshotId) {
-            this.nextSnapshotId = nextSnapshotId;
-            return this;
-        }
-
-        public Builder setDiscoveryInterval(long discoveryInterval) {
-            this.discoveryInterval = discoveryInterval;
-            return this;
-        }
-
-        public Builder setSnapshotEnumerator(SnapshotEnumerator snapshotEnumerator) {
-            this.snapshotEnumerator = snapshotEnumerator;
-            return this;
-        }
-
-        public ContinuousFileSplitEnumerator build() {
-            return new ContinuousFileSplitEnumerator(
-                    context, initialSplits, nextSnapshotId, discoveryInterval, snapshotEnumerator);
-        }
+        enumerator.handleSplitRequest(1, "test-host");
+        enumerator.handleSplitRequest(2, "test-host");
+        Map<Integer, SplitAssignmentState<FileStoreSourceSplit>> assignments =
+                context.getSplitAssignments();
+        assertThat(assignments).containsOnlyKeys(0, 1, 2);
+        assertThat(assignments.get(0).getAssignedSplits()).containsExactly(splits.get(0));
+        assertThat(assignments.get(1).getAssignedSplits()).containsExactly(splits.get(1));
+        assertThat(assignments.get(2).getAssignedSplits()).isEmpty();
     }
 }


### PR DESCRIPTION
The following batch assignment operation is for two things:
1. It can be evenly distributed during batch reading to avoid scheduling problems (for example, the current resource can only schedule part of the tasks) that cause some tasks to fail to read data.
2. Read with limit, if split is assigned one by one, it may cause the task to repeatedly create SplitFetchers. After the task is created, it is found that it is idle and then closed. Then, new split coming, it will create a new SplitFetcher and repeatedly read the data of the limit number (because the limit status is in the SplitFetcher).