### PR TITLE
[FLINK-31431] Support copying a FileStoreTable with latest schema

### DIFF
--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AbstractFileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/AbstractFileStoreTable.java
@@ -41,6 +41,7 @@ import org.apache.flink.table.store.table.source.snapshot.SnapshotSplitReaderImp
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 
 import static org.apache.flink.table.store.CoreOptions.PATH;
@@ -125,6 +126,21 @@ public abstract class AbstractFileStoreTable implements FileStoreTable {
         SchemaValidation.validateTableSchema(newTableSchema);
 
         return copy(newTableSchema);
+    }
+
+    @Override
+    public FileStoreTable copyWithLatestSchema() {
+        Map<String, String> options = tableSchema.options();
+        SchemaManager schemaManager = new SchemaManager(fileIO(), location());
+        Optional<TableSchema> optionalLatestSchema = schemaManager.latest();
+        if (optionalLatestSchema.isPresent()) {
+            TableSchema newTableSchema = optionalLatestSchema.get();
+            newTableSchema = newTableSchema.copy(options);
+            SchemaValidation.validateTableSchema(newTableSchema);
+            return copy(newTableSchema);
+        } else {
+            return this;
+        }
     }
 
     protected SchemaManager schemaManager() {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/FileStoreTable.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/FileStoreTable.java
@@ -55,6 +55,8 @@ public interface FileStoreTable extends DataTable, SupportsPartition {
     @Override
     FileStoreTable copy(Map<String, String> dynamicOptions);
 
+    FileStoreTable copyWithLatestSchema();
+
     @Override
     TableWriteImpl<?> newWrite(String commitUser);
 


### PR DESCRIPTION
To capture schema changes, CDC sinks of Flink Table Store should be able to use the latest schema at any time. This requires us to copy a `FileStoreTable` with latest schema so that we can create `TableWrite` with latest schema.