### PR TITLE
[FLINK-31311] Supports Bounded Watermark streaming read

### DIFF
--- a/docs/content/docs/how-to/querying-tables.md
+++ b/docs/content/docs/how-to/querying-tables.md
@@ -87,6 +87,10 @@ Users can also adjust `changelog-producer` table property to specify the pattern
 
 {{< img src="/img/scan-mode.png">}}
 
+{{< hint info >}}
+Streaming Source can also be bounded, you can specify 'scan.bounded.watermark' to define the end condition for bounded streaming mode, stream reading will end until a larger watermark snapshot is encountered.
+{{< /hint >}}
+
 ## System Tables
 
 System tables contain metadata and information about each table, such as the snapshots created and the options in use. Users can access system tables with batch queries.

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -234,7 +234,7 @@
             <td><h5>scan.bounded.watermark</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Long</td>
-            <td>End condition "watermark" for bounded streaming mode. Stream reading will end until a larger watermark snapshot is encountered.</td>
+            <td>End condition "watermark" for bounded streaming mode. Stream reading will end when a larger watermark snapshot is encountered.</td>
         </tr>
         <tr>
             <td><h5>scan.mode</h5></td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -81,6 +81,12 @@
             <td>The discovery interval of continuous reading.</td>
         </tr>
         <tr>
+            <td><h5>file.compression.per.level</h5></td>
+            <td style="word-wrap: break-word;"></td>
+            <td>Map</td>
+            <td>Define different compression policies for different level, you can add the conf like this: 'file.compression.per.level' = '0:lz4,1:zlib', for orc file format, the compression value could be NONE, ZLIB, SNAPPY, LZO, LZ4, for parquet file format, the compression value could be UNCOMPRESSED, SNAPPY, GZIP, LZO, BROTLI, LZ4, ZSTD.</td>
+        </tr>
+        <tr>
             <td><h5>file.format</h5></td>
             <td style="word-wrap: break-word;">"orc"</td>
             <td>String</td>
@@ -115,12 +121,6 @@
             <td style="word-wrap: break-word;">"json"</td>
             <td>String</td>
             <td>Specify the key message format of log system with primary key.</td>
-        </tr>
-        <tr>
-            <td><h5>log.retention</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>Duration</td>
-            <td>It means how long changes log will be kept. The default value is from the log system cluster.</td>
         </tr>
         <tr>
             <td><h5>log.scan.remove-normalize</h5></td>
@@ -183,12 +183,6 @@
             <td>Define the default false positive probability for bloom filters.</td>
         </tr>
         <tr>
-            <td><h5>file.compression.per.level</h5></td>
-            <td style="word-wrap: break-word;"></td>
-            <td>Map</td>
-            <td>Define different compression policies for different level, you can add the conf like this: 'file.compression.per.level' = '0:lz4,1:zlib', for orc file format, the compression value could be NONE, ZLIB, SNAPPY, LZO, LZ4, for parquet file format, the compression value could be UNCOMPRESSED, SNAPPY, GZIP, LZO, BROTLI, LZ4, ZSTD.</td>
-        </tr>
-        <tr>
             <td><h5>page-size</h5></td>
             <td style="word-wrap: break-word;">64 kb</td>
             <td>MemorySize</td>
@@ -199,6 +193,12 @@
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>Whether to ignore delete records in partial-update mode.</td>
+        </tr>
+        <tr>
+            <td><h5>partition</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Define partition by table options, cannot define partition on DDL and table options at the same time.</td>
         </tr>
         <tr>
             <td><h5>partition.default-name</h5></td>
@@ -229,6 +229,18 @@
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
             <td>You can specify a pattern to get a timestamp from partitions. The formatter pattern is defined by 'partition.timestamp-formatter'.<ul><li>By default, read from the first field.</li><li>If the timestamp in the partition is a single field called 'dt', you can use '$dt'.</li><li>If it is spread across multiple fields for year, month, day, and hour, you can use '$year-$month-$day $hour:00:00'.</li><li>If the timestamp is in fields dt and hour, you can use '$dt $hour:00:00'.</li></ul></td>
+        </tr>
+        <tr>
+            <td><h5>primary-key</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Define primary key by table options, cannot define primary key on DDL and table options at the same time.</td>
+        </tr>
+        <tr>
+            <td><h5>scan.bounded.watermark</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Long</td>
+            <td>End condition "watermark" for bounded streaming mode. Stream reading will end until a larger watermark snapshot is encountered.</td>
         </tr>
         <tr>
             <td><h5>scan.mode</h5></td>
@@ -325,18 +337,6 @@
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>If set to true, compactions and snapshot expiration will be skipped. This option is used along with dedicated compact jobs.</td>
-        </tr>
-        <tr>
-            <td><h5>primary-key</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
-            <td>Define primary key by table options, cannot define primary key on DDL and table options at the same time.</td>
-        </tr>
-        <tr>
-            <td><h5>partition</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
-            <td>Define partition by table options, cannot define partition on DDL and table options at the same time.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -33,12 +33,6 @@
             <td>Whether to double write to a changelog file. This changelog file keeps the details of data changes, it can be read directly during stream reads.<br /><br />Possible values:<ul><li>"none": No changelog file.</li><li>"input": Double write to a changelog file when flushing memory table, the changelog is from input.</li><li>"full-compaction": Generate changelog files with each full compaction.</li></ul></td>
         </tr>
         <tr>
-            <td><h5>changelog-producer.compaction-interval</h5></td>
-            <td style="word-wrap: break-word;">0 ms</td>
-            <td>Duration</td>
-            <td>When changelog-producer is set to FULL_COMPACTION, full compaction will be constantly triggered after this interval.</td>
-        </tr>
-        <tr>
             <td><h5>commit.force-compact</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>changelog-producer.compaction-interval</h5></td>
+            <td style="word-wrap: break-word;">30 min</td>
+            <td>Duration</td>
+            <td>When changelog-producer is set to FULL_COMPACTION, full compaction will be constantly triggered after this interval.</td>
+        </tr>
+        <tr>
             <td><h5>log.system</h5></td>
             <td style="word-wrap: break-word;">"none"</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -10,7 +10,7 @@
     <tbody>
         <tr>
             <td><h5>changelog-producer.compaction-interval</h5></td>
