### PR TITLE
[FLINK-31289] Default aggregate-function for field can be last_non_null_value

### DIFF
--- a/docs/content/docs/concepts/primary-key-table.md
+++ b/docs/content/docs/concepts/primary-key-table.md
@@ -65,7 +65,7 @@ Partial cannot receive `DELETE` messages because the behavior cannot be defined.
 
 Sometimes users only care about aggregated results. The `aggregation` merge engine aggregates each value field with the latest data one by one under the same primary key according to the aggregate function.
 
-Each field not part of the primary keys must be given an aggregate function, specified by the `fields.<field-name>.aggregate-function` table property. For example, consider the following table definition.
+Each field not part of the primary keys can be given an aggregate function, specified by the `fields.<field-name>.aggregate-function` table property, otherwise it will use `last_non_null_value` aggregation as default. For example, consider the following table definition.
 
 {{< tabs "aggregation-merge-engine-example" >}}
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/aggregate/FieldAggregator.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/compact/aggregate/FieldAggregator.java
@@ -36,35 +36,40 @@ public abstract class FieldAggregator implements Serializable {
         if (isPrimaryKey) {
             fieldAggregator = new FieldPrimaryKeyAgg(fieldType);
         } else {
-            // ordered by type root definition
-            switch (strAgg) {
-                case FieldSumAgg.NAME:
-                    fieldAggregator = new FieldSumAgg(fieldType);
-                    break;
-                case FieldMaxAgg.NAME:
-                    fieldAggregator = new FieldMaxAgg(fieldType);
-                    break;
-                case FieldMinAgg.NAME:
-                    fieldAggregator = new FieldMinAgg(fieldType);
-                    break;
-                case FieldLastNonNullValueAgg.NAME:
-                    fieldAggregator = new FieldLastNonNullValueAgg(fieldType);
-                    break;
-                case FieldLastValueAgg.NAME:
-                    fieldAggregator = new FieldLastValueAgg(fieldType);
-                    break;
-                case FieldListaggAgg.NAME:
-                    fieldAggregator = new FieldListaggAgg(fieldType);
-                    break;
-                case FieldBoolOrAgg.NAME:
-                    fieldAggregator = new FieldBoolOrAgg(fieldType);
-                    break;
-                case FieldBoolAndAgg.NAME:
-                    fieldAggregator = new FieldBoolAndAgg(fieldType);
-                    break;
-                default:
-                    throw new RuntimeException(
-                            "Use unsupported aggregation or spell aggregate function incorrectly!");
+            // If the field has no aggregate function, use last_non_null_value.
+            if (strAgg == null) {
+                fieldAggregator = new FieldLastNonNullValueAgg(fieldType);
+            } else {
+                // ordered by type root definition
+                switch (strAgg) {
+                    case FieldSumAgg.NAME:
+                        fieldAggregator = new FieldSumAgg(fieldType);
+                        break;
+                    case FieldMaxAgg.NAME:
+                        fieldAggregator = new FieldMaxAgg(fieldType);
+                        break;
+                    case FieldMinAgg.NAME:
+                        fieldAggregator = new FieldMinAgg(fieldType);
+                        break;
+                    case FieldLastNonNullValueAgg.NAME:
+                        fieldAggregator = new FieldLastNonNullValueAgg(fieldType);
+                        break;
+                    case FieldLastValueAgg.NAME:
+                        fieldAggregator = new FieldLastValueAgg(fieldType);
+                        break;
+                    case FieldListaggAgg.NAME:
+                        fieldAggregator = new FieldListaggAgg(fieldType);
+                        break;
+                    case FieldBoolOrAgg.NAME:
+                        fieldAggregator = new FieldBoolOrAgg(fieldType);
+                        break;
+                    case FieldBoolAndAgg.NAME:
+                        fieldAggregator = new FieldBoolAndAgg(fieldType);
+                        break;
+                    default:
+                        throw new RuntimeException(
+                                "Use unsupported aggregation or spell aggregate function incorrectly!");
+                }
             }
         }
 


### PR DESCRIPTION
If the field has no aggregate function for aggregation merge-engine, use last_non_null_value aggregation as default.