### PR TITLE
[FLINK-31226] Bump FRocksDB version to 6.20.3-ververica-2.0

### DIFF
--- a/flink-table-store-flink/flink-table-store-flink-common/pom.xml
+++ b/flink-table-store-flink/flink-table-store-flink-common/pom.xml
@@ -35,7 +35,7 @@ under the License.
 
     <properties>
         <flink.version>1.16.1</flink.version>
-        <frocksdbjni.version>6.20.3-ververica-1.0</frocksdbjni.version>
+        <frocksdbjni.version>6.20.3-ververica-2.0</frocksdbjni.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Current FRocksDB version in flink-table-store is still 6.20.3-ververica-1.0, which cannot run with Apple's silicon chips.
Newly released 6.20.3-ververica-2.0 FRocksDB could run well with Apple's silicon chips and is compatible with the previous version.