-            <td style="word-wrap: break-word;">30 min</td>
+            <td style="word-wrap: break-word;">0 ms</td>
             <td>Duration</td>
             <td>When changelog-producer is set to FULL_COMPACTION, full compaction will be constantly triggered after this interval.</td>
         </tr>

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
@@ -359,7 +359,7 @@ public class CoreOptions implements Serializable {
                     .noDefaultValue()
                     .withDescription(
                             "End condition \"watermark\" for bounded streaming mode. Stream"
-                                    + " reading will end until a larger watermark snapshot is encountered.");
+                                    + " reading will end when a larger watermark snapshot is encountered.");
 
     public static final ConfigOption<LogConsistency> LOG_CONSISTENCY =
             key("log.consistency")

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
@@ -353,12 +353,13 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Optional snapshot id used in case of \"from-snapshot\" scan mode");
 
-    public static final ConfigOption<Duration> LOG_RETENTION =
-            key("log.retention")
-                    .durationType()
+    public static final ConfigOption<Long> SCAN_BOUNDED_WATERMARK =
+            key("scan.bounded.watermark")
+                    .longType()
                     .noDefaultValue()
                     .withDescription(
-                            "It means how long changes log will be kept. The default value is from the log system cluster.");
+                            "End condition \"watermark\" for bounded streaming mode. Stream"
+                                    + " reading will end until a larger watermark snapshot is encountered.");
 
     public static final ConfigOption<LogConsistency> LOG_CONSISTENCY =
             key("log.consistency")
