### PR TITLE
[FLINK-31436] Remove schemaId from constructor of FileStoreCommitImpl and ManifestFile in Table Store

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/AbstractFileStore.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/AbstractFileStore.java
@@ -79,7 +79,6 @@ public abstract class AbstractFileStore<T> implements FileStore<T> {
         return new ManifestFile.Factory(
                 fileIO,
                 schemaManager,
-                schemaId,
                 partitionType,
                 options.manifestFormat(),
                 pathFactory(),
@@ -106,7 +105,7 @@ public abstract class AbstractFileStore<T> implements FileStore<T> {
     public FileStoreCommitImpl newCommit(String commitUser) {
         return new FileStoreCommitImpl(
                 fileIO,
-                schemaId,
+                schemaManager,
                 commitUser,
                 partitionType,
                 pathFactory(),

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/operation/FileStoreCommitImpl.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.store.file.manifest.ManifestFileMeta;
 import org.apache.flink.table.store.file.manifest.ManifestList;
 import org.apache.flink.table.store.file.predicate.Predicate;
 import org.apache.flink.table.store.file.predicate.PredicateBuilder;
+import org.apache.flink.table.store.file.schema.SchemaManager;
 import org.apache.flink.table.store.file.utils.FileStorePathFactory;
 import org.apache.flink.table.store.file.utils.SnapshotManager;
 import org.apache.flink.table.store.fs.FileIO;
@@ -85,7 +86,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
     private static final Logger LOG = LoggerFactory.getLogger(FileStoreCommitImpl.class);
 
     private final FileIO fileIO;
-    private final long schemaId;
+    private final SchemaManager schemaManager;
     private final String commitUser;
     private final RowType partitionType;
     private final RowDataToObjectArrayConverter partitionObjectConverter;
@@ -104,7 +105,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
 
     public FileStoreCommitImpl(
             FileIO fileIO,
-            long schemaId,
+            SchemaManager schemaManager,
             String commitUser,
             RowType partitionType,
             FileStorePathFactory pathFactory,
@@ -117,7 +118,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             int manifestMergeMinCount,
             @Nullable Comparator<InternalRow> keyComparator) {
         this.fileIO = fileIO;
-        this.schemaId = schemaId;
+        this.schemaManager = schemaManager;
         this.commitUser = commitUser;
         this.partitionType = partitionType;
         this.partitionObjectConverter = new RowDataToObjectArrayConverter(partitionType);
@@ -526,7 +527,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             newSnapshot =
                     new Snapshot(
                             newSnapshotId,
-                            schemaId,
+                            schemaManager.latest().get().id(),
                             previousChangesListName,
                             newChangesListName,
                             changelogListName,

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestFileMetaTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestFileMetaTest.java
@@ -144,7 +144,6 @@ public class ManifestFileMetaTest {
         return new ManifestFile.Factory(
                         fileIO,
                         new SchemaManager(fileIO, path),
-                        0,
                         PARTITION_TYPE,
                         avro,
                         new FileStorePathFactory(

--- a/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestFileTest.java
+++ b/flink-table-store-core/src/test/java/org/apache/flink/table/store/file/manifest/ManifestFileTest.java
@@ -101,7 +101,6 @@ public class ManifestFileTest {
         return new ManifestFile.Factory(
                         fileIO,
                         new SchemaManager(fileIO, path),
-                        0,
                         DEFAULT_PART_TYPE,
                         avro,
                         pathFactory,


### PR DESCRIPTION
As schema may change during a CTAS streaming job, the schema ID of snapshots and manifest files may also change. We should remove `schemaId` from their constructor and calculate the real `schemaId` on the fly.