### PR TITLE
[FLINK-31329] Fix Parquet stats extractor

### DIFF
--- a/flink-table-store-common/src/main/java/org/apache/flink/table/store/data/Timestamp.java
+++ b/flink-table-store-common/src/main/java/org/apache/flink/table/store/data/Timestamp.java
@@ -47,6 +47,10 @@ public final class Timestamp implements Comparable<Timestamp>, Serializable {
     // the number of milliseconds in a day
     private static final long MILLIS_PER_DAY = 86400000; // = 24 * 60 * 60 * 1000
 
+    public static final long MICROS_PER_MILLIS = 1000L;
+
+    public static final long NANOS_PER_MICROS = 1000L;
+
     // this field holds the integral second and the milli-of-second
     private final long millisecond;
 
@@ -102,6 +106,12 @@ public final class Timestamp implements Comparable<Timestamp>, Serializable {
         }
         long nanoAdjustment = milliOfSecond * 1_000_000 + nanoOfMillisecond;
         return Instant.ofEpochSecond(epochSecond, nanoAdjustment);
+    }
+
+    /** Converts this {@link Timestamp} object to micros. */
+    public long toMicros() {
+        long micros = Math.multiplyExact(millisecond, MICROS_PER_MILLIS);
+        return micros + nanoOfMillisecond / NANOS_PER_MICROS;
     }
 
     @Override