@@ -690,6 +691,10 @@ public class CoreOptions implements Serializable {
 
     public Long scanTimestampMills() {
         return options.get(SCAN_TIMESTAMP_MILLIS);
+    }
+
+    public Long scanBoundedWatermark() {
+        return options.get(SCAN_BOUNDED_WATERMARK);
     }
 
     public Long scanSnapshotId() {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/Snapshot.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/Snapshot.java
@@ -82,6 +82,7 @@ public class Snapshot {
     private static final String FIELD_TOTAL_RECORD_COUNT = "totalRecordCount";
     private static final String FIELD_DELTA_RECORD_COUNT = "deltaRecordCount";
     private static final String FIELD_CHANGELOG_RECORD_COUNT = "changelogRecordCount";
+    private static final String FILED_WATERMARK = "watermark";
 
     // version of snapshot
     // null for table store <= 0.2
@@ -150,6 +151,14 @@ public class Snapshot {
     @Nullable
     private final Long changelogRecordCount;
 
+    // watermark for input records
+    // null for table store <= 0.3
+    // null if there is no watermark in new committing, and the previous snapshot does not have a
+    // watermark
+    @JsonProperty(FILED_WATERMARK)
+    @Nullable
+    private final Long watermark;
+
     public Snapshot(
             long id,
             long schemaId,
@@ -163,7 +172,8 @@ public class Snapshot {
             Map<Integer, Long> logOffsets,
             @Nullable Long totalRecordCount,
             @Nullable Long deltaRecordCount,
-            @Nullable Long changelogRecordCount) {
+            @Nullable Long changelogRecordCount,
+            @Nullable Long watermark) {
         this(
                 CURRENT_VERSION,
                 id,
@@ -178,7 +188,8 @@ public class Snapshot {
                 logOffsets,
                 totalRecordCount,
                 deltaRecordCount,
-                changelogRecordCount);
+                changelogRecordCount,
+                watermark);
     }
 
     @JsonCreator
@@ -196,7 +207,8 @@ public class Snapshot {
             @JsonProperty(FIELD_LOG_OFFSETS) Map<Integer, Long> logOffsets,
             @JsonProperty(FIELD_TOTAL_RECORD_COUNT) Long totalRecordCount,
             @JsonProperty(FIELD_DELTA_RECORD_COUNT) Long deltaRecordCount,
-            @JsonProperty(FIELD_CHANGELOG_RECORD_COUNT) Long changelogRecordCount) {
+            @JsonProperty(FIELD_CHANGELOG_RECORD_COUNT) Long changelogRecordCount,
+            @JsonProperty(FILED_WATERMARK) Long watermark) {
         this.version = version;
         this.id = id;
         this.schemaId = schemaId;
@@ -211,6 +223,7 @@ public class Snapshot {
         this.totalRecordCount = totalRecordCount;
         this.deltaRecordCount = deltaRecordCount;
         this.changelogRecordCount = changelogRecordCount;
+        this.watermark = watermark;
     }
 
     @JsonGetter(FIELD_VERSION)
@@ -286,6 +299,12 @@ public class Snapshot {
     @Nullable
     public Long changelogRecordCount() {
         return changelogRecordCount;
+    }
+
+    @JsonGetter(FILED_WATERMARK)
+    @Nullable
+    public Long watermark() {
+        return watermark;
     }
 
     /**

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestCommittable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestCommittable.java
@@ -32,7 +32,7 @@ import java.util.Objects;
 public class ManifestCommittable {
 
     private final long identifier;
-    private final Long watermark;
+    @Nullable private final Long watermark;
     private final Map<Integer, Long> logOffsets;
     private final List<CommitMessage> commitMessages;
 
@@ -75,6 +75,7 @@ public class ManifestCommittable {
         return identifier;
     }
 
+    @Nullable
     public Long watermark() {
         return watermark;
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestCommittable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestCommittable.java
@@ -20,6 +20,8 @@ package org.apache.flink.table.store.file.manifest;
 
 import org.apache.flink.table.store.table.sink.CommitMessage;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -30,18 +32,28 @@ import java.util.Objects;
 public class ManifestCommittable {
 
     private final long identifier;
+    private final Long watermark;
     private final Map<Integer, Long> logOffsets;
     private final List<CommitMessage> commitMessages;
 
     public ManifestCommittable(long identifier) {
+        this(identifier, null);
+    }
+
+    public ManifestCommittable(long identifier, @Nullable Long watermark) {
         this.identifier = identifier;
+        this.watermark = watermark;
         this.logOffsets = new HashMap<>();
         this.commitMessages = new ArrayList<>();
     }
 
     public ManifestCommittable(
-            long identifier, Map<Integer, Long> logOffsets, List<CommitMessage> commitMessages) {
+            long identifier,
+            Long watermark,
+            Map<Integer, Long> logOffsets,
+            List<CommitMessage> commitMessages) {
         this.identifier = identifier;
+        this.watermark = watermark;
         this.logOffsets = logOffsets;
         this.commitMessages = commitMessages;
     }
@@ -63,6 +75,10 @@ public class ManifestCommittable {
         return identifier;
     }
 
+    public Long watermark() {
+        return watermark;
+    }
+
     public Map<Integer, Long> logOffsets() {
         return logOffsets;
     }
@@ -81,13 +97,14 @@ public class ManifestCommittable {
         }
         ManifestCommittable that = (ManifestCommittable) o;
         return Objects.equals(identifier, that.identifier)
+                && Objects.equals(watermark, that.watermark)
                 && Objects.equals(logOffsets, that.logOffsets)
                 && Objects.equals(commitMessages, that.commitMessages);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(identifier, logOffsets, commitMessages);
+        return Objects.hash(identifier, watermark, logOffsets, commitMessages);
     }
 
     @Override
@@ -95,8 +112,9 @@ public class ManifestCommittable {
         return String.format(
                 "ManifestCommittable {"
                         + "identifier = %s, "
+                        + "watermark = %s, "
                         + "logOffsets = %s, "
-                        + "fileCommittables = %s",
-                identifier, logOffsets, commitMessages);
+                        + "commitMessages = %s",
+                identifier, watermark, logOffsets, commitMessages);
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestCommittableSerializer.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestCommittableSerializer.java
@@ -51,6 +51,12 @@ public class ManifestCommittableSerializer implements VersionedSerializer<Manife
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         DataOutputViewStreamWrapper view = new DataOutputViewStreamWrapper(out);
         view.writeLong(obj.identifier());
+        if (obj.watermark() == null) {
+            view.writeBoolean(true);
+        } else {
+            view.writeBoolean(false);
+            view.writeLong(obj.watermark());
+        }
         serializeOffsets(view, obj.logOffsets());
         view.writeInt(commitMessageSerializer.getVersion());
         commitMessageSerializer.serializeList(obj.fileCommittables(), view);
@@ -80,11 +86,12 @@ public class ManifestCommittableSerializer implements VersionedSerializer<Manife
 
         DataInputDeserializer view = new DataInputDeserializer(serialized);
         long identifier = view.readLong();
+        Long watermark = view.readBoolean() ? null : view.readLong();
         Map<Integer, Long> offsets = deserializeOffsets(view);
         int fileCommittableSerializerVersion = view.readInt();
-        List<CommitMessage> commitMessages =
+        List<CommitMessage> fileCommittables =
                 commitMessageSerializer.deserializeList(fileCommittableSerializerVersion, view);
-        return new ManifestCommittable(identifier, offsets, commitMessages);
+        return new ManifestCommittable(identifier, watermark, offsets, fileCommittables);
     }
 
     private Map<Integer, Long> deserializeOffsets(DataInputDeserializer view) throws IOException {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestCommittableSerializer.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/manifest/ManifestCommittableSerializer.java
@@ -51,11 +51,12 @@ public class ManifestCommittableSerializer implements VersionedSerializer<Manife
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         DataOutputViewStreamWrapper view = new DataOutputViewStreamWrapper(out);
         view.writeLong(obj.identifier());
-        if (obj.watermark() == null) {
+        Long watermark = obj.watermark();
+        if (watermark == null) {
             view.writeBoolean(true);
         } else {
             view.writeBoolean(false);
-            view.writeLong(obj.watermark());
+            view.writeLong(watermark);
         }
         serializeOffsets(view, obj.logOffsets());
         view.writeInt(commitMessageSerializer.getVersion());

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
@@ -212,6 +212,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                     appendTableFiles,
                     appendChangelog,
                     committable.identifier(),
+                    committable.watermark(),
                     committable.logOffsets(),
                     Snapshot.CommitKind.APPEND,
                     safeLatestSnapshotId);
@@ -235,6 +236,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                     compactTableFiles,
                     compactChangelog,
                     committable.identifier(),
+                    committable.watermark(),
                     committable.logOffsets(),
                     Snapshot.CommitKind.COMPACT,
                     safeLatestSnapshotId);
@@ -318,6 +320,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                 partitionFilter,
                 appendTableFiles,
                 committable.identifier(),
+                committable.watermark(),
                 committable.logOffsets());
 
         if (!compactTableFiles.isEmpty()) {
@@ -325,6 +328,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                     compactTableFiles,
                     Collections.emptyList(),
                     committable.identifier(),
+                    committable.watermark(),
                     committable.logOffsets(),
                     Snapshot.CommitKind.COMPACT,
                     null);
@@ -374,6 +378,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             List<ManifestEntry> tableFiles,
             List<ManifestEntry> changelogFiles,
             long identifier,
+            Long watermark,
             Map<Integer, Long> logOffsets,
             Snapshot.CommitKind commitKind,
             Long safeLatestSnapshotId) {
@@ -383,6 +388,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                     tableFiles,
                     changelogFiles,
                     identifier,
+                    watermark,
                     logOffsets,
                     commitKind,
                     latestSnapshotId,
@@ -396,6 +402,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             Predicate partitionFilter,
             List<ManifestEntry> changes,
             long identifier,
+            Long watermark,
             Map<Integer, Long> logOffsets) {
         while (true) {
             Long latestSnapshotId = snapshotManager.latestSnapshotId();
@@ -423,6 +430,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                     changesWithOverwrite,
                     Collections.emptyList(),
                     identifier,
+                    watermark,
                     logOffsets,
                     Snapshot.CommitKind.OVERWRITE,
                     latestSnapshotId,
@@ -436,6 +444,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             List<ManifestEntry> tableFiles,
             List<ManifestEntry> changelogFiles,
             long identifier,
+            Long watermark,
             Map<Integer, Long> logOffsets,
             Snapshot.CommitKind commitKind,
             Long latestSnapshotId,
@@ -474,6 +483,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         List<ManifestFileMeta> changelogMetas = new ArrayList<>();
         try {
             long previousTotalRecordCount = 0L;
+            Long currentWatermark = watermark;
             if (latestSnapshot != null) {
                 previousTotalRecordCount = latestSnapshot.totalRecordCount(scan);
                 List<ManifestFileMeta> previousManifests =
@@ -483,6 +493,13 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                 // read the last snapshot to complete the bucket's offsets when logOffsets does not
                 // contain all buckets
                 latestSnapshot.logOffsets().forEach(logOffsets::putIfAbsent);
+                Long latestWatermark = latestSnapshot.watermark();
+                if (latestWatermark != null) {
+                    currentWatermark =
+                            currentWatermark == null
+                                    ? latestWatermark
+                                    : Math.max(currentWatermark, latestWatermark);
+                }
             }
             // merge manifest files with changes
             newMetas.addAll(
@@ -520,7 +537,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                             logOffsets,
                             previousTotalRecordCount + deltaRecordCount,
                             deltaRecordCount,
-                            Snapshot.recordCount(changelogFiles));
+                            Snapshot.recordCount(changelogFiles),
+                            currentWatermark);
         } catch (Throwable e) {
             // fails when preparing for commit, we should clean up
             cleanUpTmpManifests(

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
@@ -378,7 +378,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             List<ManifestEntry> tableFiles,
             List<ManifestEntry> changelogFiles,
             long identifier,
-            Long watermark,
+            @Nullable Long watermark,
             Map<Integer, Long> logOffsets,
             Snapshot.CommitKind commitKind,
             Long safeLatestSnapshotId) {
@@ -402,7 +402,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             Predicate partitionFilter,
             List<ManifestEntry> changes,
             long identifier,
-            Long watermark,
+            @Nullable Long watermark,
             Map<Integer, Long> logOffsets) {
         while (true) {
             Long latestSnapshotId = snapshotManager.latestSnapshotId();
@@ -444,7 +444,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             List<ManifestEntry> tableFiles,
             List<ManifestEntry> changelogFiles,
             long identifier,
-            Long watermark,
+            @Nullable Long watermark,
             Map<Integer, Long> logOffsets,
             Snapshot.CommitKind commitKind,
             Long latestSnapshotId,

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/SnapshotManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/utils/SnapshotManager.java
@@ -76,6 +76,11 @@ public class SnapshotManager implements Serializable {
         }
     }
 
+    public @Nullable Snapshot latestSnapshot() {
+        Long snapshotId = latestSnapshotId();
+        return snapshotId == null ? null : snapshot(snapshotId);
+    }
+
     public @Nullable Long latestSnapshotId() {
         try {
             return findLatest();

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableCommitImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/TableCommitImpl.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.store.file.operation.PartitionExpire;
 
 import javax.annotation.Nullable;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -102,6 +103,10 @@ public class TableCommitImpl implements InnerTableCommit {
             commit.overwrite(overwritePartitions, committable, new HashMap<>());
         }
         expire();
+    }
+
+    public void commit(ManifestCommittable committable) {
+        commitMultiple(Collections.singletonList(committable));
     }
 
     public void commitMultiple(List<ManifestCommittable> committables) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/snapshot/BoundedWatermarkFollowUpScanner.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/snapshot/BoundedWatermarkFollowUpScanner.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.table.source.snapshot;
+
+import org.apache.flink.table.store.file.Snapshot;
+import org.apache.flink.table.store.table.source.DataTableScan;
+import org.apache.flink.table.store.table.source.DataTableScan.DataFilePlan;
+
+/**
+ * {@link FollowUpScanner} for bounded watermark, end scanning when a snapshot larger than bounded
+ * watermark appears.
+ */
+public class BoundedWatermarkFollowUpScanner implements FollowUpScanner {
+
+    private final FollowUpScanner innerScanner;
+    private final long boundedWatermark;
+
+    public BoundedWatermarkFollowUpScanner(FollowUpScanner innerScanner, long boundedWatermark) {
+        this.innerScanner = innerScanner;
+        this.boundedWatermark = boundedWatermark;
+    }
+
+    @Override
+    public boolean shouldScanSnapshot(Snapshot snapshot) {
+        return innerScanner.shouldScanSnapshot(snapshot);
+    }
+
+    @Override
+    public boolean shouldEndInput(Snapshot snapshot) {
+        Long watermark = snapshot.watermark();
+        return watermark != null && watermark > boundedWatermark;
+    }
+
+    @Override
+    public boolean isBounded() {
+        return true;
+    }
+
+    @Override
+    public DataFilePlan getPlan(long snapshotId, DataTableScan scan) {
+        return innerScanner.getPlan(snapshotId, scan);
+    }
+}

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/snapshot/FollowUpScanner.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/snapshot/FollowUpScanner.java
@@ -26,5 +26,13 @@ public interface FollowUpScanner {
 
     boolean shouldScanSnapshot(Snapshot snapshot);
 
+    default boolean shouldEndInput(Snapshot snapshot) {
+        return false;
+    }
+
+    default boolean isBounded() {
+        return false;
+    }
+
     DataTableScan.DataFilePlan getPlan(long snapshotId, DataTableScan scan);
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/snapshot/SnapshotEnumerator.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/snapshot/SnapshotEnumerator.java
@@ -29,11 +29,14 @@ import java.util.List;
 public interface SnapshotEnumerator {
 
     /**
-     * The first call to this method will produce a {@link DataFilePlan} containing the base files
-     * for the following incremental changes (or just return null if there are no base files).
+     * The first call to this method will produce a {@link PlanResult} containing the base files for
+     * the following incremental changes (or containing null if there are no base files).
      *
-     * <p>Following calls to this method will produce {@link DataFilePlan}s containing incremental
-     * changed files. If there is currently no newer snapshots, null will be returned instead.
+     * <p>Following calls to this method will produce {@link PlanResult}s containing incremental
+     * changed files. If there is currently no newer snapshots, {@link PlanResult} with null plan
+     * will be returned instead.
+     *
+     * <p>Returning {@link FinishedResult} if this enumerator is finished.
      */
     Result enumerate();
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/snapshot/SnapshotEnumerator.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/snapshot/SnapshotEnumerator.java
@@ -18,22 +18,78 @@
 
 package org.apache.flink.table.store.table.source.snapshot;
 
-import org.apache.flink.table.store.table.source.DataTableScan;
+import org.apache.flink.table.store.table.source.DataTableScan.DataFilePlan;
 
 import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /** Enumerate incremental changes from newly created snapshots. */
 public interface SnapshotEnumerator {
 
     /**
-     * The first call to this method will produce a {@link DataTableScan.DataFilePlan} containing
-     * the base files for the following incremental changes (or just return null if there are no
-     * base files).
+     * The first call to this method will produce a {@link DataFilePlan} containing the base files
+     * for the following incremental changes (or just return null if there are no base files).
      *
-     * <p>Following calls to this method will produce {@link DataTableScan.DataFilePlan}s containing
-     * incremental changed files. If there is currently no newer snapshots, null will be returned
-     * instead.
+     * <p>Following calls to this method will produce {@link DataFilePlan}s containing incremental
+     * changed files. If there is currently no newer snapshots, null will be returned instead.
      */
-    @Nullable
-    DataTableScan.DataFilePlan enumerate();
+    Result enumerate();
+
+    default Result planResult(@Nullable DataFilePlan plan) {
+        return new PlanResult(plan);
+    }
+
+    default Result finishedResult() {
+        return new FinishedResult();
+    }
+
+    default List<DataFilePlan> enumerateAll() {
+        List<DataFilePlan> plans = new ArrayList<>();
+        while (true) {
+            Result result = enumerate();
+            if (result instanceof FinishedResult) {
+                break;
+            }
+            DataFilePlan plan = result.plan();
+            if (plan == null) {
+                continue;
+            }
+            plans.add(plan);
+        }
+        return plans;
+    }
+
+    /** Result of enumeration. */
+    interface Result {
+        @Nullable
+        DataFilePlan plan();
+    }
+
+    /** Result for a plan. */
+    class PlanResult implements Result {
+
+        private final DataFilePlan plan;
+
+        public PlanResult(DataFilePlan plan) {
+            this.plan = plan;
+        }
+
+        @Nullable
+        @Override
+        public DataFilePlan plan() {
+            return plan;
+        }
+    }
+
+    /** Result for finished. */
+    class FinishedResult implements Result {
+
+        @Nullable
+        @Override
+        public DataFilePlan plan() {
+            throw new RuntimeException("This is a finished result.");
+        }
+    }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/snapshot/StaticDataFileSnapshotEnumerator.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/source/snapshot/StaticDataFileSnapshotEnumerator.java
@@ -26,8 +26,6 @@ import org.apache.flink.table.store.table.DataTable;
 import org.apache.flink.table.store.table.source.DataTableScan;
 import org.apache.flink.table.store.utils.Preconditions;
 
-import javax.annotation.Nullable;
-
 import java.io.Serializable;
 
 /** {@link SnapshotEnumerator} for batch read. */
@@ -48,14 +46,13 @@ public class StaticDataFileSnapshotEnumerator implements SnapshotEnumerator {
         this.hasNext = true;
     }
 
-    @Nullable
     @Override
-    public DataTableScan.DataFilePlan enumerate() {
+    public Result enumerate() {
         if (hasNext) {
             hasNext = false;
-            return startingScanner.getPlan(snapshotManager, scan);
+            return planResult(startingScanner.getPlan(snapshotManager, scan));
         } else {
-            return null;
+            return finishedResult();
         }
     }
 

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/system/FilesTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/system/FilesTable.java
@@ -173,7 +173,8 @@ public class FilesTable implements ReadonlyTable {
         @Nullable
         private DataTableScan.DataFilePlan dataFilePlan() {
             return StaticDataFileSnapshotEnumerator.create(storeTable, storeTable.newScan())
-                    .enumerate();
+                    .enumerate()
+                    .plan();
         }
 
         @Override

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/system/SnapshotsTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/system/SnapshotsTable.java
@@ -75,7 +75,8 @@ public class SnapshotsTable implements ReadonlyTable {
                             new DataField(5, "commit_time", new TimestampType(false, 3)),
                             new DataField(6, "total_record_count", new BigIntType(true)),
                             new DataField(7, "delta_record_count", new BigIntType(true)),
-                            new DataField(8, "changelog_record_count", new BigIntType(true))));
+                            new DataField(8, "changelog_record_count", new BigIntType(true)),
+                            new DataField(9, "watermark", new BigIntType(true))));
 
     private final FileIO fileIO;
     private final Path location;
@@ -213,7 +214,8 @@ public class SnapshotsTable implements ReadonlyTable {
                                     ZoneId.systemDefault())),
                     snapshot.totalRecordCount(),
                     snapshot.deltaRecordCount(),
-                    snapshot.changelogRecordCount());
+                    snapshot.changelogRecordCount(),
+                    snapshot.watermark());
         }
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestCommittableSerializerTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestCommittableSerializerTest.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -57,7 +56,11 @@ public class ManifestCommittableSerializerTest {
     }
 
     public static ManifestCommittable create() {
-        ManifestCommittable committable = new ManifestCommittable(new Random().nextLong());
+        ThreadLocalRandom rnd = ThreadLocalRandom.current();
+        ManifestCommittable committable =
+                rnd.nextBoolean()
+                        ? new ManifestCommittable(rnd.nextLong(), rnd.nextLong())
+                        : new ManifestCommittable(rnd.nextLong(), null);
         addFileCommittables(committable, row(0), 0);
         addFileCommittables(committable, row(0), 1);
         addFileCommittables(committable, row(1), 0);

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTableTest.java
@@ -424,7 +424,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
 
         Function<Integer, Void> assertNextSnapshot =
                 i -> {
-                    TableScan.Plan plan = enumerator.enumerate();
+                    TableScan.Plan plan = enumerator.enumerate().plan();
                     assertThat(plan).isNotNull();
 
                     List<Split> splits = plan.splits();
@@ -452,7 +452,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         }
 
         // no more changelog
-        assertThat(enumerator.enumerate()).isNull();
+        assertThat(enumerator.enumerate().plan()).isNull();
 
         // write another commit
         StreamTableWrite write = table.newWrite(commitUser);
@@ -467,7 +467,7 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
         assertNextSnapshot.apply(2);
 
         // no more changelog
-        assertThat(enumerator.enumerate()).isNull();
+        assertThat(enumerator.enumerate().plan()).isNull();
     }
 
     private void writeData() throws Exception {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/source/snapshot/BoundedWatermarkFollowUpScannerTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/source/snapshot/BoundedWatermarkFollowUpScannerTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.table.source.snapshot;
+
+import org.apache.flink.table.store.file.Snapshot;
+import org.apache.flink.table.store.file.manifest.ManifestCommittable;
+import org.apache.flink.table.store.file.utils.SnapshotManager;
+import org.apache.flink.table.store.table.FileStoreTable;
+import org.apache.flink.table.store.table.sink.TableCommitImpl;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link BoundedWatermarkFollowUpScanner}. */
+public class BoundedWatermarkFollowUpScannerTest extends SnapshotEnumeratorTestBase {
+
+    @Test
+    public void testBounded() throws Exception {
+        FileStoreTable table = createFileStoreTable();
+        SnapshotManager snapshotManager = table.snapshotManager();
+        TableCommitImpl commit = table.newCommit(commitUser).ignoreEmptyCommit(false);
+        FollowUpScanner scanner =
+                new BoundedWatermarkFollowUpScanner(new DeltaFollowUpScanner(), 2000L);
+
+        commit.commit(new ManifestCommittable(0, 1024L));
+        Snapshot snapshot = snapshotManager.latestSnapshot();
+        assertThat(scanner.shouldEndInput(snapshot)).isFalse();
+        assertThat(scanner.getPlan(snapshot.id(), table.newScan()).splits()).isEmpty();
+
+        commit.commit(new ManifestCommittable(0, 2000L));
+        snapshot = snapshotManager.latestSnapshot();
+        assertThat(scanner.shouldEndInput(snapshot)).isFalse();
+        assertThat(scanner.getPlan(snapshot.id(), table.newScan()).splits()).isEmpty();
+
+        commit.commit(new ManifestCommittable(0, 2001L));
+        snapshot = snapshotManager.latestSnapshot();
+        assertThat(scanner.shouldEndInput(snapshot)).isTrue();
+    }
+}

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/source/snapshot/ContinuousDataFileSnapshotEnumeratorTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/source/snapshot/ContinuousDataFileSnapshotEnumeratorTest.java
@@ -46,7 +46,7 @@ public class ContinuousDataFileSnapshotEnumeratorTest extends SnapshotEnumerator
                 ContinuousDataFileSnapshotEnumerator.create(table, table.newScan(), null);
 
         // first call without any snapshot, should return null
-        assertThat(enumerator.enumerate()).isNull();
+        assertThat(enumerator.enumerate().plan()).isNull();
 
         // write base data
         write.write(rowData(1, 10, 100L));
@@ -60,13 +60,13 @@ public class ContinuousDataFileSnapshotEnumeratorTest extends SnapshotEnumerator
         commit.commit(1, write.prepareCommit(true, 1));
 
         // first call with snapshot, should return complete records from 2nd commit
-        DataTableScan.DataFilePlan plan = enumerator.enumerate();
+        DataTableScan.DataFilePlan plan = enumerator.enumerate().plan();
         assertThat(plan.snapshotId).isEqualTo(2);
         assertThat(getResult(read, plan.splits()))
                 .hasSameElementsAs(Arrays.asList("+I 1|10|101", "+I 1|20|200", "+I 1|30|300"));
 
         // incremental call without new snapshots, should return null
-        assertThat(enumerator.enumerate()).isNull();
+        assertThat(enumerator.enumerate().plan()).isNull();
 
         // write incremental data
         write.write(rowDataWithKind(RowKind.DELETE, 1, 10, 101L));
@@ -81,19 +81,19 @@ public class ContinuousDataFileSnapshotEnumeratorTest extends SnapshotEnumerator
         commit.commit(3, write.prepareCommit(true, 3));
 
         // first incremental call, should return incremental records from 3rd commit
-        plan = enumerator.enumerate();
+        plan = enumerator.enumerate().plan();
         assertThat(plan.snapshotId).isEqualTo(3);
         assertThat(getResult(read, plan.splits()))
                 .hasSameElementsAs(Arrays.asList("+I 1|10|102", "+I 1|20|201", "+I 1|40|400"));
 
         // second incremental call, should return incremental records from 4th commit
-        plan = enumerator.enumerate();
+        plan = enumerator.enumerate().plan();
         assertThat(plan.snapshotId).isEqualTo(4);
         assertThat(getResult(read, plan.splits()))
                 .hasSameElementsAs(Arrays.asList("+I 1|10|103", "-D 1|40|400", "+I 1|50|500"));
 
         // no more new snapshots, should return null
-        assertThat(enumerator.enumerate()).isNull();
+        assertThat(enumerator.enumerate().plan()).isNull();
 
         write.close();
         commit.close();
@@ -112,7 +112,7 @@ public class ContinuousDataFileSnapshotEnumeratorTest extends SnapshotEnumerator
                 ContinuousDataFileSnapshotEnumerator.create(table, table.newScan(), null);
 
         // first call without any snapshot, should return null
-        assertThat(enumerator.enumerate()).isNull();
+        assertThat(enumerator.enumerate().plan()).isNull();
 
         // write base data
         write.write(rowData(1, 10, 100L));
@@ -134,13 +134,13 @@ public class ContinuousDataFileSnapshotEnumeratorTest extends SnapshotEnumerator
         commit.commit(2, write.prepareCommit(true, 2));
 
         // first call with snapshot, should return full compacted records from 3rd commit
-        DataTableScan.DataFilePlan plan = enumerator.enumerate();
+        DataTableScan.DataFilePlan plan = enumerator.enumerate().plan();
         assertThat(plan.snapshotId).isEqualTo(4);
         assertThat(getResult(read, plan.splits()))
                 .hasSameElementsAs(Arrays.asList("+I 1|10|101", "+I 1|20|200", "+I 1|30|300"));
 
         // incremental call without new snapshots, should return null
-        assertThat(enumerator.enumerate()).isNull();
+        assertThat(enumerator.enumerate().plan()).isNull();
 
         // write incremental data
         write.write(rowData(1, 10, 103L));
@@ -149,13 +149,13 @@ public class ContinuousDataFileSnapshotEnumeratorTest extends SnapshotEnumerator
         commit.commit(3, write.prepareCommit(true, 3));
 
         // no new compact snapshots, should return null
-        assertThat(enumerator.enumerate()).isNull();
+        assertThat(enumerator.enumerate().plan()).isNull();
 
         write.compact(binaryRow(1), 0, true);
         commit.commit(4, write.prepareCommit(true, 4));
 
         // full compaction done, read new changelog
-        plan = enumerator.enumerate();
+        plan = enumerator.enumerate().plan();
         assertThat(plan.snapshotId).isEqualTo(6);
         assertThat(getResult(read, plan.splits()))
                 .hasSameElementsAs(
@@ -167,7 +167,7 @@ public class ContinuousDataFileSnapshotEnumeratorTest extends SnapshotEnumerator
                                 "+I 1|50|500"));
 
         // no more new snapshots, should return null
-        assertThat(enumerator.enumerate()).isNull();
+        assertThat(enumerator.enumerate().plan()).isNull();
 
         write.close();
         commit.close();

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/source/snapshot/StaticDataFileSnapshotEnumeratorTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/source/snapshot/StaticDataFileSnapshotEnumeratorTest.java
@@ -55,7 +55,7 @@ public class StaticDataFileSnapshotEnumeratorTest extends SnapshotEnumeratorTest
 
         assertThat(snapshotManager.latestSnapshotId()).isEqualTo(2);
 
-        DataTableScan.DataFilePlan plan = enumerator.enumerate();
+        DataTableScan.DataFilePlan plan = enumerator.enumerate().plan();
         assertThat(plan.snapshotId).isEqualTo(2);
         assertThat(getResult(table.newRead(), plan.splits()))
                 .hasSameElementsAs(Arrays.asList("+I 1|10|101", "+I 1|20|200", "+I 1|30|300"));
@@ -64,7 +64,7 @@ public class StaticDataFileSnapshotEnumeratorTest extends SnapshotEnumeratorTest
         write.write(rowData(1, 30, 301L));
         commit.commit(2, write.prepareCommit(true, 2));
 
-        assertThat(enumerator.enumerate()).isNull();
+        assertThat(enumerator.enumerate()).isInstanceOf(SnapshotEnumerator.FinishedResult.class);
 
         write.close();
         commit.close();

--- a/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/sink/Committer.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/sink/Committer.java
@@ -37,7 +37,7 @@ public interface Committer extends AutoCloseable {
             List<ManifestCommittable> globalCommittables) throws IOException;
 
     /** Compute an aggregated committable from a list of committables. */
-    ManifestCommittable combine(long checkpointId, List<Committable> committables)
+    ManifestCommittable combine(long checkpointId, long watermark, List<Committable> committables)
             throws IOException;
 
     /** Commits the given {@link ManifestCommittable}. */

--- a/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/sink/StoreCommitter.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/sink/StoreCommitter.java
@@ -51,8 +51,9 @@ public class StoreCommitter implements Committer {
     }
 
     @Override
-    public ManifestCommittable combine(long checkpointId, List<Committable> committables) {
-        ManifestCommittable manifestCommittable = new ManifestCommittable(checkpointId);
+    public ManifestCommittable combine(
+            long checkpointId, long watermark, List<Committable> committables) {
+        ManifestCommittable manifestCommittable = new ManifestCommittable(checkpointId, watermark);
         for (Committable committable : committables) {
             switch (committable.kind()) {
                 case FILE:

--- a/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/source/ContinuousFileStoreSource.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/source/ContinuousFileStoreSource.java
@@ -53,7 +53,7 @@ public class ContinuousFileStoreSource extends FlinkSource {
                 projectedFields,
                 predicate,
                 limit,
-                ContinuousDataFileSnapshotEnumerator::create);
+                new ContinuousDataFileSnapshotEnumerator.DefaultFactory());
     }
 
     public ContinuousFileStoreSource(
@@ -69,7 +69,9 @@ public class ContinuousFileStoreSource extends FlinkSource {
 
     @Override
     public Boundedness getBoundedness() {
-        return Boundedness.CONTINUOUS_UNBOUNDED;
+        return enumeratorFactory.isBounded(table)
+                ? Boundedness.BOUNDED
+                : Boundedness.CONTINUOUS_UNBOUNDED;
     }
 
     @Override

--- a/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/source/FlinkSourceBuilder.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/source/FlinkSourceBuilder.java
@@ -118,7 +118,7 @@ public class FlinkSourceBuilder {
         return new ContinuousFileStoreSource(table, projectedFields, predicate, limit);
     }
 
-    private Source<RowData, ?, ?> buildSource() {
+    public Source<RowData, ?, ?> buildSource() {
         if (isContinuous) {
             ContinuousDataFileSnapshotEnumerator.validate(table.schema());
 

--- a/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/source/StaticFileStoreSource.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/source/StaticFileStoreSource.java
@@ -26,13 +26,14 @@ import org.apache.flink.table.store.file.predicate.Predicate;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
 import org.apache.flink.table.store.table.DataTable;
 import org.apache.flink.table.store.table.source.DataTableScan;
-import org.apache.flink.table.store.table.source.snapshot.SnapshotEnumerator;
+import org.apache.flink.table.store.table.source.DataTableScan.DataFilePlan;
 import org.apache.flink.table.store.table.source.snapshot.StaticDataFileSnapshotEnumerator;
 
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 /** Bounded {@link FlinkSource} for reading records. It does not monitor new snapshots. */
 public class StaticFileStoreSource extends FlinkSource {
@@ -80,12 +81,8 @@ public class StaticFileStoreSource extends FlinkSource {
             FileStoreSourceSplitGenerator splitGenerator = new FileStoreSourceSplitGenerator();
 
             // read all splits from the enumerator in one go
-            SnapshotEnumerator snapshotEnumerator = enumeratorFactory.create(table, scan);
-            while (true) {
-                DataTableScan.DataFilePlan plan = snapshotEnumerator.enumerate();
-                if (plan == null) {
-                    break;
-                }
+            List<DataFilePlan> plans = enumeratorFactory.create(table, scan).enumerateAll();
+            for (DataFilePlan plan : plans) {
                 snapshotId = plan.snapshotId;
                 splits.addAll(splitGenerator.createSplits(plan));
             }

--- a/flink-table-store-flink/flink-table-store-flink-common/src/test/java/org/apache/flink/table/store/connector/action/CompactActionITCase.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/test/java/org/apache/flink/table/store/connector/action/CompactActionITCase.java
@@ -149,7 +149,7 @@ public class CompactActionITCase extends ActionITCaseBase {
         // no full compaction has happened, so plan should be empty
         SnapshotEnumerator snapshotEnumerator =
                 ContinuousDataFileSnapshotEnumerator.create(table, table.newScan(), null);
-        DataTableScan.DataFilePlan plan = snapshotEnumerator.enumerate();
+        DataTableScan.DataFilePlan plan = snapshotEnumerator.enumerate().plan();
         Assertions.assertEquals(1, (long) plan.snapshotId);
         Assertions.assertTrue(plan.splits().isEmpty());
 
@@ -220,7 +220,7 @@ public class CompactActionITCase extends ActionITCaseBase {
         List<String> actual = new ArrayList<>();
         long start = System.currentTimeMillis();
         while (actual.size() != expected.size()) {
-            DataTableScan.DataFilePlan plan = snapshotEnumerator.enumerate();
+            DataTableScan.DataFilePlan plan = snapshotEnumerator.enumerate().plan();
             if (plan != null) {
                 actual.addAll(getResult(table.newRead(), plan.splits(), ROW_TYPE));
             }

--- a/flink-table-store-flink/flink-table-store-flink-common/src/test/java/org/apache/flink/table/store/connector/source/ContinuousFileSplitEnumeratorTest.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/test/java/org/apache/flink/table/store/connector/source/ContinuousFileSplitEnumeratorTest.java
@@ -22,7 +22,9 @@ import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.connector.testutils.source.reader.TestingSplitEnumeratorContext;
 import org.apache.flink.table.store.file.io.DataFileMeta;
 import org.apache.flink.table.store.table.source.DataSplit;
+import org.apache.flink.table.store.table.source.DataTableScan.DataFilePlan;
 import org.apache.flink.table.store.table.source.snapshot.SnapshotEnumerator;
+import org.apache.flink.table.store.table.source.snapshot.SnapshotEnumerator.Result;
 
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +33,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.UUID;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.connector.testutils.source.reader.TestingSplitEnumeratorContext.SplitAssignmentState;
 import static org.apache.flink.table.store.file.mergetree.compact.MergeTreeCompactManagerTest.row;
@@ -136,12 +141,81 @@ public class ContinuousFileSplitEnumeratorTest {
         assertThat(assignedSplits).hasSameElementsAs(expectedSplits.subList(2, 4));
     }
 
+    @Test
+    public void testSnapshotEnumerator() {
+        final TestingSplitEnumeratorContext<FileStoreSourceSplit> context =
+                new TestingSplitEnumeratorContext<>(2);
+        context.registerReader(0, "test-host");
+        context.registerReader(1, "test-host");
+
+        Queue<Result> results = new LinkedBlockingQueue<>();
+        SnapshotEnumerator snapshotEnumerator = results::poll;
+        ContinuousFileSplitEnumerator enumerator =
+                new Builder()
+                        .setSplitEnumeratorContext(context)
+                        .setInitialSplits(Collections.emptyList())
+                        .setDiscoveryInterval(1)
+                        .setSnapshotEnumerator(snapshotEnumerator)
+                        .build();
+        enumerator.start();
+
+        long snapshot = 0;
+        List<DataSplit> splits = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            splits.add(createDataSplit(snapshot, i, Collections.emptyList()));
+        }
+        results.add(snapshotEnumerator.planResult(new DataFilePlan(snapshot, splits)));
+        context.triggerAllActions();
+
+        // assign to task 0
+        enumerator.handleSplitRequest(0, "test-host");
+        Map<Integer, SplitAssignmentState<FileStoreSourceSplit>> assignments =
+                context.getSplitAssignments();
+        assertThat(assignments).containsOnlyKeys(0);
+        assertThat(toDataSplits(assignments.get(0).getAssignedSplits()))
+                .containsExactly(splits.get(0), splits.get(2));
+
+        // no more splits task 0
+        enumerator.handleSplitRequest(0, "test-host");
+        results.add(snapshotEnumerator.finishedResult());
+        context.triggerAllActions();
+        assignments = context.getSplitAssignments();
+        assertThat(assignments).containsOnlyKeys(0);
+        assertThat(assignments.get(0).hasReceivedNoMoreSplitsSignal()).isTrue();
+        assignments.clear();
+
+        // assign to task 1
+        enumerator.handleSplitRequest(1, "test-host");
+        assignments = context.getSplitAssignments();
+        assertThat(assignments).containsOnlyKeys(1);
+        assertThat(toDataSplits(assignments.get(1).getAssignedSplits()))
+                .containsExactly(splits.get(1), splits.get(3));
+
+        // no more splits task 1
+        enumerator.handleSplitRequest(1, "test-host");
+        assignments = context.getSplitAssignments();
+        assertThat(assignments).containsOnlyKeys(1);
+        assertThat(assignments.get(1).hasReceivedNoMoreSplitsSignal()).isTrue();
+    }
+
+    private static List<DataSplit> toDataSplits(List<FileStoreSourceSplit> splits) {
+        return splits.stream()
+                .map(FileStoreSourceSplit::split)
+                .map(split -> (DataSplit) split)
+                .collect(Collectors.toList());
+    }
+
     public static FileStoreSourceSplit createSnapshotSplit(
             int snapshotId, int bucket, List<DataFileMeta> files) {
         return new FileStoreSourceSplit(
                 UUID.randomUUID().toString(),
                 new DataSplit(snapshotId, row(1), bucket, files, true),
                 0);
+    }
+
+    private static DataSplit createDataSplit(
+            long snapshotId, int bucket, List<DataFileMeta> files) {
+        return new DataSplit(snapshotId, row(1), bucket, files, true);
     }
 
     private static class Builder {


### PR DESCRIPTION
There are some bound stream scenarios that require that stream reading can be ended. Generally speaking, the end event time is the better.

So in this ticket, supports writing the watermark to the snapshot and can specify the ending watermark when reading the stream.