### PR TITLE
[FLINK-31294] Close the Committer when the CommitterOperator closes.

### DIFF
--- a/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/sink/CommitterOperator.java
+++ b/flink-table-store-flink/flink-table-store-flink-common/src/main/java/org/apache/flink/table/store/connector/sink/CommitterOperator.java
@@ -156,6 +156,7 @@ public class CommitterOperator extends AbstractStreamOperator<Committable>
     public void close() throws Exception {
         committablesPerCheckpoint.clear();
         inputs.clear();
+        committer.close();
         super.close();
     }
 


### PR DESCRIPTION
Close the Committer when the CommitterOperator closes.