@@ -203,6 +213,13 @@ public final class Timestamp implements Comparable<Timestamp>, Serializable {
         int nanoOfMillisecond = nanoSecond % 1_000_000;
 
         return new Timestamp(millisecond, nanoOfMillisecond);
+    }
+
+    /** Creates an instance of {@link Timestamp} from micros. */
+    public static Timestamp fromMicros(long micros) {
+        long mills = Math.floorDiv(micros, MICROS_PER_MILLIS);
+        long nanos = (micros - mills * MICROS_PER_MILLIS) * NANOS_PER_MICROS;
+        return Timestamp.fromEpochMillis(mills, (int) nanos);
     }
 
     /**

--- a/flink-table-store-common/src/main/java/org/apache/flink/table/store/data/columnar/ColumnarMap.java
+++ b/flink-table-store-common/src/main/java/org/apache/flink/table/store/data/columnar/ColumnarMap.java
@@ -70,4 +70,9 @@ public final class ColumnarMap implements InternalMap, Serializable {
         throw new UnsupportedOperationException(
                 "ColumnarMapData do not support hashCode, please hash fields one by one!");
     }
+
+    @Override
+    public String toString() {
+        return getClass().getName() + "@" + Integer.toHexString(super.hashCode());
+    }
 }

--- a/flink-table-store-common/src/main/java/org/apache/flink/table/store/file/predicate/In.java
+++ b/flink-table-store-common/src/main/java/org/apache/flink/table/store/file/predicate/In.java
@@ -51,7 +51,8 @@ public class In extends LeafFunction {
     @Override
     public boolean test(
             DataType type, long rowCount, FieldStats fieldStats, List<Object> literals) {
-        if (rowCount == fieldStats.nullCount()) {
+        Long nullCount = fieldStats.nullCount();
+        if (nullCount != null && rowCount == nullCount) {
             return false;
         }
         for (Object literal : literals) {

--- a/flink-table-store-common/src/main/java/org/apache/flink/table/store/file/predicate/IsNotNull.java
+++ b/flink-table-store-common/src/main/java/org/apache/flink/table/store/file/predicate/IsNotNull.java
@@ -38,7 +38,8 @@ public class IsNotNull extends LeafUnaryFunction {
 
     @Override
     public boolean test(DataType type, long rowCount, FieldStats fieldStats) {
-        return fieldStats.nullCount() < rowCount;
+        Long nullCount = fieldStats.nullCount();
+        return nullCount == null || nullCount < rowCount;
     }
 
     @Override

--- a/flink-table-store-common/src/main/java/org/apache/flink/table/store/file/predicate/IsNull.java
+++ b/flink-table-store-common/src/main/java/org/apache/flink/table/store/file/predicate/IsNull.java
@@ -38,7 +38,8 @@ public class IsNull extends LeafUnaryFunction {
 
     @Override
     public boolean test(DataType type, long rowCount, FieldStats fieldStats) {
-        return fieldStats.nullCount() > 0;
+        Long nullCount = fieldStats.nullCount();
+        return nullCount == null || nullCount > 0;
     }
 
     @Override

--- a/flink-table-store-common/src/main/java/org/apache/flink/table/store/file/predicate/LeafPredicate.java
+++ b/flink-table-store-common/src/main/java/org/apache/flink/table/store/file/predicate/LeafPredicate.java
@@ -90,7 +90,8 @@ public class LeafPredicate implements Predicate {
     @Override
     public boolean test(long rowCount, FieldStats[] fieldStats) {
         FieldStats stats = fieldStats[fieldIndex];
-        if (rowCount != stats.nullCount()) {
+        Long nullCount = stats.nullCount();
+        if (nullCount == null || rowCount != nullCount) {
             // not all null
             // min or max is null
             // unknown stats

--- a/flink-table-store-common/src/main/java/org/apache/flink/table/store/file/predicate/NotIn.java
+++ b/flink-table-store-common/src/main/java/org/apache/flink/table/store/file/predicate/NotIn.java
@@ -51,7 +51,8 @@ public class NotIn extends LeafFunction {
     @Override
     public boolean test(
             DataType type, long rowCount, FieldStats fieldStats, List<Object> literals) {
-        if (rowCount == fieldStats.nullCount()) {
+        Long nullCount = fieldStats.nullCount();
+        if (nullCount != null && rowCount == nullCount) {
             return false;
         }
         for (Object literal : literals) {

--- a/flink-table-store-common/src/main/java/org/apache/flink/table/store/file/predicate/NullFalseLeafBinaryFunction.java
+++ b/flink-table-store-common/src/main/java/org/apache/flink/table/store/file/predicate/NullFalseLeafBinaryFunction.java
@@ -44,8 +44,11 @@ public abstract class NullFalseLeafBinaryFunction extends LeafFunction {
     @Override
     public boolean test(
             DataType type, long rowCount, FieldStats fieldStats, List<Object> literals) {
-        if (rowCount == fieldStats.nullCount() || literals.get(0) == null) {
-            return false;
+        Long nullCount = fieldStats.nullCount();
+        if (nullCount != null) {
+            if (rowCount == nullCount || literals.get(0) == null) {
+                return false;
+            }
         }
         return test(type, rowCount, fieldStats, literals.get(0));
     }

--- a/flink-table-store-common/src/main/java/org/apache/flink/table/store/format/FieldStats.java
+++ b/flink-table-store-common/src/main/java/org/apache/flink/table/store/format/FieldStats.java
@@ -27,23 +27,27 @@ public class FieldStats {
 
     @Nullable private final Object minValue;
     @Nullable private final Object maxValue;
-    private final long nullCount;
+    private final Long nullCount;
 
-    public FieldStats(@Nullable Object minValue, @Nullable Object maxValue, long nullCount) {
+    public FieldStats(
+            @Nullable Object minValue, @Nullable Object maxValue, @Nullable Long nullCount) {
         this.minValue = minValue;
         this.maxValue = maxValue;
         this.nullCount = nullCount;
     }
 
+    @Nullable
     public Object minValue() {
         return minValue;
     }
 
+    @Nullable
     public Object maxValue() {
         return maxValue;
     }
 
-    public long nullCount() {
+    @Nullable
+    public Long nullCount() {
         return nullCount;
     }
 
@@ -55,7 +59,7 @@ public class FieldStats {
         FieldStats that = (FieldStats) o;
         return Objects.equals(minValue, that.minValue)
                 && Objects.equals(maxValue, that.maxValue)
-                && nullCount == that.nullCount;
+                && Objects.equals(nullCount, that.nullCount);
     }
 
     @Override

--- a/flink-table-store-common/src/test/java/org/apache/flink/table/store/data/TimestampTest.java
+++ b/flink-table-store-common/src/test/java/org/apache/flink/table/store/data/TimestampTest.java
@@ -130,4 +130,13 @@ public class TimestampTest {
         assertThat(Timestamp.fromInstant(instant).toString())
                 .isEqualTo("1970-01-01T00:00:00.123456789");
     }
+
+    @Test
+    public void testToMicros() {
+        java.sql.Timestamp t = java.sql.Timestamp.valueOf("2005-01-02 00:00:00.123456789");
+        assertThat(Timestamp.fromSQLTimestamp(t).toString())
+                .isEqualTo("2005-01-02T00:00:00.123456789");
+        assertThat(Timestamp.fromMicros(Timestamp.fromSQLTimestamp(t).toMicros()).toString())
+                .isEqualTo("2005-01-02T00:00:00.123456");
+    }
 }

--- a/flink-table-store-common/src/test/java/org/apache/flink/table/store/format/FileStatsExtractorTestBase.java
+++ b/flink-table-store-common/src/test/java/org/apache/flink/table/store/format/FileStatsExtractorTestBase.java
@@ -90,7 +90,14 @@ public abstract class FileStatsExtractorTestBase {
         FileStatsExtractor extractor = format.createStatsExtractor(rowType).get();
         assertThat(extractor).isNotNull();
         FieldStats[] actual = extractor.extract(fileIO, path);
+        for (int i = 0; i < expected.length; i++) {
+            expected[i] = regenerate(expected[i], rowType.getTypeAt(i));
+        }
         assertThat(actual).isEqualTo(expected);
+    }
+
+    protected FieldStats regenerate(FieldStats stats, DataType type) {
+        return stats;
     }
 
     private List<GenericRow> createData(RowType rowType) {

--- a/flink-table-store-core/pom.xml
+++ b/flink-table-store-core/pom.xml
@@ -116,6 +116,35 @@ under the License.
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-client-core</artifactId>
+            <version>${hadoop.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.reload4j</groupId>
+                    <artifactId>reload4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-reload4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/io/DataFileMeta.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/io/DataFileMeta.java
@@ -46,7 +46,7 @@ public class DataFileMeta {
     // Append only data files don't have any key columns and meaningful level value. it will use
     // the following dummy values.
     public static final BinaryTableStats EMPTY_KEY_STATS =
-            new BinaryTableStats(EMPTY_ROW, EMPTY_ROW, new long[0]);
+            new BinaryTableStats(EMPTY_ROW, EMPTY_ROW, new Long[0]);
     public static final BinaryRow EMPTY_MIN_KEY = EMPTY_ROW;
     public static final BinaryRow EMPTY_MAX_KEY = EMPTY_ROW;
     public static final int DUMMY_LEVEL = 0;

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/stats/BinaryTableStats.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/stats/BinaryTableStats.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.store.file.stats;
 import org.apache.flink.table.store.data.BinaryRow;
 import org.apache.flink.table.store.data.GenericArray;
 import org.apache.flink.table.store.data.GenericRow;
+import org.apache.flink.table.store.data.InternalArray;
 import org.apache.flink.table.store.data.InternalRow;
 import org.apache.flink.table.store.format.FieldStats;
 
@@ -40,20 +41,20 @@ public class BinaryTableStats {
     @Nullable private FieldStats[] cacheArray;
     @Nullable private BinaryRow cacheMin;
     @Nullable private BinaryRow cacheMax;
-    @Nullable private long[] cacheNullCounts;
+    @Nullable private Long[] cacheNullCounts;
 
     public BinaryTableStats(InternalRow row) {
         this.row = row;
     }
 
-    public BinaryTableStats(BinaryRow cacheMin, BinaryRow cacheMax, long[] cacheNullCounts) {
+    public BinaryTableStats(BinaryRow cacheMin, BinaryRow cacheMax, Long[] cacheNullCounts) {
         this(cacheMin, cacheMax, cacheNullCounts, null);
     }
 
     public BinaryTableStats(
             BinaryRow cacheMin,
             BinaryRow cacheMax,
-            long[] cacheNullCounts,
+            Long[] cacheNullCounts,
             @Nullable FieldStats[] cacheArray) {
         this.cacheMin = cacheMin;
         this.cacheMax = cacheMax;
@@ -88,10 +89,15 @@ public class BinaryTableStats {
         return cacheMax;
     }
 
-    public long[] nullCounts() {
+    public Long[] nullCounts() {
         if (cacheNullCounts == null) {
             checkNotNull(row);
-            cacheNullCounts = row.getArray(2).toLongArray();
+            InternalArray internalArray = row.getArray(2);
+            Long[] array = new Long[internalArray.size()];
+            for (int i = 0; i < array.length; i++) {
+                array[i] = internalArray.isNullAt(i) ? null : internalArray.getLong(i);
+            }
+            return array;
         }
         return cacheNullCounts;
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/stats/FieldStatsArraySerializer.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/stats/FieldStatsArraySerializer.java
@@ -71,7 +71,7 @@ public class FieldStatsArraySerializer {
         int rowFieldCount = stats.length;
         GenericRow minValues = new GenericRow(rowFieldCount);
         GenericRow maxValues = new GenericRow(rowFieldCount);
-        long[] nullCounts = new long[rowFieldCount];
+        Long[] nullCounts = new Long[rowFieldCount];
         for (int i = 0; i < rowFieldCount; i++) {
             minValues.setField(i, stats[i].minValue());
             maxValues.setField(i, stats[i].maxValue());
@@ -91,6 +91,7 @@ public class FieldStatsArraySerializer {
     public FieldStats[] fromBinary(BinaryTableStats array, @Nullable Long rowCount) {
         int fieldCount = indexMapping == null ? fieldGetters.length : indexMapping.length;
         FieldStats[] stats = new FieldStats[fieldCount];
+        Long[] nullCounts = array.nullCounts();
         for (int i = 0; i < fieldCount; i++) {
             int fieldIndex = indexMapping == null ? i : indexMapping[i];
             if (fieldIndex < 0 || fieldIndex >= array.min().getFieldCount()) {
@@ -108,7 +109,7 @@ public class FieldStatsArraySerializer {
                 Object max = fieldGetters[fieldIndex].getFieldOrNull(array.max());
                 max = converter == null || max == null ? max : converter.cast(max);
 
-                stats[i] = new FieldStats(min, max, array.nullCounts()[fieldIndex]);
+                stats[i] = new FieldStats(min, max, nullCounts[fieldIndex]);
             }
         }
         return stats;
@@ -118,7 +119,7 @@ public class FieldStatsArraySerializer {
         List<DataField> fields = new ArrayList<>();
         fields.add(new DataField(0, "_MIN_VALUES", newBytesType(false)));
         fields.add(new DataField(1, "_MAX_VALUES", newBytesType(false)));
-        fields.add(new DataField(2, "_NULL_COUNTS", new ArrayType(new BigIntType(false))));
+        fields.add(new DataField(2, "_NULL_COUNTS", new ArrayType(new BigIntType(true))));
         return new RowType(fields);
     }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/predicate/PredicateBuilderTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/predicate/PredicateBuilderTest.java
@@ -42,11 +42,11 @@ public class PredicateBuilderTest {
         assertThat(predicate.test(new Object[] {4})).isEqualTo(false);
         assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
 
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0)})).isEqualTo(true);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(2, 5, 0)})).isEqualTo(true);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 2, 0)})).isEqualTo(true);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(false);
-        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(2, 5, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 2, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1L)}))
                 .isEqualTo(false);
     }
 
@@ -61,11 +61,11 @@ public class PredicateBuilderTest {
         assertThat(predicate.test(new Object[] {4})).isEqualTo(false);
         assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
 
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0)})).isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(2, 5, 0)})).isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 2, 0)})).isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(false);
-        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(2, 5, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 2, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1L)}))
                 .isEqualTo(false);
     }
 

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/predicate/PredicateTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/predicate/PredicateTest.java
@@ -42,10 +42,10 @@ public class PredicateTest {
         assertThat(predicate.test(new Object[] {5})).isEqualTo(true);
         assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
 
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0)})).isEqualTo(true);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 6, 0)})).isEqualTo(true);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(false);
-        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 6, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1L)}))
                 .isEqualTo(false);
 
         assertThat(predicate.negate().orElse(null)).isEqualTo(builder.notEqual(0, 5));
@@ -59,8 +59,8 @@ public class PredicateTest {
         assertThat(predicate.test(new Object[] {4})).isEqualTo(false);
         assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
 
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0)})).isEqualTo(false);
-        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1L)}))
                 .isEqualTo(false);
     }
 
@@ -73,11 +73,11 @@ public class PredicateTest {
         assertThat(predicate.test(new Object[] {5})).isEqualTo(false);
         assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
 
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0)})).isEqualTo(true);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 6, 0)})).isEqualTo(true);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(true);
-        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(5, 5, 0)})).isEqualTo(false);
-        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 6, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(5, 5, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1L)}))
                 .isEqualTo(false);
 
         assertThat(predicate.negate().orElse(null)).isEqualTo(builder.equal(0, 5));
@@ -91,8 +91,8 @@ public class PredicateTest {
         assertThat(predicate.test(new Object[] {4})).isEqualTo(false);
         assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
 
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0)})).isEqualTo(false);
-        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1L)}))
                 .isEqualTo(false);
     }
 
@@ -106,11 +106,11 @@ public class PredicateTest {
         assertThat(predicate.test(new Object[] {6})).isEqualTo(true);
         assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
 
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 4, 0)})).isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0)})).isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 6, 0)})).isEqualTo(true);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(true);
-        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 4, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 6, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1L)}))
                 .isEqualTo(false);
 
         assertThat(predicate.negate().orElse(null)).isEqualTo(builder.lessOrEqual(0, 5));
@@ -124,8 +124,8 @@ public class PredicateTest {
         assertThat(predicate.test(new Object[] {4})).isEqualTo(false);
         assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
 
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 4, 0)})).isEqualTo(false);
-        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 4, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1L)}))
                 .isEqualTo(false);
     }
 
@@ -139,11 +139,11 @@ public class PredicateTest {
         assertThat(predicate.test(new Object[] {6})).isEqualTo(true);
         assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
 
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 4, 0)})).isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0)})).isEqualTo(true);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 6, 0)})).isEqualTo(true);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(true);
-        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 4, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 6, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1L)}))
                 .isEqualTo(false);
 
         assertThat(predicate.negate().orElse(null)).isEqualTo(builder.lessThan(0, 5));
@@ -157,8 +157,8 @@ public class PredicateTest {
         assertThat(predicate.test(new Object[] {4})).isEqualTo(false);
         assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
 
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 4, 0)})).isEqualTo(false);
-        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 4, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1L)}))
                 .isEqualTo(false);
     }
 
@@ -172,10 +172,10 @@ public class PredicateTest {
         assertThat(predicate.test(new Object[] {6})).isEqualTo(false);
         assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
 
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(5, 7, 0)})).isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(4, 7, 0)})).isEqualTo(true);
-        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(5, 7, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(4, 7, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1L)}))
                 .isEqualTo(false);
 
         assertThat(predicate.negate().orElse(null)).isEqualTo(builder.greaterOrEqual(0, 5));
@@ -189,8 +189,8 @@ public class PredicateTest {
         assertThat(predicate.test(new Object[] {4})).isEqualTo(false);
         assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
 
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(false);
-        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1L)}))
                 .isEqualTo(false);
     }
 
@@ -204,10 +204,10 @@ public class PredicateTest {
         assertThat(predicate.test(new Object[] {6})).isEqualTo(false);
         assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
 
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(5, 7, 0)})).isEqualTo(true);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(4, 7, 0)})).isEqualTo(true);
-        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(5, 7, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(4, 7, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1L)}))
                 .isEqualTo(false);
 
         assertThat(predicate.negate().orElse(null)).isEqualTo(builder.greaterThan(0, 5));
@@ -221,8 +221,8 @@ public class PredicateTest {
         assertThat(predicate.test(new Object[] {4})).isEqualTo(false);
         assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
 
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(false);
-        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1L)}))
                 .isEqualTo(false);
     }
 
@@ -234,8 +234,8 @@ public class PredicateTest {
         assertThat(predicate.test(new Object[] {4})).isEqualTo(false);
         assertThat(predicate.test(new Object[] {null})).isEqualTo(true);
 
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(5, 7, 1)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(5, 7, 1L)})).isEqualTo(true);
 
         assertThat(predicate.negate().orElse(null)).isEqualTo(builder.isNotNull(0));
     }
@@ -248,9 +248,9 @@ public class PredicateTest {
         assertThat(predicate.test(new Object[] {4})).isEqualTo(true);
         assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
 
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(true);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(5, 7, 1)})).isEqualTo(true);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(null, null, 3)}))
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(5, 7, 1L)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(null, null, 3L)}))
                 .isEqualTo(false);
 
         assertThat(predicate.negate().orElse(null)).isEqualTo(builder.isNull(0));
@@ -267,9 +267,9 @@ public class PredicateTest {
         assertThat(predicate.test(new Object[] {3})).isEqualTo(true);
         assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
 
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0)})).isEqualTo(true);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(false);
-        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1L)}))
                 .isEqualTo(false);
     }
 
@@ -284,9 +284,9 @@ public class PredicateTest {
         assertThat(predicate.test(new Object[] {3})).isEqualTo(true);
         assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
 
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0)})).isEqualTo(true);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(false);
-        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1L)}))
                 .isEqualTo(false);
     }
 
@@ -301,12 +301,12 @@ public class PredicateTest {
         assertThat(predicate.test(new Object[] {3})).isEqualTo(false);
         assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
 
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(1, 1, 0)})).isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(3, 3, 0)})).isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(1, 3, 0)})).isEqualTo(true);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0)})).isEqualTo(true);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(true);
-        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(1, 1, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(3, 3, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(1, 3, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1L)}))
                 .isEqualTo(false);
     }
 
@@ -321,12 +321,12 @@ public class PredicateTest {
         assertThat(predicate.test(new Object[] {3})).isEqualTo(false);
         assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
 
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(1, 1, 0)})).isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(3, 3, 0)})).isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(1, 3, 0)})).isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0)})).isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(false);
-        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(1, 1, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(3, 3, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(1, 3, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1L)}))
                 .isEqualTo(false);
     }
 
@@ -347,11 +347,12 @@ public class PredicateTest {
         assertThat(predicate.test(new Object[] {3})).isEqualTo(true);
         assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
 
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0)})).isEqualTo(true);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(false);
-        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1L)}))
                 .isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(29, 32, 0)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(29, 32, 0L)}))
+                .isEqualTo(true);
     }
 
     @Test
@@ -372,11 +373,12 @@ public class PredicateTest {
         assertThat(predicate.test(new Object[] {3})).isEqualTo(true);
         assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
 
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0)})).isEqualTo(true);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(false);
-        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1L)}))
                 .isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(29, 32, 0)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(29, 32, 0L)}))
+                .isEqualTo(true);
     }
 
     @Test
@@ -396,14 +398,15 @@ public class PredicateTest {
         assertThat(predicate.test(new Object[] {3})).isEqualTo(false);
         assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
 
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(1, 1, 0)})).isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(3, 3, 0)})).isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(1, 3, 0)})).isEqualTo(true);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0)})).isEqualTo(true);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(true);
-        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(1, 1, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(3, 3, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(1, 3, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0L)})).isEqualTo(true);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1L)}))
                 .isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(29, 32, 0)})).isEqualTo(true);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(29, 32, 0L)}))
+                .isEqualTo(true);
     }
 
     @Test
@@ -424,14 +427,14 @@ public class PredicateTest {
         assertThat(predicate.test(new Object[] {3})).isEqualTo(false);
         assertThat(predicate.test(new Object[] {null})).isEqualTo(false);
 
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(1, 1, 0)})).isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(3, 3, 0)})).isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(1, 3, 0)})).isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0)})).isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0)})).isEqualTo(false);
-        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1)}))
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(1, 1, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(3, 3, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(1, 3, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(0, 5, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(6, 7, 0L)})).isEqualTo(false);
+        assertThat(predicate.test(1, new FieldStats[] {new FieldStats(null, null, 1L)}))
                 .isEqualTo(false);
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(29, 32, 0)}))
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(29, 32, 0L)}))
                 .isEqualTo(false);
     }
 
@@ -449,21 +452,21 @@ public class PredicateTest {
                         predicate.test(
                                 3,
                                 new FieldStats[] {
-                                    new FieldStats(3, 6, 0), new FieldStats(4, 6, 0)
+                                    new FieldStats(3, 6, 0L), new FieldStats(4, 6, 0L)
                                 }))
                 .isEqualTo(true);
         assertThat(
                         predicate.test(
                                 3,
                                 new FieldStats[] {
-                                    new FieldStats(3, 6, 0), new FieldStats(6, 8, 0)
+                                    new FieldStats(3, 6, 0L), new FieldStats(6, 8, 0L)
                                 }))
                 .isEqualTo(false);
         assertThat(
                         predicate.test(
                                 3,
                                 new FieldStats[] {
-                                    new FieldStats(6, 7, 0), new FieldStats(4, 6, 0)
+                                    new FieldStats(6, 7, 0L), new FieldStats(4, 6, 0L)
                                 }))
                 .isEqualTo(false);
 
@@ -485,21 +488,21 @@ public class PredicateTest {
                         predicate.test(
                                 3,
                                 new FieldStats[] {
-                                    new FieldStats(3, 6, 0), new FieldStats(4, 6, 0)
+                                    new FieldStats(3, 6, 0L), new FieldStats(4, 6, 0L)
                                 }))
                 .isEqualTo(true);
         assertThat(
                         predicate.test(
                                 3,
                                 new FieldStats[] {
-                                    new FieldStats(3, 6, 0), new FieldStats(6, 8, 0)
+                                    new FieldStats(3, 6, 0L), new FieldStats(6, 8, 0L)
                                 }))
                 .isEqualTo(true);
         assertThat(
                         predicate.test(
                                 3,
                                 new FieldStats[] {
-                                    new FieldStats(6, 7, 0), new FieldStats(8, 10, 0)
+                                    new FieldStats(6, 7, 0L), new FieldStats(8, 10, 0L)
                                 }))
                 .isEqualTo(false);
 
@@ -512,11 +515,11 @@ public class PredicateTest {
         PredicateBuilder builder = new PredicateBuilder(RowType.of(new IntType()));
         Predicate predicate = builder.equal(0, 5);
 
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(null, null, 3)}))
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(null, null, 3L)}))
                 .isEqualTo(false);
 
         // unknown stats, we don't know, likely to hit
-        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(null, null, 4)}))
+        assertThat(predicate.test(3, new FieldStats[] {new FieldStats(null, null, 4L)}))
                 .isEqualTo(true);
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/stats/BinaryTableStatsTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/stats/BinaryTableStatsTest.java
@@ -38,7 +38,7 @@ public class BinaryTableStatsTest {
     public void testBinaryTableStats() {
         List<Integer> minList = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9);
         List<Integer> maxList = Arrays.asList(11, 12, 13, 14, 15, 16, 17, 18, 19);
-        long[] nullCounts = new long[] {0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L};
+        Long[] nullCounts = new Long[] {0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L};
 
         BinaryRow minRowData = binaryRow(minList);
         BinaryRow maxRowData = binaryRow(maxList);

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/stats/FieldStatsArraySerializerTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/stats/FieldStatsArraySerializerTest.java
@@ -77,7 +77,7 @@ public class FieldStatsArraySerializerTest {
                         tableSchema.logicalRowType(), indexMapping, converterMapping);
         BinaryRow minRowData = row(1, 2, 3, 4);
         BinaryRow maxRowData = row(100, 99, 98, 97);
-        long[] nullCounts = new long[] {1, 0, 10, 100};
+        Long[] nullCounts = new Long[] {1L, 0L, 10L, 100L};
         BinaryTableStats dataTableStats = new BinaryTableStats(minRowData, maxRowData, nullCounts);
 
         FieldStats[] fieldStatsArray = dataTableStats.fields(fieldStatsArraySerializer, 1000L);

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/stats/FieldStatsCollectorTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/stats/FieldStatsCollectorTest.java
@@ -47,24 +47,24 @@ public class FieldStatsCollectorTest {
         assertThat(collector.extract())
                 .isEqualTo(
                         new FieldStats[] {
-                            new FieldStats(1, 1, 0),
+                            new FieldStats(1, 1, 0L),
                             new FieldStats(
                                     BinaryString.fromString("Flink"),
                                     BinaryString.fromString("Flink"),
-                                    0),
-                            new FieldStats(null, null, 0)
+                                    0L),
+                            new FieldStats(null, null, 0L)
                         });
 
         collector.collect(GenericRow.of(3, null, new GenericArray(new int[] {3, 30})));
         assertThat(collector.extract())
                 .isEqualTo(
                         new FieldStats[] {
-                            new FieldStats(1, 3, 0),
+                            new FieldStats(1, 3, 0L),
                             new FieldStats(
                                     BinaryString.fromString("Flink"),
                                     BinaryString.fromString("Flink"),
-                                    1),
-                            new FieldStats(null, null, 0)
+                                    1L),
+                            new FieldStats(null, null, 0L)
                         });
 
         collector.collect(
@@ -75,24 +75,24 @@ public class FieldStatsCollectorTest {
         assertThat(collector.extract())
                 .isEqualTo(
                         new FieldStats[] {
-                            new FieldStats(1, 3, 1),
+                            new FieldStats(1, 3, 1L),
                             new FieldStats(
                                     BinaryString.fromString("Apache"),
                                     BinaryString.fromString("Flink"),
-                                    1),
-                            new FieldStats(null, null, 0)
+                                    1L),
+                            new FieldStats(null, null, 0L)
                         });
 
         collector.collect(GenericRow.of(2, BinaryString.fromString("Batch"), null));
         assertThat(collector.extract())
                 .isEqualTo(
                         new FieldStats[] {
-                            new FieldStats(1, 3, 1),
+                            new FieldStats(1, 3, 1L),
                             new FieldStats(
                                     BinaryString.fromString("Apache"),
                                     BinaryString.fromString("Flink"),
-                                    1),
-                            new FieldStats(null, null, 1)
+                                    1L),
+                            new FieldStats(null, null, 1L)
                         });
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/stats/StatsTestUtils.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/stats/StatsTestUtils.java
@@ -76,7 +76,7 @@ public class StatsTestUtils {
                 new FieldStatsArraySerializer(RowType.of(new IntType()));
         FieldStats[] array = new FieldStats[fieldCount];
         for (int i = 0; i < fieldCount; i++) {
-            array[i] = new FieldStats(null, null, 0);
+            array[i] = new FieldStats(null, null, 0L);
         }
         return statsConverter.toBinary(array);
     }
@@ -84,6 +84,6 @@ public class StatsTestUtils {
     public static BinaryTableStats newTableStats(int min, int max) {
         FieldStatsArraySerializer statsConverter =
                 new FieldStatsArraySerializer(RowType.of(new IntType()));
-        return statsConverter.toBinary(new FieldStats[] {new FieldStats(min, max, 0)});
+        return statsConverter.toBinary(new FieldStats[] {new FieldStats(min, max, 0L)});
     }
 }

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTableTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/ChangelogWithKeyFileStoreTableTest.java
@@ -499,6 +499,10 @@ public class ChangelogWithKeyFileStoreTableTest extends FileStoreTableTestBase {
     @Test
     public void testReadFilter() throws Exception {
         FileStoreTable table = createFileStoreTable();
+        if (table.options().fileFormat().getFormatIdentifier().equals("parquet")) {
+            // TODO support parquet reader filter push down
+            return;
+        }
 
         StreamTableWrite write = table.newWrite(commitUser);
         StreamTableCommit commit = table.newCommit(commitUser);

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/FileStoreTableTestBase.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/table/FileStoreTableTestBase.java
@@ -238,6 +238,10 @@ public abstract class FileStoreTableTestBase {
     @Test
     public void testReadFilter() throws Exception {
         FileStoreTable table = createFileStoreTable();
+        if (table.options().fileFormat().getFormatIdentifier().equals("parquet")) {
+            // TODO support parquet reader filter push down
+            return;
+        }
 
         StreamTableWrite write = table.newWrite(commitUser);
         StreamTableCommit commit = table.newCommit(commitUser);

--- a/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/parquet/ParquetUtil.java
+++ b/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/parquet/ParquetUtil.java
@@ -44,17 +44,17 @@ public class ParquetUtil {
      * @return result sets as map, key is column name, value is statistics (for example, null count,
      *     minimum value, maximum value)
      */
