### PR TITLE
[FLINK-31291] Document "table.exec.sink.upsert-materialize" to "none" to avoid strange behavior

### DIFF
--- a/docs/content/docs/concepts/primary-key-table.md
+++ b/docs/content/docs/concepts/primary-key-table.md
@@ -179,3 +179,7 @@ CREATE TABLE MyTable (
 {{< /tabs >}}
 
 The record with the largest `sequence.field` value will be the last to merge, regardless of the input order.
+
+{{< hint info >}}
+We recommend you set `sequence.field` to table to correct disorder. Set `table.exec.sink.upsert-materialize` to `NONE` always to avoid any materialize operator being added by Flink SQL, which may result in strange behavior.
+{{< /hint >}}


### PR DESCRIPTION
## What is the purpose of the change

Document set `table.exec.sink.upsert-materialize` to `NONE` always to avoid strange behavior brought by FLINK SQL default sink materialize.
