### PR TITLE
[FLINK-31412] HiveCatalog rollbacks schema in dfs if it alters table failed

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
@@ -413,7 +413,6 @@ public class SchemaManager implements Serializable {
         return new Path(tableRoot + "/schema");
     }
 
-    @VisibleForTesting
     public Path toSchemaPath(long id) {
         return new Path(tableRoot + "/schema/" + SCHEMA_PREFIX + id);
     }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/schema/SchemaManager.java
@@ -413,8 +413,18 @@ public class SchemaManager implements Serializable {
         return new Path(tableRoot + "/schema");
     }
 
+    @VisibleForTesting
     public Path toSchemaPath(long id) {
         return new Path(tableRoot + "/schema/" + SCHEMA_PREFIX + id);
+    }
+
+    /**
+     * Delete schema with specific id.
+     *
+     * @param schemaId the schema id to delete.
+     */
+    public void deleteSchema(long schemaId) {
+        fileIO.deleteQuietly(toSchemaPath(schemaId));
     }
 
     public static void checkAlterTableOption(String key) {

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/schema/SchemaManagerTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/schema/SchemaManagerTest.java
@@ -289,4 +289,24 @@ public class SchemaManagerTest {
                         "Cannot define any primary key in an append-only table. "
                                 + "Set 'write-mode'='change-log' if still want to keep the primary key definition.");
     }
+
+    @Test
+    public void testDeleteSchemaWithSchemaId() throws Exception {
+        Map<String, String> options = new HashMap<>();
+        Schema schema =
+                new Schema(
+                        rowType.getFields(),
+                        partitionKeys,
+                        primaryKeys,
+                        options,
+                        "append-only table with primary key");
+        manager.createTable(schema);
+        String schemaContent = manager.latest().get().toString();
+
+        manager.commitChanges(SchemaChange.setOption("aa", "bb"));
+        assertThat(manager.latest().get().options().get("aa")).isEqualTo("bb");
+
+        manager.deleteSchema(manager.latest().get().id());
+        assertThat(manager.latest().get().toString()).isEqualTo(schemaContent);
+    }
 }

--- a/flink-table-store-hive/flink-table-store-hive-catalog/src/main/java/org/apache/flink/table/store/hive/HiveCatalog.java
+++ b/flink-table-store-hive/flink-table-store-hive-catalog/src/main/java/org/apache/flink/table/store/hive/HiveCatalog.java
@@ -299,7 +299,7 @@ public class HiveCatalog extends AbstractCatalog {
         try {
             final SchemaManager schemaManager = schemaManager(identifier);
             // first commit changes to underlying files
-            TableSchema schema = schemaManager(identifier).commitChanges(changes);
+            TableSchema schema = schemaManager.commitChanges(changes);
 
             try {
                 // sync to hive hms
@@ -308,7 +308,7 @@ public class HiveCatalog extends AbstractCatalog {
                 updateHmsTable(table, identifier, schema);
                 client.alter_table(identifier.getDatabaseName(), identifier.getObjectName(), table);
             } catch (TException te) {
-                fileIO.deleteQuietly(schemaManager.toSchemaPath(schema.id()));
+                schemaManager.deleteSchema(schema.id());
                 throw te;
             }
         } catch (Exception e) {

--- a/flink-table-store-hive/flink-table-store-hive-catalog/src/test/java/org/apache/flink/table/store/hive/AlterFailHiveMetaStoreClient.java
+++ b/flink-table-store-hive/flink-table-store-hive-catalog/src/test/java/org/apache/flink/table/store/hive/AlterFailHiveMetaStoreClient.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.hive;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.thrift.TException;
+
+/** A {@link HiveMetaStoreClient} to test altering table failed in Hive metastore client. */
+public class AlterFailHiveMetaStoreClient extends HiveMetaStoreClient implements IMetaStoreClient {
+    public AlterFailHiveMetaStoreClient(HiveConf conf) throws MetaException {
+        super(conf);
+    }
+
+    public AlterFailHiveMetaStoreClient(HiveConf conf, HiveMetaHookLoader hookLoader)
+            throws MetaException {
+        super(conf, hookLoader);
+    }
+
+    public AlterFailHiveMetaStoreClient(
+            HiveConf conf, HiveMetaHookLoader hookLoader, Boolean allowEmbedded)
+            throws MetaException {
+        super(conf, hookLoader, allowEmbedded);
+    }
+
+    @Override
+    public void alter_table(String defaultDatabaseName, String tblName, Table table)
+            throws InvalidOperationException, MetaException, TException {
+        throw new TException();
+    }
+}

--- a/flink-table-store-hive/flink-table-store-hive-catalog/src/test/java/org/apache/flink/table/store/hive/CreateFailHiveMetaStoreClient.java
+++ b/flink-table-store-hive/flink-table-store-hive-catalog/src/test/java/org/apache/flink/table/store/hive/CreateFailHiveMetaStoreClient.java
@@ -24,23 +24,24 @@ import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
 import org.apache.hadoop.hive.metastore.api.InvalidObjectException;
+import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.thrift.TException;
 
-/** A {@link HiveMetaStoreClient} to test accessing exception in Hive metastore client. */
-public class FailHiveMetaStoreClient extends HiveMetaStoreClient implements IMetaStoreClient {
-    public FailHiveMetaStoreClient(HiveConf conf) throws MetaException {
+/** A {@link HiveMetaStoreClient} to test creating table failed in Hive metastore client. */
+public class CreateFailHiveMetaStoreClient extends HiveMetaStoreClient implements IMetaStoreClient {
+    public CreateFailHiveMetaStoreClient(HiveConf conf) throws MetaException {
         super(conf);
     }
 
-    public FailHiveMetaStoreClient(HiveConf conf, HiveMetaHookLoader hookLoader)
+    public CreateFailHiveMetaStoreClient(HiveConf conf, HiveMetaHookLoader hookLoader)
             throws MetaException {
         super(conf, hookLoader);
     }
 
-    public FailHiveMetaStoreClient(
+    public CreateFailHiveMetaStoreClient(
             HiveConf conf, HiveMetaHookLoader hookLoader, Boolean allowEmbedded)
             throws MetaException {
         super(conf, hookLoader, allowEmbedded);
@@ -50,6 +51,12 @@ public class FailHiveMetaStoreClient extends HiveMetaStoreClient implements IMet
     public void createTable(Table tbl)
             throws AlreadyExistsException, InvalidObjectException, MetaException,
                     NoSuchObjectException, TException {
+        throw new TException();
+    }
+
+    @Override
+    public void alter_table(String defaultDatabaseName, String tblName, Table table)
+            throws InvalidOperationException, MetaException, TException {
         throw new TException();
     }
 }


### PR DESCRIPTION
This PR amis to delete updated schema in dfs when `HiveCatalog` updates table failed in `metastore`