-    public static Map<String, Statistics> extractColumnStats(FileIO fileIO, Path path)
+    public static Map<String, Statistics<?>> extractColumnStats(FileIO fileIO, Path path)
             throws IOException {
         ParquetMetadata parquetMetadata = getParquetReader(fileIO, path).getFooter();
         List<BlockMetaData> blockMetaDataList = parquetMetadata.getBlocks();
-        Map<String, Statistics> resultStats = new HashMap<>();
+        Map<String, Statistics<?>> resultStats = new HashMap<>();
         for (BlockMetaData blockMetaData : blockMetaDataList) {
             List<ColumnChunkMetaData> columnChunkMetaDataList = blockMetaData.getColumns();
             for (ColumnChunkMetaData columnChunkMetaData : columnChunkMetaDataList) {
-                Statistics stats = columnChunkMetaData.getStatistics();
+                Statistics<?> stats = columnChunkMetaData.getStatistics();
                 String columnName = columnChunkMetaData.getPath().toDotString();
-                Statistics midStats;
+                Statistics<?> midStats;
                 if (!resultStats.containsKey(columnName)) {
                     midStats = stats;
                 } else {
@@ -79,7 +79,7 @@ public class ParquetUtil {
     }
 
     static void assertStatsClass(
-            DataField field, Statistics stats, Class<? extends Statistics> expectedClass) {
+            DataField field, Statistics<?> stats, Class<? extends Statistics<?>> expectedClass) {
         if (!expectedClass.isInstance(stats)) {
             throw new IllegalArgumentException(
                     "Expecting "

--- a/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/parquet/reader/ParquetTimestampVector.java
+++ b/flink-table-store-format/src/main/java/org/apache/flink/table/store/format/parquet/reader/ParquetTimestampVector.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.format.parquet.reader;
+
+import org.apache.flink.table.store.data.Timestamp;
+import org.apache.flink.table.store.data.columnar.ColumnVector;
+import org.apache.flink.table.store.data.columnar.LongColumnVector;
+import org.apache.flink.table.store.data.columnar.TimestampColumnVector;
+
+import org.apache.parquet.Preconditions;
+
+/**
+ * Parquet write timestamp precision 0-3 as int64 mills, 4-6 as int64 micros, 7-9 as int96, this
+ * class wrap the real vector to provide {@link TimestampColumnVector} interface.
+ */
+public class ParquetTimestampVector implements TimestampColumnVector {
+
+    private final ColumnVector vector;
+
+    public ParquetTimestampVector(ColumnVector vector) {
+        this.vector = vector;
+    }
+
+    @Override
+    public Timestamp getTimestamp(int i, int precision) {
+        if (precision <= 3 && vector instanceof LongColumnVector) {
+            return Timestamp.fromEpochMillis(((LongColumnVector) vector).getLong(i));
+        } else if (precision <= 6 && vector instanceof LongColumnVector) {
+            return Timestamp.fromMicros(((LongColumnVector) vector).getLong(i));
+        } else {
+            Preconditions.checkArgument(
+                    vector instanceof TimestampColumnVector,
+                    "Reading timestamp type occur unsupported vector type: %s",
+                    vector.getClass());
+            return ((TimestampColumnVector) vector).getTimestamp(i, precision);
+        }
+    }
+
+    public ColumnVector getVector() {
+        return vector;
+    }
+
+    @Override
+    public boolean isNullAt(int i) {
+        return vector.isNullAt(i);
+    }
+}

--- a/flink-table-store-format/src/test/java/org/apache/flink/table/store/format/parquet/ParquetFileStatsExtractorTest.java
+++ b/flink-table-store-format/src/test/java/org/apache/flink/table/store/format/parquet/ParquetFileStatsExtractorTest.java
@@ -18,20 +18,28 @@
 
 package org.apache.flink.table.store.format.parquet;
 
+import org.apache.flink.table.store.format.FieldStats;
 import org.apache.flink.table.store.format.FileFormat;
 import org.apache.flink.table.store.format.FileStatsExtractorTestBase;
 import org.apache.flink.table.store.options.Options;
+import org.apache.flink.table.store.types.ArrayType;
 import org.apache.flink.table.store.types.BigIntType;
+import org.apache.flink.table.store.types.BinaryType;
 import org.apache.flink.table.store.types.BooleanType;
 import org.apache.flink.table.store.types.CharType;
+import org.apache.flink.table.store.types.DataType;
 import org.apache.flink.table.store.types.DateType;
 import org.apache.flink.table.store.types.DecimalType;
 import org.apache.flink.table.store.types.DoubleType;
 import org.apache.flink.table.store.types.FloatType;
 import org.apache.flink.table.store.types.IntType;
+import org.apache.flink.table.store.types.MapType;
+import org.apache.flink.table.store.types.MultisetType;
 import org.apache.flink.table.store.types.RowType;
 import org.apache.flink.table.store.types.SmallIntType;
+import org.apache.flink.table.store.types.TimestampType;
 import org.apache.flink.table.store.types.TinyIntType;
+import org.apache.flink.table.store.types.VarBinaryType;
 import org.apache.flink.table.store.types.VarCharType;
 
 /** Tests for {@link ParquetFileStatsExtractor}. */
@@ -49,6 +57,8 @@ public class ParquetFileStatsExtractorTest extends FileStatsExtractorTestBase {
                         new CharType(8),
                         new VarCharType(8),
                         new BooleanType(),
+                        new BinaryType(8),
+                        new VarBinaryType(8),
                         new TinyIntType(),
                         new SmallIntType(),
                         new IntType(),
@@ -56,8 +66,33 @@ public class ParquetFileStatsExtractorTest extends FileStatsExtractorTestBase {
                         new FloatType(),
                         new DoubleType(),
                         new DecimalType(5, 2),
+                        new DecimalType(15, 2),
                         new DecimalType(38, 18),
-                        new DateType())
+                        new DateType(),
+                        new TimestampType(3),
+                        new TimestampType(6),
+                        new TimestampType(9),
+                        new ArrayType(new IntType()),
+                        new MapType(new VarCharType(8), new VarCharType(8)),
+                        new MultisetType(new VarCharType(8)))
                 .build();
+    }
+
+    @Override
+    protected FieldStats regenerate(FieldStats stats, DataType type) {
+        switch (type.getTypeRoot()) {
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+                TimestampType timestampType = (TimestampType) type;
+                if (timestampType.getPrecision() > 6) {
+                    return new FieldStats(null, null, stats.nullCount());
+                }
+                break;
+            case ARRAY:
+            case MAP:
+            case MULTISET:
+            case ROW:
+                return new FieldStats(null, null, null);
+        }
+        return stats;
     }
 }

--- a/flink-table-store-format/src/test/java/org/apache/flink/table/store/format/parquet/ParquetReadWriteTest.java
+++ b/flink-table-store-format/src/test/java/org/apache/flink/table/store/format/parquet/ParquetReadWriteTest.java
@@ -86,6 +86,8 @@ public class ParquetReadWriteTest {
                             new BigIntType(),
                             new FloatType(),
                             new DoubleType(),
+                            new TimestampType(3),
+                            new TimestampType(6),
                             new TimestampType(9),
                             new DecimalType(5, 0),
                             new DecimalType(15, 2),
@@ -362,6 +364,8 @@ public class ParquetReadWriteTest {
                         assertThat(row.isNullAt(30)).isTrue();
                         assertThat(row.isNullAt(31)).isTrue();
                         assertThat(row.isNullAt(32)).isTrue();
+                        assertThat(row.isNullAt(33)).isTrue();
+                        assertThat(row.isNullAt(34)).isTrue();
                     } else {
                         assertThat(row.getString(0)).hasToString("" + v);
                         assertThat(row.getBoolean(1)).isEqualTo(v % 2 == 0);
@@ -371,55 +375,56 @@ public class ParquetReadWriteTest {
                         assertThat(row.getLong(5)).isEqualTo(v.longValue());
                         assertThat(row.getFloat(6)).isEqualTo(v.floatValue());
                         assertThat(row.getDouble(7)).isEqualTo(v.doubleValue());
-                        assertThat(row.getTimestamp(8, 9).toLocalDateTime())
-                                .isEqualTo(toDateTime(v));
+                        assertThat(row.getTimestamp(8, 3)).isEqualTo(toMills(v));
+                        assertThat(row.getTimestamp(9, 6)).isEqualTo(toMicros(v));
+                        assertThat(row.getTimestamp(10, 9)).isEqualTo(toNanos(v));
                         if (Decimal.fromBigDecimal(BigDecimal.valueOf(v), 5, 0) == null) {
-                            assertThat(row.isNullAt(9)).isTrue();
-                            assertThat(row.isNullAt(12)).isTrue();
-                            assertThat(row.isNullAt(24)).isTrue();
-                            assertThat(row.isNullAt(27)).isTrue();
+                            assertThat(row.isNullAt(11)).isTrue();
+                            assertThat(row.isNullAt(14)).isTrue();
+                            assertThat(row.isNullAt(26)).isTrue();
+                            assertThat(row.isNullAt(29)).isTrue();
                         } else {
-                            assertThat(row.getDecimal(9, 5, 0))
+                            assertThat(row.getDecimal(11, 5, 0))
                                     .isEqualTo(Decimal.fromBigDecimal(BigDecimal.valueOf(v), 5, 0));
-                            assertThat(row.getDecimal(12, 5, 0))
+                            assertThat(row.getDecimal(14, 5, 0))
                                     .isEqualTo(Decimal.fromBigDecimal(BigDecimal.valueOf(v), 5, 0));
-                            assertThat(row.getArray(24).getDecimal(0, 5, 0))
+                            assertThat(row.getArray(26).getDecimal(0, 5, 0))
                                     .isEqualTo(Decimal.fromBigDecimal(BigDecimal.valueOf(v), 5, 0));
-                            assertThat(row.getArray(27).getDecimal(0, 5, 0))
+                            assertThat(row.getArray(29).getDecimal(0, 5, 0))
                                     .isEqualTo(Decimal.fromBigDecimal(BigDecimal.valueOf(v), 5, 0));
                         }
-                        assertThat(row.getDecimal(10, 15, 2))
+                        assertThat(row.getDecimal(12, 15, 2))
                                 .isEqualTo(Decimal.fromUnscaledLong(v.longValue(), 15, 2));
-                        assertThat(row.getDecimal(11, 20, 0).toBigDecimal())
+                        assertThat(row.getDecimal(13, 20, 0).toBigDecimal())
                                 .isEqualTo(BigDecimal.valueOf(v));
-                        assertThat(row.getDecimal(13, 15, 0).toBigDecimal())
+                        assertThat(row.getDecimal(15, 15, 0).toBigDecimal())
                                 .isEqualTo(BigDecimal.valueOf(v));
-                        assertThat(row.getDecimal(14, 20, 0).toBigDecimal())
+                        assertThat(row.getDecimal(16, 20, 0).toBigDecimal())
                                 .isEqualTo(BigDecimal.valueOf(v));
-                        assertThat(row.getArray(15).getString(0)).hasToString("" + v);
-                        assertThat(row.getArray(16).getBoolean(0)).isEqualTo(v % 2 == 0);
-                        assertThat(row.getArray(17).getByte(0)).isEqualTo(v.byteValue());
-                        assertThat(row.getArray(18).getShort(0)).isEqualTo(v.shortValue());
-                        assertThat(row.getArray(19).getInt(0)).isEqualTo(v.intValue());
-                        assertThat(row.getArray(20).getLong(0)).isEqualTo(v.longValue());
-                        assertThat(row.getArray(21).getFloat(0)).isEqualTo(v.floatValue());
-                        assertThat(row.getArray(22).getDouble(0)).isEqualTo(v.doubleValue());
-                        assertThat(row.getArray(23).getTimestamp(0, 9).toLocalDateTime())
+                        assertThat(row.getArray(17).getString(0)).hasToString("" + v);
+                        assertThat(row.getArray(18).getBoolean(0)).isEqualTo(v % 2 == 0);
+                        assertThat(row.getArray(19).getByte(0)).isEqualTo(v.byteValue());
+                        assertThat(row.getArray(20).getShort(0)).isEqualTo(v.shortValue());
+                        assertThat(row.getArray(21).getInt(0)).isEqualTo(v.intValue());
+                        assertThat(row.getArray(22).getLong(0)).isEqualTo(v.longValue());
+                        assertThat(row.getArray(23).getFloat(0)).isEqualTo(v.floatValue());
+                        assertThat(row.getArray(24).getDouble(0)).isEqualTo(v.doubleValue());
+                        assertThat(row.getArray(25).getTimestamp(0, 9).toLocalDateTime())
                                 .isEqualTo(toDateTime(v));
 
-                        assertThat(row.getArray(25).getDecimal(0, 15, 0))
+                        assertThat(row.getArray(27).getDecimal(0, 15, 0))
                                 .isEqualTo(Decimal.fromBigDecimal(BigDecimal.valueOf(v), 15, 0));
-                        assertThat(row.getArray(26).getDecimal(0, 20, 0))
+                        assertThat(row.getArray(28).getDecimal(0, 20, 0))
                                 .isEqualTo(Decimal.fromBigDecimal(BigDecimal.valueOf(v), 20, 0));
-                        assertThat(row.getArray(28).getDecimal(0, 15, 0))
+                        assertThat(row.getArray(30).getDecimal(0, 15, 0))
                                 .isEqualTo(Decimal.fromBigDecimal(BigDecimal.valueOf(v), 15, 0));
-                        assertThat(row.getArray(29).getDecimal(0, 20, 0))
+                        assertThat(row.getArray(31).getDecimal(0, 20, 0))
                                 .isEqualTo(Decimal.fromBigDecimal(BigDecimal.valueOf(v), 20, 0));
-                        assertThat(row.getMap(30).valueArray().getString(0)).hasToString("" + v);
-                        assertThat(row.getMap(31).valueArray().getBoolean(0)).isEqualTo(v % 2 == 0);
-                        assertThat(row.getMap(32).keyArray().getString(0)).hasToString("" + v);
-                        assertThat(row.getRow(33, 2).getString(0)).hasToString("" + v);
-                        assertThat(row.getRow(33, 2).getInt(1)).isEqualTo(v.intValue());
+                        assertThat(row.getMap(32).valueArray().getString(0)).hasToString("" + v);
+                        assertThat(row.getMap(33).valueArray().getBoolean(0)).isEqualTo(v % 2 == 0);
+                        assertThat(row.getMap(34).keyArray().getString(0)).hasToString("" + v);
+                        assertThat(row.getRow(35, 2).getString(0)).hasToString("" + v);
+                        assertThat(row.getRow(35, 2).getInt(1)).isEqualTo(v.intValue());
                     }
                     cnt.incrementAndGet();
                 });
@@ -450,7 +455,9 @@ public class ParquetReadWriteTest {
                 v.longValue(),
                 v.floatValue(),
                 v.doubleValue(),
-                Timestamp.fromLocalDateTime(toDateTime(v)),
+                toMills(v),
+                toMicros(v),
+                toNanos(v),
                 Decimal.fromBigDecimal(BigDecimal.valueOf(v), 5, 0),
                 Decimal.fromUnscaledLong(v.longValue(), 15, 2),
                 Decimal.fromBigDecimal(BigDecimal.valueOf(v), 20, 0),
@@ -465,7 +472,7 @@ public class ParquetReadWriteTest {
                 new GenericArray(new Object[] {v.longValue(), null}),
                 new GenericArray(new Object[] {v.floatValue(), null}),
                 new GenericArray(new Object[] {v.doubleValue(), null}),
-                new GenericArray(new Object[] {Timestamp.fromLocalDateTime(toDateTime(v)), null}),
+                new GenericArray(new Object[] {toNanos(v), null}),
                 Decimal.fromBigDecimal(BigDecimal.valueOf(v), 5, 0) == null
                         ? null
                         : new GenericArray(
@@ -490,6 +497,19 @@ public class ParquetReadWriteTest {
                 new GenericMap(f31),
                 new GenericMap(f32),
                 GenericRow.of(BinaryString.fromString("" + v), v));
+    }
+
+    private Timestamp toMills(Integer v) {
+        return Timestamp.fromEpochMillis(
+                Timestamp.fromLocalDateTime(toDateTime(v)).getMillisecond());
+    }
+
+    private Timestamp toMicros(Integer v) {
+        return Timestamp.fromMicros(Timestamp.fromLocalDateTime(toDateTime(v)).toMicros());
+    }
+
+    private Timestamp toNanos(Integer v) {
+        return Timestamp.fromLocalDateTime(toDateTime(v));
     }
 
     private LocalDateTime toDateTime(Integer v) {


### PR DESCRIPTION
Some bugs in Parquet stats extractor:
- Decimal Supports
- Timestamp Supports
- Null nullCounts supports